### PR TITLE
feat: 공지사항 수정, 삭제, 태그 기능 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
 	implementation("org.springframework.boot:spring-boot-starter-security")
 	implementation("org.springframework.boot:spring-boot-starter-web")
+	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	runtimeOnly("com.mysql:mysql-connector-j")

--- a/src/main/kotlin/com/wafflestudio/csereal/common/config/CserealExceptionHandler.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/config/CserealExceptionHandler.kt
@@ -1,0 +1,33 @@
+package com.wafflestudio.csereal.common.config
+
+import com.wafflestudio.csereal.common.CserealException
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.validation.BindingResult
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import java.sql.SQLIntegrityConstraintViolationException
+
+@RestControllerAdvice
+class CserealExceptionHandler {
+
+    // @Valid로 인해 오류 떴을 때 메시지 전송
+    @ExceptionHandler(value = [MethodArgumentNotValidException::class])
+    fun handle(e: MethodArgumentNotValidException): ResponseEntity<Any> {
+        val bindingResult: BindingResult = e.bindingResult
+        return ResponseEntity(bindingResult.fieldError?.defaultMessage, HttpStatus.BAD_REQUEST)
+    }
+
+    // csereal 내부 규정 오류
+    @ExceptionHandler(value = [CserealException::class])
+    fun handle(e: CserealException): ResponseEntity<Any> {
+        return ResponseEntity(e.message, e.status)
+    }
+
+    // db에서 중복된 값 있을 때
+    @ExceptionHandler(value = [SQLIntegrityConstraintViolationException::class])
+    fun handle(e: SQLIntegrityConstraintViolationException): ResponseEntity<Any> {
+        return ResponseEntity("중복된 값이 있습니다.", HttpStatus.CONFLICT)
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
@@ -28,7 +28,7 @@ class NoticeController(
         return noticeService.createNotice(request)
     }
 
-    @PutMapping("/{noticeId}")
+    @PatchMapping("/{noticeId}")
     fun updateNotice(
         @PathVariable noticeId: Long,
         @Valid @RequestBody request: UpdateNoticeRequest,
@@ -39,9 +39,8 @@ class NoticeController(
     @DeleteMapping("/{noticeId}")
     fun deleteNotice(
         @PathVariable noticeId: Long
-    ) : ResponseEntity<String> {
+    ) {
         noticeService.deleteNotice(noticeId)
-        return ResponseEntity<String>("삭제되었습니다. (noticeId: $noticeId)", HttpStatus.OK)
     }
 
     @PostMapping("/tag")

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
@@ -43,4 +43,12 @@ class NoticeController(
         noticeService.deleteNotice(noticeId)
         return ResponseEntity<String>("삭제되었습니다. (noticeId: $noticeId)", HttpStatus.OK)
     }
+
+    @PostMapping("/tag")
+    fun enrollTag(
+        @RequestBody tagName: Map<String, String>
+    ) : ResponseEntity<String> {
+        noticeService.enrollTag(tagName["name"]!!)
+        return ResponseEntity<String>("등록되었습니다. (tagName: ${tagName["name"]})", HttpStatus.OK)
+    }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
@@ -2,7 +2,9 @@ package com.wafflestudio.csereal.core.notice.api
 
 import com.wafflestudio.csereal.core.notice.dto.CreateNoticeRequest
 import com.wafflestudio.csereal.core.notice.dto.NoticeDto
+import com.wafflestudio.csereal.core.notice.dto.UpdateNoticeRequest
 import com.wafflestudio.csereal.core.notice.service.NoticeService
+import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.*
 
 @RequestMapping("/notice")
@@ -19,8 +21,16 @@ class NoticeController(
 
     @PostMapping
     fun createNotice(
-        @RequestBody request: CreateNoticeRequest
+        @Valid @RequestBody request: CreateNoticeRequest
     ) : NoticeDto {
         return noticeService.createNotice(request)
+    }
+
+    @PutMapping("/{noticeId}")
+    fun updateNotice(
+        @PathVariable noticeId: Long,
+        @Valid @RequestBody request: UpdateNoticeRequest,
+    ) : NoticeDto {
+        return noticeService.updateNotice(noticeId, request)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
@@ -5,6 +5,8 @@ import com.wafflestudio.csereal.core.notice.dto.NoticeDto
 import com.wafflestudio.csereal.core.notice.dto.UpdateNoticeRequest
 import com.wafflestudio.csereal.core.notice.service.NoticeService
 import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
 @RequestMapping("/notice")
@@ -32,5 +34,13 @@ class NoticeController(
         @Valid @RequestBody request: UpdateNoticeRequest,
     ) : NoticeDto {
         return noticeService.updateNotice(noticeId, request)
+    }
+
+    @DeleteMapping("/{noticeId}")
+    fun deleteNotice(
+        @PathVariable noticeId: Long
+    ) : ResponseEntity<String> {
+        noticeService.deleteNotice(noticeId)
+        return ResponseEntity<String>("삭제되었습니다. (noticeId: $noticeId)", HttpStatus.OK)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeEntity.kt
@@ -1,8 +1,10 @@
 package com.wafflestudio.csereal.core.notice.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.OneToMany
 
 
 @Entity(name = "notice")
@@ -24,6 +26,9 @@ class NoticeEntity(
 //    var isSlide: Boolean,
 //
 //    var isPinned: Boolean,
+
+    @OneToMany(mappedBy = "notice", cascade = [CascadeType.PERSIST])
+    var noticeTag: MutableSet<NoticeTagEntity> = mutableSetOf()
 ): BaseTimeEntity() {
 
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeEntity.kt
@@ -27,8 +27,16 @@ class NoticeEntity(
 //
 //    var isPinned: Boolean,
 
-    @OneToMany(mappedBy = "notice", cascade = [CascadeType.PERSIST])
+    @OneToMany(mappedBy = "notice", cascade = [CascadeType.ALL])
     var noticeTag: MutableSet<NoticeTagEntity> = mutableSetOf()
 ): BaseTimeEntity() {
+
+    fun setNoticeTag(noticeTag: NoticeTagEntity) {
+
+        this.noticeTag.add(noticeTag)
+        noticeTag.notice = this
+    }
+
+
 
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeEntity.kt
@@ -28,14 +28,8 @@ class NoticeEntity(
 //    var isPinned: Boolean,
 
     @OneToMany(mappedBy = "notice", cascade = [CascadeType.ALL])
-    var noticeTag: MutableSet<NoticeTagEntity> = mutableSetOf()
+    var noticeTags: MutableSet<NoticeTagEntity> = mutableSetOf()
 ): BaseTimeEntity() {
-
-    fun setNoticeTag(noticeTag: NoticeTagEntity) {
-
-        this.noticeTag.add(noticeTag)
-        noticeTag.notice = this
-    }
 
 
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeEntity.kt
@@ -7,6 +7,10 @@ import jakarta.persistence.Entity
 
 @Entity(name = "notice")
 class NoticeEntity(
+
+    @Column
+    var isDeleted: Boolean = false,
+
     @Column
     var title: String,
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeEntity.kt
@@ -11,7 +11,15 @@ class NoticeEntity(
     var title: String,
 
     @Column(columnDefinition = "text")
-    var description: String
+    var description: String,
+
+//    var postType: String,
+//
+//    var isPublic: Boolean,
+//
+//    var isSlide: Boolean,
+//
+//    var isPinned: Boolean,
 ): BaseTimeEntity() {
 
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeTagEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeTagEntity.kt
@@ -17,9 +17,9 @@ class NoticeTagEntity(
     companion object {
 
         fun createNoticeTag(notice: NoticeEntity, tag: TagEntity) {
-            NoticeTagEntity(notice, tag)
-            notice.noticeTags.add(NoticeTagEntity(notice, tag))
-            tag.noticeTags.add(NoticeTagEntity(notice,tag))
+            val noticeTag = NoticeTagEntity(notice, tag)
+            notice.noticeTags.add(noticeTag)
+            tag.noticeTags.add(noticeTag)
         }
     }
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeTagEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeTagEntity.kt
@@ -1,0 +1,20 @@
+package com.wafflestudio.csereal.core.notice.database
+
+import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Entity
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+
+@Entity(name="noticeTag")
+class NoticeTagEntity(
+    @ManyToOne(cascade = [CascadeType.ALL])
+    @JoinColumn(name = "notice_id")
+    val notice: NoticeEntity,
+
+    @ManyToOne(cascade = [CascadeType.ALL])
+    @JoinColumn(name = "tag_id")
+    val tag: TagEntity,
+
+    ) : BaseTimeEntity() {
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeTagEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeTagEntity.kt
@@ -8,13 +8,13 @@ import jakarta.persistence.ManyToOne
 
 @Entity(name="noticeTag")
 class NoticeTagEntity(
-    @ManyToOne(cascade = [CascadeType.ALL])
+    @ManyToOne(cascade = [CascadeType.PERSIST])
     @JoinColumn(name = "notice_id")
-    val notice: NoticeEntity,
+    var notice: NoticeEntity,
 
-    @ManyToOne(cascade = [CascadeType.ALL])
+    @ManyToOne(cascade = [CascadeType.PERSIST])
     @JoinColumn(name = "tag_id")
-    val tag: TagEntity,
+    var tag: TagEntity,
 
     ) : BaseTimeEntity() {
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeTagEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeTagEntity.kt
@@ -1,18 +1,15 @@
 package com.wafflestudio.csereal.core.notice.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
-import jakarta.persistence.CascadeType
-import jakarta.persistence.Entity
-import jakarta.persistence.JoinColumn
-import jakarta.persistence.ManyToOne
+import jakarta.persistence.*
 
 @Entity(name="noticeTag")
 class NoticeTagEntity(
-    @ManyToOne(cascade = [CascadeType.PERSIST])
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "notice_id")
     var notice: NoticeEntity,
 
-    @ManyToOne(cascade = [CascadeType.PERSIST])
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "tag_id")
     var tag: TagEntity,
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeTagEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeTagEntity.kt
@@ -3,7 +3,7 @@ package com.wafflestudio.csereal.core.notice.database
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
 import jakarta.persistence.*
 
-@Entity(name="noticeTag")
+@Entity(name = "noticeTag")
 class NoticeTagEntity(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "notice_id")
@@ -14,4 +14,16 @@ class NoticeTagEntity(
     var tag: TagEntity,
 
     ) : BaseTimeEntity() {
+    companion object {
+
+        fun createNoticeTag(notice: NoticeEntity, tag: TagEntity) {
+            NoticeTagEntity(notice, tag)
+            notice.noticeTags.add(NoticeTagEntity(notice, tag))
+            tag.noticeTags.add(NoticeTagEntity(notice,tag))
+        }
+    }
+
+
+
 }
+

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeTagRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeTagRepository.kt
@@ -3,5 +3,6 @@ package com.wafflestudio.csereal.core.notice.database
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface NoticeTagRepository : JpaRepository<NoticeTagEntity, Long> {
+    fun findAllByNoticeId(noticeId: Long)
     fun deleteAllByNoticeId(noticeId: Long)
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeTagRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeTagRepository.kt
@@ -1,0 +1,7 @@
+package com.wafflestudio.csereal.core.notice.database
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface NoticeTagRepository : JpaRepository<NoticeTagEntity, Long> {
+    fun deleteAllByNoticeId(noticeId: Long)
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeTagRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeTagRepository.kt
@@ -3,6 +3,5 @@ package com.wafflestudio.csereal.core.notice.database
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface NoticeTagRepository : JpaRepository<NoticeTagEntity, Long> {
-    fun findAllByNoticeId(noticeId: Long)
     fun deleteAllByNoticeId(noticeId: Long)
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/TagEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/TagEntity.kt
@@ -1,10 +1,15 @@
 package com.wafflestudio.csereal.core.notice.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import jakarta.persistence.CascadeType
 import jakarta.persistence.Entity
+import jakarta.persistence.OneToMany
 
 @Entity(name = "tag")
 class TagEntity(
-    var name: String
+    var name: String,
+
+    @OneToMany(mappedBy = "tag", cascade = [CascadeType.PERSIST])
+    val noticeTag: MutableSet<NoticeTagEntity> = mutableSetOf()
 ) : BaseTimeEntity() {
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/TagEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/TagEntity.kt
@@ -10,6 +10,6 @@ class TagEntity(
     var name: String,
 
     @OneToMany(mappedBy = "tag")
-    val noticeTag: MutableSet<NoticeTagEntity> = mutableSetOf()
+    val noticeTags: MutableSet<NoticeTagEntity> = mutableSetOf()
 ) : BaseTimeEntity() {
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/TagEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/TagEntity.kt
@@ -9,7 +9,7 @@ import jakarta.persistence.OneToMany
 class TagEntity(
     var name: String,
 
-    @OneToMany(mappedBy = "tag", cascade = [CascadeType.PERSIST])
+    @OneToMany(mappedBy = "tag")
     val noticeTag: MutableSet<NoticeTagEntity> = mutableSetOf()
 ) : BaseTimeEntity() {
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/TagEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/TagEntity.kt
@@ -1,0 +1,10 @@
+package com.wafflestudio.csereal.core.notice.database
+
+import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import jakarta.persistence.Entity
+
+@Entity(name = "tag")
+class TagEntity(
+    var name: String
+) : BaseTimeEntity() {
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/TagRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/TagRepository.kt
@@ -1,0 +1,6 @@
+package com.wafflestudio.csereal.core.notice.database
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface TagRepository : JpaRepository<TagEntity, Long> {
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/CreateNoticeRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/CreateNoticeRequest.kt
@@ -9,6 +9,6 @@ data class CreateNoticeRequest(
     @field:NotBlank(message = "내용은 비어있을 수 없습니다")
     val description: String,
 
-    val tag: List<Long> = emptyList()
+    val tags: List<Long> = emptyList()
 ) {
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/CreateNoticeRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/CreateNoticeRequest.kt
@@ -8,5 +8,7 @@ data class CreateNoticeRequest(
 
     @NotBlank(message = "내용은 비어있을 수 없습니다")
     val description: String,
+
+    val tag: List<String> = emptyList()
 ) {
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/CreateNoticeRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/CreateNoticeRequest.kt
@@ -3,10 +3,10 @@ package com.wafflestudio.csereal.core.notice.dto
 import jakarta.validation.constraints.NotBlank
 
 data class CreateNoticeRequest(
-    @NotBlank(message = "제목은 비어있을 수 없습니다")
+    @field:NotBlank(message = "제목은 비어있을 수 없습니다")
     val title: String,
 
-    @NotBlank(message = "내용은 비어있을 수 없습니다")
+    @field:NotBlank(message = "내용은 비어있을 수 없습니다")
     val description: String,
 
     val tag: List<Long> = emptyList()

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/CreateNoticeRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/CreateNoticeRequest.kt
@@ -9,6 +9,6 @@ data class CreateNoticeRequest(
     @NotBlank(message = "내용은 비어있을 수 없습니다")
     val description: String,
 
-    val tag: List<String> = emptyList()
+    val tag: List<Long> = emptyList()
 ) {
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/CreateNoticeRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/CreateNoticeRequest.kt
@@ -1,7 +1,12 @@
 package com.wafflestudio.csereal.core.notice.dto
 
+import jakarta.validation.constraints.NotBlank
+
 data class CreateNoticeRequest(
+    @NotBlank(message = "제목은 비어있을 수 없습니다")
     val title: String,
-    val description: String
+
+    @NotBlank(message = "내용은 비어있을 수 없습니다")
+    val description: String,
 ) {
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/NoticeDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/NoticeDto.kt
@@ -22,8 +22,12 @@ data class NoticeDto(
                 id = this.id,
                 title = this.title,
                 description = this.description,
+                // postType = this.postType,
                 createdAt = this.createdAt,
-                modifiedAt = this.modifiedAt
+                modifiedAt = this.modifiedAt,
+//                isPublic = this.isPublic,
+//                isSlide = this.isSlide,
+//                isPinned = this.isPinned,
             )
         }
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/NoticeDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/NoticeDto.kt
@@ -5,6 +5,7 @@ import java.time.LocalDateTime
 
 data class NoticeDto(
     val id: Long,
+    val isDeleted: Boolean,
     val title: String,
     val description: String,
     // val postType: String,
@@ -20,6 +21,7 @@ data class NoticeDto(
         fun of(entity: NoticeEntity): NoticeDto = entity.run {
             NoticeDto(
                 id = this.id,
+                isDeleted = false,
                 title = this.title,
                 description = this.description,
                 // postType = this.postType,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/UpdateNoticeRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/UpdateNoticeRequest.kt
@@ -3,6 +3,6 @@ package com.wafflestudio.csereal.core.notice.dto
 data class UpdateNoticeRequest(
     val title: String?,
     val description: String?,
-    val tag: List<Long> = emptyList()
+    val tag: List<Long>?
 ) {
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/UpdateNoticeRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/UpdateNoticeRequest.kt
@@ -3,6 +3,6 @@ package com.wafflestudio.csereal.core.notice.dto
 data class UpdateNoticeRequest(
     val title: String?,
     val description: String?,
-    val tag: List<Long>?
+    val tags: List<Long>?
 ) {
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/UpdateNoticeRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/UpdateNoticeRequest.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.csereal.core.notice.dto
 
 data class UpdateNoticeRequest(
     val title: String?,
-    val description: String?
+    val description: String?,
+    val tag: List<Long> = emptyList()
 ) {
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/UpdateNoticeRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/UpdateNoticeRequest.kt
@@ -1,0 +1,7 @@
+package com.wafflestudio.csereal.core.notice.dto
+
+data class UpdateNoticeRequest(
+    val title: String?,
+    val description: String?
+) {
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
@@ -39,14 +39,9 @@ class NoticeServiceImpl(
             description = request.description,
         )
 
-        for (i: Int in 0 until request.tag.size) {
-            newNotice.setNoticeTag(
-                NoticeTagEntity(
-                    notice = newNotice,
-                    tag = tagRepository.findByIdOrNull(request.tag[i])
-                        ?: throw CserealException.Csereal400("해당하는 태그가 없습니다")
-                )
-            )
+        for (tagId in request.tags) {
+            val tag = tagRepository.findByIdOrNull(tagId) ?: throw CserealException.Csereal400("해당하는 태그가 없습니다")
+            NoticeTagEntity.createNoticeTag(newNotice, tag)
         }
 
         noticeRepository.save(newNotice)
@@ -64,17 +59,12 @@ class NoticeServiceImpl(
         notice.title = request.title ?: notice.title
         notice.description = request.description ?: notice.description
 
-        if (request.tag != null) {
+        if (request.tags != null) {
             noticeTagRepository.deleteAllByNoticeId(noticeId)
-            notice.noticeTag = mutableSetOf()
-            for (i: Int in 0 until request.tag.size) {
-                notice.setNoticeTag(
-                    NoticeTagEntity(
-                        notice = notice,
-                        tag = tagRepository.findByIdOrNull(request.tag[i])
-                            ?: throw CserealException.Csereal400("해당하는 태그가 없습니다")
-                    )
-                )
+            notice.noticeTags.clear()
+            for (tagId in request.tags) {
+                val tag = tagRepository.findByIdOrNull(tagId) ?: throw CserealException.Csereal400("해당하는 태그가 없습니다")
+                NoticeTagEntity.createNoticeTag(notice, tag)
             }
         }
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
@@ -14,6 +14,7 @@ interface NoticeService {
     fun readNotice(noticeId: Long): NoticeDto
     fun createNotice(request: CreateNoticeRequest): NoticeDto
     fun updateNotice(noticeId: Long, request: UpdateNoticeRequest) : NoticeDto
+    fun deleteNotice(noticeId: Long)
 }
 
 @Service
@@ -25,6 +26,7 @@ class NoticeServiceImpl(
     override fun readNotice(noticeId: Long): NoticeDto {
         val notice: NoticeEntity = noticeRepository.findByIdOrNull(noticeId)
             ?: throw CserealException.Csereal400("존재하지 않는 공지사항입니다.(noticeId: $noticeId)")
+        if(notice.isDeleted) throw CserealException.Csereal400("삭제된 공지사항입니다.(noticeId: $noticeId)")
         return NoticeDto.of(notice)
     }
 
@@ -45,6 +47,7 @@ class NoticeServiceImpl(
     override fun updateNotice(noticeId: Long, request: UpdateNoticeRequest) : NoticeDto {
         val notice: NoticeEntity = noticeRepository.findByIdOrNull(noticeId)
             ?: throw CserealException.Csereal400("존재하지 않는 공지사항입니다.(noticeId: $noticeId")
+        if(notice.isDeleted) throw CserealException.Csereal400("삭제된 공지사항입니다.(noticeId: $noticeId")
 
         notice.title = request.title ?: notice.title
         notice.description = request.description ?: notice.description
@@ -52,5 +55,14 @@ class NoticeServiceImpl(
         noticeRepository.save(notice)
 
         return NoticeDto.of(notice)
+    }
+
+    @Transactional
+    override fun deleteNotice(noticeId: Long) {
+        val notice : NoticeEntity = noticeRepository.findByIdOrNull(noticeId)
+            ?: throw CserealException.Csereal400("존재하지 않는 공지사항입니다.(noticeId: $noticeId)")
+
+        notice.isDeleted = true
+
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
@@ -5,6 +5,7 @@ import com.wafflestudio.csereal.core.notice.database.NoticeEntity
 import com.wafflestudio.csereal.core.notice.database.NoticeRepository
 import com.wafflestudio.csereal.core.notice.dto.CreateNoticeRequest
 import com.wafflestudio.csereal.core.notice.dto.NoticeDto
+import com.wafflestudio.csereal.core.notice.dto.UpdateNoticeRequest
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -12,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional
 interface NoticeService {
     fun readNotice(noticeId: Long): NoticeDto
     fun createNotice(request: CreateNoticeRequest): NoticeDto
+    fun updateNotice(noticeId: Long, request: UpdateNoticeRequest) : NoticeDto
 }
 
 @Service
@@ -28,7 +30,6 @@ class NoticeServiceImpl(
 
     @Transactional
     override fun createNotice(request: CreateNoticeRequest): NoticeDto {
-        // TODO:"아직 날짜가 제대로 안 뜸"
         val newNotice = NoticeEntity(
             title = request.title,
             description = request.description,
@@ -38,5 +39,18 @@ class NoticeServiceImpl(
 
         return NoticeDto.of(newNotice)
 
+    }
+
+    @Transactional
+    override fun updateNotice(noticeId: Long, request: UpdateNoticeRequest) : NoticeDto {
+        val notice: NoticeEntity = noticeRepository.findByIdOrNull(noticeId)
+            ?: throw CserealException.Csereal400("존재하지 않는 공지사항입니다.(noticeId: $noticeId")
+
+        notice.title = request.title ?: notice.title
+        notice.description = request.description ?: notice.description
+
+        noticeRepository.save(notice)
+
+        return NoticeDto.of(notice)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
@@ -3,6 +3,8 @@ package com.wafflestudio.csereal.core.notice.service
 import com.wafflestudio.csereal.common.CserealException
 import com.wafflestudio.csereal.core.notice.database.NoticeEntity
 import com.wafflestudio.csereal.core.notice.database.NoticeRepository
+import com.wafflestudio.csereal.core.notice.database.TagEntity
+import com.wafflestudio.csereal.core.notice.database.TagRepository
 import com.wafflestudio.csereal.core.notice.dto.CreateNoticeRequest
 import com.wafflestudio.csereal.core.notice.dto.NoticeDto
 import com.wafflestudio.csereal.core.notice.dto.UpdateNoticeRequest
@@ -15,11 +17,13 @@ interface NoticeService {
     fun createNotice(request: CreateNoticeRequest): NoticeDto
     fun updateNotice(noticeId: Long, request: UpdateNoticeRequest) : NoticeDto
     fun deleteNotice(noticeId: Long)
+    fun enrollTag(tagName: String)
 }
 
 @Service
 class NoticeServiceImpl(
     private val noticeRepository: NoticeRepository,
+    private val tagRepository: TagRepository,
 ) : NoticeService {
 
     @Transactional(readOnly = true)
@@ -64,5 +68,12 @@ class NoticeServiceImpl(
 
         notice.isDeleted = true
 
+    }
+
+    override fun enrollTag(tagName: String) {
+        val newTag = TagEntity(
+            name = tagName
+        )
+        tagRepository.save(newTag)
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,14 +5,10 @@ spring:
 ---
 spring:
   config.activate.on-profile: local
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://127.0.0.1:3306/csereal_local?useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul
-    username: root
-    password: toor
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
+    show-sql: true
 logging.level:
   default: INFO
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,10 +5,14 @@ spring:
 ---
 spring:
   config.activate.on-profile: local
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://127.0.0.1:3306/csereal_local?useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul
+    username: root
+    password: toor
   jpa:
     hibernate:
-      ddl-auto: create
-    show-sql: true
+      ddl-auto: update
 logging.level:
   default: INFO
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,9 +5,14 @@ spring:
 ---
 spring:
   config.activate.on-profile: local
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://127.0.0.1:3306/csereal_local?useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul
+    username: root
+    password: toor
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
 logging.level:
   default: INFO


### PR DESCRIPTION
## 제목
공지사항 수정, 삭제, 태그

### 한줄 요약

ExceptionHandler, updateNotice, deleteNotice, Tag 엔티티, noticeTag 연관 엔티티 추가

### 상세 설명

[068225a]: 예외가 나올 때 처리하는 기능을 추가했습니다. @Valid로 인해 오류 떴을 때 메시지 전송 / csereal 내부 규정 오류 /  db에서 중복된 값 있을 때 나오는 예외를 처리했습니다.

[8d8d5cd]: 공지사항을 수정하는 기능을 추가했습니다. _@Valid을 통해 제목이 빈칸이거나, 내용이 빈칸이면 오류 메시지가 뜨도록 했습니다._ -> 확인해보니 내용을 ""으로 전송해도 전송이 잘 되네요.. 이거는 다음 pr에 수정하도록 할게요. NoticeEntity에서 isPublic 등의 기타 칼럼을 추가했습니다 

[0382376]: 공지사항을 삭제하는 기능을 추가했습니다. soft_delete 방식을 적용하여서, 삭제할 때 db 상에서 없어지는 게 아니라 isDeleted = true가 되도록 했습니다.

[3f2e94d]: TagEntity, NoticeTagEntity 엔티티를 추가하고, 공지사항에 태그를 추가하기 전에 우선 태그를 등록하는 기능을 추가했습니다.

[be6d433]: 공지사항을 올릴 때 태그도 같이 올리고, 수정할 때 태그도 같이 수정할 수 있도록 했습니다.

[c349869]: 혼자서 만들때는 로컬 db에 연결해서 하는데, 깜박하고 안 없앴네요. 다시 없는 상태로 올렸습니다.

### TODO
@Valid 메시지가 적용되도록 할 것. 다음으로는 페이지네이션 생각 중
+) (07/26 12:49) @Valid 잘 되도록 했습니다 다음 pr 때 올릴게요
