### PR TITLE
feat: 페이지네이션+검색 기능 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 	kotlin("jvm") version "1.7.22"
 	kotlin("plugin.spring") version "1.7.22"
 	kotlin("plugin.jpa") version "1.7.22"
+	kotlin("kapt") version "1.7.10"
 }
 
 group = "com.wafflestudio"
@@ -30,17 +31,23 @@ dependencies {
 	runtimeOnly("com.mysql:mysql-connector-j")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.springframework.security:spring-security-test")
+
+	//queryDsl
+	implementation ("com.querydsl:querydsl-jpa:5.0.0:jakarta")
+	kapt("com.querydsl:querydsl-apt:5.0.0:jakarta")
+	kapt("jakarta.annotation:jakarta.annotation-api")
+	kapt("jakarta.persistence:jakarta.persistence-api")
 }
 noArg {
-	annotation("javax.persistence.Entity")
-	annotation("javax.persistence.MappedSuperclass")
-	annotation("javax.persistence.Embeddable")
+	annotation("jakarta.persistence.Entity")
+	annotation("jakarta.persistence.MappedSuperclass")
+	annotation("jakarta.persistence.Embeddable")
 }
 
 allOpen {
-	annotation("javax.persistence.Entity")
-	annotation("javax.persistence.MappedSuperclass")
-	annotation("javax.persistence.Embeddable")
+	annotation("jakarta.persistence.Entity")
+	annotation("jakarta.persistence.MappedSuperclass")
+	annotation("jakarta.persistence.Embeddable")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/com/wafflestudio/csereal/common/config/QueryDslConfig.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/config/QueryDslConfig.kt
@@ -1,0 +1,17 @@
+package com.wafflestudio.csereal.common.config
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class QueryDslConfig(
+    @PersistenceContext
+    private val entityManager: EntityManager,
+) {
+    @Bean
+    fun jpaQueryFactory(): JPAQueryFactory =
+        JPAQueryFactory(entityManager)
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/common/config/QueryDslConfig.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/config/QueryDslConfig.kt
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Configuration
 @Configuration
 class QueryDslConfig(
     @PersistenceContext
-    private val entityManager: EntityManager,
+    val entityManager: EntityManager,
 ) {
     @Bean
     fun jpaQueryFactory(): JPAQueryFactory =

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
@@ -17,29 +17,29 @@ class NoticeController(
         @RequestParam(required = false) tag : List<Long>?,
         @RequestParam(required = false) keyword: String?,
         @RequestParam(required = false, defaultValue = "0") pageNum: Long
-    ): List<SearchResponse> {
-        return noticeService.searchNotice(tag, keyword, pageNum)
+    ): ResponseEntity<SearchResponse> {
+        return ResponseEntity.ok(noticeService.searchNotice(tag, keyword, pageNum))
     }
     @GetMapping("/{noticeId}")
     fun readNotice(
         @PathVariable noticeId: Long,
-    ) : NoticeDto {
-        return noticeService.readNotice(noticeId)
+    ) : ResponseEntity<NoticeDto> {
+        return ResponseEntity.ok(noticeService.readNotice(noticeId))
     }
 
     @PostMapping
     fun createNotice(
         @Valid @RequestBody request: CreateNoticeRequest
-    ) : NoticeDto {
-        return noticeService.createNotice(request)
+    ) : ResponseEntity<NoticeDto> {
+        return ResponseEntity.ok(noticeService.createNotice(request))
     }
 
     @PatchMapping("/{noticeId}")
     fun updateNotice(
         @PathVariable noticeId: Long,
         @Valid @RequestBody request: UpdateNoticeRequest,
-    ) : NoticeDto {
-        return noticeService.updateNotice(noticeId, request)
+    ) : ResponseEntity<NoticeDto> {
+        return ResponseEntity.ok(noticeService.updateNotice(noticeId, request))
     }
 
     @DeleteMapping("/{noticeId}")

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
@@ -14,9 +14,10 @@ class NoticeController(
 ) {
     @GetMapping("/search")
     fun searchNotice(
-        @RequestBody request: SearchRequest
+        @RequestParam(required = false) tag : List<Long>?,
+        @RequestParam(required = false) keyword: String?
     ): List<SearchResponse> {
-        return noticeService.searchNotice(request.tags, request.keyWord)
+        return noticeService.searchNotice(tag, keyword)
     }
     @GetMapping("/{noticeId}")
     fun readNotice(

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
@@ -15,9 +15,10 @@ class NoticeController(
     @GetMapping("/search")
     fun searchNotice(
         @RequestParam(required = false) tag : List<Long>?,
-        @RequestParam(required = false) keyword: String?
+        @RequestParam(required = false) keyword: String?,
+        @RequestParam(required = false, defaultValue = "0") pageNum: Long
     ): List<SearchResponse> {
-        return noticeService.searchNotice(tag, keyword)
+        return noticeService.searchNotice(tag, keyword, pageNum)
     }
     @GetMapping("/{noticeId}")
     fun readNotice(

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
@@ -1,8 +1,6 @@
 package com.wafflestudio.csereal.core.notice.api
 
-import com.wafflestudio.csereal.core.notice.dto.CreateNoticeRequest
-import com.wafflestudio.csereal.core.notice.dto.NoticeDto
-import com.wafflestudio.csereal.core.notice.dto.UpdateNoticeRequest
+import com.wafflestudio.csereal.core.notice.dto.*
 import com.wafflestudio.csereal.core.notice.service.NoticeService
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
@@ -14,6 +12,12 @@ import org.springframework.web.bind.annotation.*
 class NoticeController(
     private val noticeService: NoticeService,
 ) {
+    @GetMapping("/search")
+    fun searchNotice(
+        @RequestBody request: SearchRequest
+    ): List<SearchResponse> {
+        return noticeService.searchNotice(request.tags, request.keyWord)
+    }
     @GetMapping("/{noticeId}")
     fun readNotice(
         @PathVariable noticeId: Long,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.*
 class NoticeController(
     private val noticeService: NoticeService,
 ) {
-    @GetMapping("/search")
+    @GetMapping
     fun searchNotice(
         @RequestParam(required = false) tag : List<Long>?,
         @RequestParam(required = false) keyword: String?,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeEntity.kt
@@ -20,12 +20,12 @@ class NoticeEntity(
     var description: String,
 
 //    var postType: String,
-//
-//    var isPublic: Boolean,
-//
-//    var isSlide: Boolean,
-//
-//    var isPinned: Boolean,
+
+    var isPublic: Boolean,
+
+    var isSlide: Boolean,
+
+    var isPinned: Boolean,
 
     @OneToMany(mappedBy = "notice", cascade = [CascadeType.ALL])
     var noticeTags: MutableSet<NoticeTagEntity> = mutableSetOf()

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
@@ -48,9 +48,11 @@ class NoticeRepositoryImpl(
                 noticeTagEntity.tag.id
             )
         ).from(noticeTagEntity)
-            .rightJoin(noticeTagEntity.notice, noticeEntity)
+            .rightJoin(noticeTagEntity.notice, noticeEntity).on(noticeEntity.isDeleted.eq(false), noticeEntity.isPublic.eq(true))
             .where(noticeTagEntity.notice.eq(noticeEntity))
             .where(booleanBuilder2)
+            .orderBy(noticeEntity.isPinned.desc())
+            .orderBy(noticeEntity.createdAt.desc())
             .fetch()
 
     }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
@@ -1,7 +1,12 @@
 package com.wafflestudio.csereal.core.notice.database
 
+import com.querydsl.core.BooleanBuilder
+import com.querydsl.core.types.Projections
 import com.querydsl.jpa.impl.JPAQueryFactory
+import com.wafflestudio.csereal.core.notice.database.QNoticeEntity.noticeEntity
+import com.wafflestudio.csereal.core.notice.database.QNoticeTagEntity.noticeTagEntity
 import com.wafflestudio.csereal.core.notice.dto.NoticeDto
+import com.wafflestudio.csereal.core.notice.dto.SearchResponse
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Component
 
@@ -9,14 +14,45 @@ interface NoticeRepository : JpaRepository<NoticeEntity, Long>, CustomNoticeRepo
 }
 
 interface CustomNoticeRepository {
-    fun searchNotice(tag: List<Long>, keyword: String) : List<NoticeDto>
+    fun searchNotice(tags: List<Long>?, keyword: String?) : List<SearchResponse>
 }
 @Component
 class NoticeRepositoryImpl(
     private val queryFactory: JPAQueryFactory,
 ) : CustomNoticeRepository {
-    override fun searchNotice(tag: List<Long>, keyword: String): List<NoticeDto> {
-        TODO("Not yet implemented")
+    override fun searchNotice(tags: List<Long>?, keyword: String?): List<SearchResponse> {
+        val booleanBuilder = BooleanBuilder()
+        val booleanBuilder2 = BooleanBuilder()
+
+        if (!keyword.isNullOrEmpty()) {
+            booleanBuilder.and(
+                noticeEntity.title.contains(keyword)
+                    .or(noticeEntity.description.contains(keyword))
+            )
+        }
+        if(!tags.isNullOrEmpty()) {
+            tags.forEach {
+                booleanBuilder2.or(
+                    noticeTagEntity.tag.id.eq(it)
+                )
+            }
+        }
+
+
+        return queryFactory.select(
+            Projections.constructor(
+                SearchResponse::class.java,
+                noticeEntity.id,
+                noticeEntity.title,
+                noticeEntity.createdAt,
+                noticeTagEntity.tag.id
+            )
+        ).from(noticeTagEntity)
+            .rightJoin(noticeTagEntity.notice, noticeEntity)
+            .where(noticeTagEntity.notice.eq(noticeEntity))
+            .where(booleanBuilder2)
+            .fetch()
+
     }
 
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
@@ -68,8 +68,8 @@ class NoticeRepositoryImpl(
             .where(tagsBooleanBuilder)
             .orderBy(noticeEntity.isPinned.desc())
             .orderBy(noticeEntity.createdAt.desc())
-            .offset(3*pageNum)
-            .limit(3)
+            .offset(20*pageNum)
+            .limit(20)
             .distinct()
             .fetch()
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
@@ -55,6 +55,7 @@ class NoticeRepositoryImpl(
                 noticeEntity.id,
                 noticeEntity.title,
                 noticeEntity.createdAt,
+                noticeEntity.isPinned
             )
         ).from(noticeEntity)
             .innerJoin(noticeTagEntity).on(noticeTagEntity.notice.eq(noticeEntity))

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
@@ -50,6 +50,7 @@ class NoticeRepositoryImpl(
         ).from(noticeTagEntity)
             .rightJoin(noticeTagEntity.notice, noticeEntity).on(noticeEntity.isDeleted.eq(false), noticeEntity.isPublic.eq(true))
             .where(noticeTagEntity.notice.eq(noticeEntity))
+            .where(booleanBuilder)
             .where(booleanBuilder2)
             .orderBy(noticeEntity.isPinned.desc())
             .orderBy(noticeEntity.createdAt.desc())

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
@@ -14,13 +14,13 @@ interface NoticeRepository : JpaRepository<NoticeEntity, Long>, CustomNoticeRepo
 }
 
 interface CustomNoticeRepository {
-    fun searchNotice(tags: List<Long>?, keyword: String?) : List<SearchResponse>
+    fun searchNotice(tag: List<Long>?, keyword: String?): List<SearchResponse>
 }
 @Component
 class NoticeRepositoryImpl(
     private val queryFactory: JPAQueryFactory,
 ) : CustomNoticeRepository {
-    override fun searchNotice(tags: List<Long>?, keyword: String?): List<SearchResponse> {
+    override fun searchNotice(tag: List<Long>?, keyword: String?): List<SearchResponse> {
         val booleanBuilder = BooleanBuilder()
         val booleanBuilder2 = BooleanBuilder()
 
@@ -30,8 +30,8 @@ class NoticeRepositoryImpl(
                     .or(noticeEntity.description.contains(keyword))
             )
         }
-        if(!tags.isNullOrEmpty()) {
-            tags.forEach {
+        if(!tag.isNullOrEmpty()) {
+            tag.forEach {
                 booleanBuilder2.or(
                     noticeTagEntity.tag.id.eq(it)
                 )

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
@@ -1,6 +1,22 @@
 package com.wafflestudio.csereal.core.notice.database
 
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.wafflestudio.csereal.core.notice.dto.NoticeDto
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Component
 
-interface NoticeRepository : JpaRepository<NoticeEntity, Long> {
+interface NoticeRepository : JpaRepository<NoticeEntity, Long>, CustomNoticeRepository {
+}
+
+interface CustomNoticeRepository {
+    fun searchNotice(tag: List<Long>, keyword: String) : List<NoticeDto>
+}
+@Component
+class NoticeRepositoryImpl(
+    private val queryFactory: JPAQueryFactory,
+) : CustomNoticeRepository {
+    override fun searchNotice(tag: List<Long>, keyword: String): List<NoticeDto> {
+        TODO("Not yet implemented")
+    }
+
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
@@ -51,7 +51,9 @@ class NoticeRepositoryImpl(
         }
 
         val total = queryFactory.select(noticeEntity)
-            .from(noticeEntity).where(keywordBooleanBuilder).where(tagsBooleanBuilder).fetch().size
+            .from(noticeEntity).leftJoin(noticeTagEntity).on(noticeTagEntity.notice.eq(noticeEntity))
+            .where(noticeEntity.isDeleted.eq(false), noticeEntity.isPublic.eq(true))
+            .where(keywordBooleanBuilder).where(tagsBooleanBuilder).fetch().size
 
         val list = queryFactory.select(
             Projections.constructor(
@@ -62,7 +64,7 @@ class NoticeRepositoryImpl(
                 noticeEntity.isPinned
             )
         ).from(noticeEntity)
-            .innerJoin(noticeTagEntity).on(noticeTagEntity.notice.eq(noticeEntity))
+            .leftJoin(noticeTagEntity).on(noticeTagEntity.notice.eq(noticeEntity))
             .where(noticeEntity.isDeleted.eq(false), noticeEntity.isPublic.eq(true))
             .where(keywordBooleanBuilder)
             .where(tagsBooleanBuilder)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
@@ -14,13 +14,13 @@ interface NoticeRepository : JpaRepository<NoticeEntity, Long>, CustomNoticeRepo
 }
 
 interface CustomNoticeRepository {
-    fun searchNotice(tag: List<Long>?, keyword: String?): List<SearchResponse>
+    fun searchNotice(tag: List<Long>?, keyword: String?, pageNum: Long): List<SearchResponse>
 }
 @Component
 class NoticeRepositoryImpl(
     private val queryFactory: JPAQueryFactory,
 ) : CustomNoticeRepository {
-    override fun searchNotice(tag: List<Long>?, keyword: String?): List<SearchResponse> {
+    override fun searchNotice(tag: List<Long>?, keyword: String?, pageNum: Long): List<SearchResponse> {
         val booleanBuilder = BooleanBuilder()
         val booleanBuilder2 = BooleanBuilder()
 
@@ -53,6 +53,8 @@ class NoticeRepositoryImpl(
             .where(booleanBuilder2)
             .orderBy(noticeEntity.isPinned.desc())
             .orderBy(noticeEntity.createdAt.desc())
+            .offset(5*pageNum)  //로컬 테스트를 위해 잠시 5로 둘 것, 원래는 20
+            .limit(5)
             .fetch()
 
     }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/CreateNoticeRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/CreateNoticeRequest.kt
@@ -9,6 +9,12 @@ data class CreateNoticeRequest(
     @field:NotBlank(message = "내용은 비어있을 수 없습니다")
     val description: String,
 
-    val tags: List<Long> = emptyList()
+    val tags: List<Long> = emptyList(),
+
+    val isPublic: Boolean,
+
+    val isSlide: Boolean,
+
+    val isPinned: Boolean,
 ) {
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/NoticeDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/NoticeDto.kt
@@ -10,6 +10,7 @@ data class NoticeDto(
     val description: String,
     // val postType: String,
     // val authorId: Int,
+    val tags: List<Long>,
     val createdAt: LocalDateTime?,
     val modifiedAt: LocalDateTime?,
     val isPublic: Boolean,
@@ -18,13 +19,14 @@ data class NoticeDto(
 ) {
 
     companion object {
-        fun of(entity: NoticeEntity): NoticeDto = entity.run {
+        fun of(entity: NoticeEntity, tags: List<Long>): NoticeDto = entity.run {
             NoticeDto(
                 id = this.id,
                 isDeleted = false,
                 title = this.title,
                 description = this.description,
                 // postType = this.postType,
+                tags = tags,
                 createdAt = this.createdAt,
                 modifiedAt = this.modifiedAt,
                 isPublic = this.isPublic,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/NoticeDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/NoticeDto.kt
@@ -12,9 +12,9 @@ data class NoticeDto(
     // val authorId: Int,
     val createdAt: LocalDateTime?,
     val modifiedAt: LocalDateTime?,
-    // val isPublic: Boolean,
-    // val isSlide: Boolean,
-    // val isPinned: Boolean,
+    val isPublic: Boolean,
+    val isSlide: Boolean,
+    val isPinned: Boolean,
 ) {
 
     companion object {
@@ -27,9 +27,9 @@ data class NoticeDto(
                 // postType = this.postType,
                 createdAt = this.createdAt,
                 modifiedAt = this.modifiedAt,
-//                isPublic = this.isPublic,
-//                isSlide = this.isSlide,
-//                isPinned = this.isPinned,
+                isPublic = this.isPublic,
+                isSlide = this.isSlide,
+                isPinned = this.isPinned,
             )
         }
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/NoticeDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/NoticeDto.kt
@@ -19,14 +19,14 @@ data class NoticeDto(
 ) {
 
     companion object {
-        fun of(entity: NoticeEntity, tags: List<Long>): NoticeDto = entity.run {
+        fun of(entity: NoticeEntity): NoticeDto = entity.run {
             NoticeDto(
                 id = this.id,
                 isDeleted = false,
                 title = this.title,
                 description = this.description,
                 // postType = this.postType,
-                tags = tags,
+                tags = this.noticeTags.map { it.tag.id },
                 createdAt = this.createdAt,
                 modifiedAt = this.modifiedAt,
                 isPublic = this.isPublic,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/SearchDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/SearchDto.kt
@@ -1,0 +1,13 @@
+package com.wafflestudio.csereal.core.notice.dto
+
+import com.querydsl.core.annotations.QueryProjection
+import java.time.LocalDateTime
+
+data class SearchDto @QueryProjection constructor(
+    val noticeId: Long,
+    val title: String,
+    val createdDate: LocalDateTime,
+    val isPinned: Boolean,
+) {
+
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/SearchRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/SearchRequest.kt
@@ -1,7 +1,0 @@
-package com.wafflestudio.csereal.core.notice.dto
-
-data class SearchRequest(
-    val tags: List<Long>?,
-    val keyword: String?
-) {
-}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/SearchRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/SearchRequest.kt
@@ -1,0 +1,7 @@
+package com.wafflestudio.csereal.core.notice.dto
+
+data class SearchRequest(
+    val tags: List<Long>?,
+    val keyword: String?
+) {
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/SearchResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/SearchResponse.kt
@@ -1,0 +1,11 @@
+package com.wafflestudio.csereal.core.notice.dto
+
+import com.querydsl.core.annotations.QueryProjection
+import java.time.LocalDateTime
+
+data class SearchResponse @QueryProjection constructor(
+    val noticeId: Long,
+    val title: String,
+    val createdDate: LocalDateTime,
+    val tagId: Long
+)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/SearchResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/SearchResponse.kt
@@ -7,5 +7,4 @@ data class SearchResponse @QueryProjection constructor(
     val noticeId: Long,
     val title: String,
     val createdDate: LocalDateTime,
-    val tagId: Long
 )

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/SearchResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/SearchResponse.kt
@@ -1,11 +1,8 @@
 package com.wafflestudio.csereal.core.notice.dto
 
-import com.querydsl.core.annotations.QueryProjection
-import java.time.LocalDateTime
+data class SearchResponse(
+    val total: Int,
+    val searchList: List<SearchDto>
+) {
 
-data class SearchResponse @QueryProjection constructor(
-    val noticeId: Long,
-    val title: String,
-    val createdDate: LocalDateTime,
-    val isPinned: Boolean
-)
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/SearchResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/SearchResponse.kt
@@ -7,4 +7,5 @@ data class SearchResponse @QueryProjection constructor(
     val noticeId: Long,
     val title: String,
     val createdDate: LocalDateTime,
+    val isPinned: Boolean
 )

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/UpdateNoticeRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/UpdateNoticeRequest.kt
@@ -3,6 +3,9 @@ package com.wafflestudio.csereal.core.notice.dto
 data class UpdateNoticeRequest(
     val title: String?,
     val description: String?,
-    val tags: List<Long>?
+    val tags: List<Long>?,
+    val isPublic: Boolean?,
+    val isSlide: Boolean?,
+    val isPinned: Boolean?,
 ) {
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 interface NoticeService {
-    fun searchNotice(tag: List<Long>?, keyword: String?): List<SearchResponse>
+    fun searchNotice(tag: List<Long>?, keyword: String?, pageNum: Long): List<SearchResponse>
     fun readNotice(noticeId: Long): NoticeDto
     fun createNotice(request: CreateNoticeRequest): NoticeDto
     fun updateNotice(noticeId: Long, request: UpdateNoticeRequest): NoticeDto
@@ -29,9 +29,10 @@ class NoticeServiceImpl(
     @Transactional
     override fun searchNotice(
         tag: List<Long>?,
-        keyword: String?
+        keyword: String?,
+        pageNum: Long
         ): List<SearchResponse> {
-            return noticeRepository.searchNotice(tag, keyword)
+            return noticeRepository.searchNotice(tag, keyword, pageNum)
         }
 
     @Transactional(readOnly = true)
@@ -105,5 +106,5 @@ class NoticeServiceImpl(
         tagRepository.save(newTag)
     }
 
-    //TODO: 이미지 등록, 페이지네이션, 글쓴이 함께 조회
+    //TODO: 이미지 등록, 글쓴이 함께 조회
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
@@ -26,7 +26,7 @@ class NoticeServiceImpl(
     private val noticeTagRepository: NoticeTagRepository
 ) : NoticeService {
 
-    @Transactional
+    @Transactional(readOnly = true)
     override fun searchNotice(
         tag: List<Long>?,
         keyword: String?,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
@@ -37,6 +37,9 @@ class NoticeServiceImpl(
         val newNotice = NoticeEntity(
             title = request.title,
             description = request.description,
+            isPublic = request.isPublic,
+            isSlide = request.isSlide,
+            isPinned = request.isPinned
         )
 
         for (tagId in request.tags) {
@@ -58,6 +61,9 @@ class NoticeServiceImpl(
 
         notice.title = request.title ?: notice.title
         notice.description = request.description ?: notice.description
+        notice.isPublic = request.isPublic ?: notice.isPublic
+        notice.isSlide = request.isSlide ?: notice.isSlide
+        notice.isPinned = request.isPinned ?: notice.isPinned
 
         if (request.tags != null) {
             noticeTagRepository.deleteAllByNoticeId(noticeId)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
@@ -39,7 +39,7 @@ class NoticeServiceImpl(
     override fun readNotice(noticeId: Long): NoticeDto {
         val notice: NoticeEntity = noticeRepository.findByIdOrNull(noticeId)
             ?: throw CserealException.Csereal400("존재하지 않는 공지사항입니다.(noticeId: $noticeId)")
-        val tags = notice.noticeTags.map { it.tag.id }
+        
         if (notice.isDeleted) throw CserealException.Csereal400("삭제된 공지사항입니다.(noticeId: $noticeId)")
         return NoticeDto.of(notice)
     }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
@@ -2,16 +2,13 @@ package com.wafflestudio.csereal.core.notice.service
 
 import com.wafflestudio.csereal.common.CserealException
 import com.wafflestudio.csereal.core.notice.database.*
-import com.wafflestudio.csereal.core.notice.dto.CreateNoticeRequest
-import com.wafflestudio.csereal.core.notice.dto.NoticeDto
-import com.wafflestudio.csereal.core.notice.dto.SearchResponse
-import com.wafflestudio.csereal.core.notice.dto.UpdateNoticeRequest
+import com.wafflestudio.csereal.core.notice.dto.*
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 interface NoticeService {
-    fun searchNotice(tag: List<Long>?, keyword: String?, pageNum: Long): List<SearchResponse>
+    fun searchNotice(tag: List<Long>?, keyword: String?, pageNum: Long): SearchResponse
     fun readNotice(noticeId: Long): NoticeDto
     fun createNotice(request: CreateNoticeRequest): NoticeDto
     fun updateNotice(noticeId: Long, request: UpdateNoticeRequest): NoticeDto
@@ -31,7 +28,7 @@ class NoticeServiceImpl(
         tag: List<Long>?,
         keyword: String?,
         pageNum: Long
-        ): List<SearchResponse> {
+        ): SearchResponse {
             return noticeRepository.searchNotice(tag, keyword, pageNum)
         }
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
@@ -4,12 +4,14 @@ import com.wafflestudio.csereal.common.CserealException
 import com.wafflestudio.csereal.core.notice.database.*
 import com.wafflestudio.csereal.core.notice.dto.CreateNoticeRequest
 import com.wafflestudio.csereal.core.notice.dto.NoticeDto
+import com.wafflestudio.csereal.core.notice.dto.SearchResponse
 import com.wafflestudio.csereal.core.notice.dto.UpdateNoticeRequest
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 interface NoticeService {
+    fun searchNotice(tags: List<Long>?, keyword: String?): List<SearchResponse>
     fun readNotice(noticeId: Long): NoticeDto
     fun createNotice(request: CreateNoticeRequest): NoticeDto
     fun updateNotice(noticeId: Long, request: UpdateNoticeRequest): NoticeDto
@@ -23,6 +25,14 @@ class NoticeServiceImpl(
     private val tagRepository: TagRepository,
     private val noticeTagRepository: NoticeTagRepository
 ) : NoticeService {
+
+    @Transactional
+    override fun searchNotice(
+        tags: List<Long>?,
+        keyword: String?
+        ): List<SearchResponse> {
+            return noticeRepository.searchNotice(tags, keyword)
+        }
 
     @Transactional(readOnly = true)
     override fun readNotice(noticeId: Long): NoticeDto {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 interface NoticeService {
-    fun searchNotice(tags: List<Long>?, keyword: String?): List<SearchResponse>
+    fun searchNotice(tag: List<Long>?, keyword: String?): List<SearchResponse>
     fun readNotice(noticeId: Long): NoticeDto
     fun createNotice(request: CreateNoticeRequest): NoticeDto
     fun updateNotice(noticeId: Long, request: UpdateNoticeRequest): NoticeDto
@@ -28,10 +28,10 @@ class NoticeServiceImpl(
 
     @Transactional
     override fun searchNotice(
-        tags: List<Long>?,
+        tag: List<Long>?,
         keyword: String?
         ): List<SearchResponse> {
-            return noticeRepository.searchNotice(tags, keyword)
+            return noticeRepository.searchNotice(tag, keyword)
         }
 
     @Transactional(readOnly = true)
@@ -105,5 +105,5 @@ class NoticeServiceImpl(
         tagRepository.save(newTag)
     }
 
-    //TODO: 이미지 등록, 페이지네이션, 검색
+    //TODO: 이미지 등록, 페이지네이션, 글쓴이 함께 조회
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,7 +12,7 @@ spring:
     password: toor
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     open-in-view: false
 logging.level:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,7 +12,7 @@ spring:
     password: toor
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: true
     open-in-view: false
 logging.level:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,12 +7,12 @@ spring:
   config.activate.on-profile: local
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/csereal
+    url: jdbc:mysql://localhost:3306/csereal_develop
     username: root
-    password: password
+    password: toor
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: true
     open-in-view: false
 logging.level:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,9 +7,9 @@ spring:
   config.activate.on-profile: local
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/csereal_develop
+    url: jdbc:mysql://127.0.0.1:3306/csereal_local?useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul
     username: root
-    password: toor
+    password: password
   jpa:
     hibernate:
       ddl-auto: update

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,18 +7,14 @@ spring:
   config.activate.on-profile: local
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://127.0.0.1:3306/csereal_local?useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul
+    url: jdbc:mysql://localhost:3306/csereal
     username: root
-    password: toor
+    password: password
   jpa:
     hibernate:
       ddl-auto: update
     show-sql: true
     open-in-view: false
-  datasource:
-    url: jdbc:mysql://localhost:3306/csereal
-    username: root
-    password: password
 logging.level:
   default: INFO
 


### PR DESCRIPTION
## 제목
페이지네이션+검색 기능 추가

### 한줄 요약
태그와 키워드를 이용한 공지사항 검색이 가능하고, 페이지네이션을 통해 페이지에 맞게 원하는 만큼을 보여줄 수 있습니다. (원래는 한페이지에 게시글 20개, 지금은 코드상 5개)

PR 요약해주세요

### 상세 설명

[ecb4513]: 엔티티에서 isPublic, isSlide, isPinned 칼럼을 생성했습니다.
 
[9443b7a]: queryDsl gradle을 도입하기 위해 implement와 kapt을 추가했습니다. 또한 spring 3.0부터는 javax를 jakarta로 바꿔야 한다고 해서 바꿨습니다. 각각 https://onethejay.tistory.com/197 와 https://covenant.tistory.com/279 을 참고했습니다.

[cb2e22b]: queryDsl을 실제로 도입하기 위해 JPAQueryFactory을 가져왔습니다.

[832e0f9]: 태그와 키워드를 입력하면, id/제목/날짜/list<태그>가 나오도록 했습니다. (태그 리스트는 로컬 테스트할 때 자주 써서 넣었습니다.) 태그를 여러개 입력하면 여러 태그 중 하나라도 만족하면 들고오도록 했고, 키워드는 제목이나 본문에서 포함하면 들고오도록 했습니다. 태그만 입력/키워드만 입력/태그+키워드 입력 모두 가능합니다. 음.. 일단 구현은 되는데, 혹시 쿼리 최적화 등에 대해 필요해보인다면 리뷰 부탁드려요.

[10ac208]: 쿼리에서 isDeleted = false, isPublic = true인 게시글만 나오고, 최신순 중에서 isPinned =true인 것들이 가장 위에 나오도록 했습니다.

[3e2b0ad]: 실제 컴공 홈페이지를 보니, ?로 파라미터를 받고 있어서 requestParam으로 고쳤습니다.

[cb0f773]: 페이지네이션 기능을 추가했습니다.

[34a1178]: 제 개인 브랜치에서 origin으로 옮기니 약간의 실수가 있었는데, 키워드 booleanBuilder을 추가하고 application.yaml에서 중복된 걸 수정했습니다. 이제 잘 돌아갑니다

+) 추가 커밋
[59fae6b]: searchNotice 서비스단에서 readOnly = true 추가했습니다

[7897a07]: 검색할때 SearchRequest가 불필요해서 삭제했습니다

[54e807f]: NoticeDto에 태그 리스트도 추가해서 각각의 공지를 읽으면 태그가 나올 수 있도록 하였습니다. 

### TODO
이미지 추가, 글쓴이 연결을 해야하는데 이거는 실제 서버가 연결되면 하려고 생각중입니다
다음으로는 새소식 만들려고 합니다.

+) 추가 todo
키워드를 띄어쓰기로 검색하면, 해당 단어들을 모두 포함하는 게시글을 띄워야 되는데 지금은 띄어쓰기까지 하나의 string으로 묶고 있네요. 수정하겠습니다

리뷰 부탁드립니다. 감사합니다
