### PR TITLE
feat: 구성원(교수) 생성 및 조회 API 구현 

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/common/Exceptions.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/Exceptions.kt
@@ -4,4 +4,5 @@ import org.springframework.http.HttpStatus
 
 open class CserealException(msg: String, val status: HttpStatus) : RuntimeException(msg) {
     class Csereal400(msg: String) : CserealException(msg, HttpStatus.BAD_REQUEST)
+    class Csereal404(msg: String) : CserealException(msg, HttpStatus.NOT_FOUND)
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/api/ProfessorController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/api/ProfessorController.kt
@@ -1,0 +1,35 @@
+package com.wafflestudio.csereal.core.member.api
+
+import com.wafflestudio.csereal.core.member.dto.ProfessorDto
+import com.wafflestudio.csereal.core.member.dto.SimpleProfessorDto
+import com.wafflestudio.csereal.core.member.service.ProfessorService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RequestMapping("/professor")
+@RestController
+class ProfessorController(
+    private val professorService: ProfessorService
+) {
+
+    @PostMapping
+    fun createProfessor(@RequestBody createProfessorRequest: ProfessorDto): ResponseEntity<ProfessorDto> {
+        return ResponseEntity.ok(professorService.createProfessor(createProfessorRequest))
+    }
+
+    @GetMapping("/{professorId}")
+    fun getProfessor(@PathVariable professorId: Long): ResponseEntity<ProfessorDto> {
+        return ResponseEntity.ok(professorService.getProfessor(professorId))
+    }
+
+    @GetMapping("/active")
+    fun getActiveProfessors(): ResponseEntity<List<SimpleProfessorDto>> {
+        return ResponseEntity.ok(professorService.getActiveProfessors())
+    }
+
+    @GetMapping("/inactive")
+    fun getInactiveProfessors(): ResponseEntity<List<SimpleProfessorDto>> {
+        return ResponseEntity.ok(professorService.getInactiveProfessors())
+    }
+
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/database/CareerEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/database/CareerEntity.kt
@@ -1,0 +1,32 @@
+package com.wafflestudio.csereal.core.member.database
+
+import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.core.member.dto.CareerDto
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+
+@Entity(name = "career")
+class CareerEntity(
+    val duration: String,
+    val name: String,
+    val workplace: String,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "professor_id")
+    val professor: ProfessorEntity
+) : BaseTimeEntity() {
+    companion object {
+        fun create(career: CareerDto, professor: ProfessorEntity): CareerEntity {
+            val careerEntity = CareerEntity(
+                duration = career.duration,
+                name = career.name,
+                workplace = career.workplace,
+                professor = professor
+            )
+            professor.careers.add(careerEntity)
+            return careerEntity
+        }
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/database/EducationEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/database/EducationEntity.kt
@@ -1,0 +1,38 @@
+package com.wafflestudio.csereal.core.member.database
+
+import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.core.member.dto.EducationDto
+import jakarta.persistence.*
+
+@Entity(name = "education")
+class EducationEntity(
+    val university: String,
+    val major: String,
+
+    @Enumerated(EnumType.STRING)
+    val degree: Degree,
+
+    val year: Int,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "professor_id")
+    val professor: ProfessorEntity
+) : BaseTimeEntity() {
+    companion object {
+        fun create(education: EducationDto, professor: ProfessorEntity): EducationEntity {
+            val educationEntity = EducationEntity(
+                university = education.university,
+                major = education.major,
+                degree = education.degree,
+                year = education.year,
+                professor = professor
+            )
+            professor.educations.add(educationEntity)
+            return educationEntity
+        }
+    }
+}
+
+enum class Degree {
+    Bachelor, Master, PhD
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/database/ProfessorEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/database/ProfessorEntity.kt
@@ -1,0 +1,65 @@
+package com.wafflestudio.csereal.core.member.database
+
+import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.core.member.dto.ProfessorDto
+import com.wafflestudio.csereal.core.research.database.LabEntity
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToMany
+import java.time.LocalDate
+
+@Entity(name = "professor")
+class ProfessorEntity(
+    val name: String,
+    //val profileImage:File
+    var isActive: Boolean,
+    var academicRank: String,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lab_id")
+    var lab: LabEntity? = null,
+
+    var startDate: LocalDate?,
+    var endDate: LocalDate?,
+    val office: String?,
+    var phone: String?,
+    var fax: String?,
+    var email: String?,
+    var website: String?,
+
+    @OneToMany(mappedBy = "professor", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val educations: MutableList<EducationEntity> = mutableListOf(),
+
+    @OneToMany(mappedBy = "professor", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val researchAreas: MutableSet<ResearchAreaEntity> = mutableSetOf(),
+
+    @OneToMany(mappedBy = "professor", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val careers: MutableList<CareerEntity> = mutableListOf(),
+
+    ) : BaseTimeEntity() {
+
+    companion object {
+        fun of(professorDto: ProfessorDto): ProfessorEntity {
+            return ProfessorEntity(
+                name = professorDto.name,
+                isActive = professorDto.isActive,
+                academicRank = professorDto.academicRank,
+                startDate = professorDto.startDate,
+                endDate = professorDto.endDate,
+                office = professorDto.office,
+                phone = professorDto.phone,
+                fax = professorDto.fax,
+                email = professorDto.email,
+                website = professorDto.website
+            )
+        }
+    }
+
+    fun addLab(lab: LabEntity) {
+        this.lab = lab
+        lab.professors.add(this)
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/database/ProfessorRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/database/ProfessorRepository.kt
@@ -1,0 +1,8 @@
+package com.wafflestudio.csereal.core.member.database
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ProfessorRepository : JpaRepository<ProfessorEntity, Long> {
+    fun findByIsActiveTrue(): List<ProfessorEntity>
+    fun findByIsActiveFalse(): List<ProfessorEntity>
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/database/ResearchAreaEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/database/ResearchAreaEntity.kt
@@ -1,0 +1,27 @@
+package com.wafflestudio.csereal.core.member.database
+
+import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+
+@Entity(name = "research_area")
+class ResearchAreaEntity(
+    val name: String,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "professor_id")
+    val professor: ProfessorEntity
+) : BaseTimeEntity() {
+    companion object {
+        fun create(name: String, professor: ProfessorEntity): ResearchAreaEntity {
+            val researchArea = ResearchAreaEntity(
+                name = name,
+                professor = professor
+            )
+            professor.researchAreas.add(researchArea)
+            return researchArea
+        }
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/dto/CareerDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/dto/CareerDto.kt
@@ -1,0 +1,19 @@
+package com.wafflestudio.csereal.core.member.dto
+
+import com.wafflestudio.csereal.core.member.database.CareerEntity
+
+data class CareerDto(
+    val duration: String,
+    val name: String,
+    val workplace: String
+) {
+    companion object {
+        fun of(careerEntity: CareerEntity): CareerDto {
+            return CareerDto(
+                duration = careerEntity.duration,
+                name = careerEntity.name,
+                workplace = careerEntity.workplace
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/dto/EducationDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/dto/EducationDto.kt
@@ -1,0 +1,22 @@
+package com.wafflestudio.csereal.core.member.dto
+
+import com.wafflestudio.csereal.core.member.database.Degree
+import com.wafflestudio.csereal.core.member.database.EducationEntity
+
+data class EducationDto(
+    val university: String,
+    val major: String,
+    val degree: Degree,
+    val year: Int
+) {
+    companion object {
+        fun of(educationEntity: EducationEntity): EducationDto {
+            return EducationDto(
+                university = educationEntity.university,
+                major = educationEntity.major,
+                degree = educationEntity.degree,
+                year = educationEntity.year
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/dto/ProfessorDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/dto/ProfessorDto.kt
@@ -1,0 +1,46 @@
+package com.wafflestudio.csereal.core.member.dto
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.wafflestudio.csereal.core.member.database.ProfessorEntity
+import java.time.LocalDate
+
+data class ProfessorDto(
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    var id: Long? = null,
+    val name: String,
+    val isActive: Boolean,
+    val academicRank: String,
+    val labId: Long?,
+    val startDate: LocalDate?,
+    val endDate: LocalDate?,
+    val office: String?,
+    val phone: String?,
+    val fax: String?,
+    val email: String?,
+    val website: String?,
+    val educations: List<EducationDto>,
+    val researchAreas: List<String>,
+    val careers: List<CareerDto>
+) {
+    companion object {
+        fun of(professorEntity: ProfessorEntity): ProfessorDto {
+            return ProfessorDto(
+                id = professorEntity.id,
+                name = professorEntity.name,
+                isActive = professorEntity.isActive,
+                academicRank = professorEntity.academicRank,
+                labId = professorEntity.lab?.id,
+                startDate = professorEntity.startDate,
+                endDate = professorEntity.endDate,
+                office = professorEntity.office,
+                phone = professorEntity.phone,
+                fax = professorEntity.fax,
+                email = professorEntity.email,
+                website = professorEntity.website,
+                educations = professorEntity.educations.map { EducationDto.of(it) },
+                researchAreas = professorEntity.researchAreas.map { it.name },
+                careers = professorEntity.careers.map { CareerDto.of(it) }
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/dto/SimpleProfessorDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/dto/SimpleProfessorDto.kt
@@ -1,0 +1,28 @@
+package com.wafflestudio.csereal.core.member.dto
+
+import com.wafflestudio.csereal.core.member.database.ProfessorEntity
+
+data class SimpleProfessorDto(
+    val id: Long,
+    val name: String,
+    val academicRank: String,
+    val labId: Long?,
+    val labName: String?,
+    val phone: String?,
+    val email: String?,
+    // val imageUri: String
+) {
+    companion object {
+        fun of(professorEntity: ProfessorEntity): SimpleProfessorDto {
+            return SimpleProfessorDto(
+                id = professorEntity.id,
+                name = professorEntity.name,
+                academicRank = professorEntity.academicRank,
+                labId = professorEntity.lab?.id,
+                labName = professorEntity.lab?.name,
+                phone = professorEntity.phone,
+                email = professorEntity.email
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/service/ProfessorService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/service/ProfessorService.kt
@@ -1,0 +1,79 @@
+package com.wafflestudio.csereal.core.member.service
+
+import com.wafflestudio.csereal.common.CserealException
+import com.wafflestudio.csereal.core.member.database.*
+import com.wafflestudio.csereal.core.member.dto.ProfessorDto
+import com.wafflestudio.csereal.core.member.dto.SimpleProfessorDto
+import com.wafflestudio.csereal.core.research.database.LabRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+interface ProfessorService {
+    fun createProfessor(professorDto: ProfessorDto): ProfessorDto
+    fun getProfessor(professorId: Long): ProfessorDto
+    fun getActiveProfessors(): List<SimpleProfessorDto>
+    fun getInactiveProfessors(): List<SimpleProfessorDto>
+    fun updateProfessor(updateProfessorRequest: ProfessorDto): ProfessorDto
+    fun deleteProfessor(professorId: Long)
+}
+
+@Service
+@Transactional
+class ProfessorServiceImpl(
+    private val labRepository: LabRepository,
+    private val professorRepository: ProfessorRepository
+) : ProfessorService {
+
+    override fun createProfessor(professorDto: ProfessorDto): ProfessorDto {
+        val professor = ProfessorEntity.of(professorDto)
+
+        if (professorDto.labId != null) {
+            val lab = labRepository.findByIdOrNull(professorDto.labId)
+                ?: throw CserealException.Csereal404("해당 연구실을 찾을 수 없습니다. LabId: ${professorDto.labId}")
+            professor.addLab(lab)
+        }
+
+        for (education in professorDto.educations) {
+            EducationEntity.create(education, professor)
+        }
+
+        for (researchArea in professorDto.researchAreas) {
+            ResearchAreaEntity.create(researchArea, professor)
+        }
+
+        for (career in professorDto.careers) {
+            CareerEntity.create(career, professor)
+        }
+
+        professorRepository.save(professor)
+
+        return ProfessorDto.of(professor)
+    }
+
+    @Transactional(readOnly = true)
+    override fun getProfessor(professorId: Long): ProfessorDto {
+        val professor = professorRepository.findByIdOrNull(professorId)
+            ?: throw CserealException.Csereal404("해당 교수님을 찾을 수 없습니다. professorId: ${professorId}")
+        return ProfessorDto.of(professor)
+    }
+
+    @Transactional(readOnly = true)
+    override fun getActiveProfessors(): List<SimpleProfessorDto> {
+        return professorRepository.findByIsActiveTrue().map { SimpleProfessorDto.of(it) }
+    }
+
+    @Transactional(readOnly = true)
+    override fun getInactiveProfessors(): List<SimpleProfessorDto> {
+        return professorRepository.findByIsActiveFalse().map { SimpleProfessorDto.of(it) }
+    }
+
+    override fun updateProfessor(updateProfessorRequest: ProfessorDto): ProfessorDto {
+        TODO("Not yet implemented")
+    }
+
+    override fun deleteProfessor(professorId: Long) {
+        TODO("Not yet implemented")
+    }
+
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/database/LabEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/database/LabEntity.kt
@@ -1,0 +1,15 @@
+package com.wafflestudio.csereal.core.research.database
+
+import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.core.member.database.ProfessorEntity
+import jakarta.persistence.Entity
+import jakarta.persistence.OneToMany
+
+@Entity(name = "lab")
+class LabEntity(
+    
+    val name: String,
+
+    @OneToMany(mappedBy = "lab")
+    val professors: MutableSet<ProfessorEntity> = mutableSetOf()
+) : BaseTimeEntity()

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/database/LabRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/database/LabRepository.kt
@@ -1,0 +1,6 @@
+package com.wafflestudio.csereal.core.research.database
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface LabRepository : JpaRepository<LabEntity, Long> {
+}


### PR DESCRIPTION
## 교수 생성 및 조회 API

### 한줄 요약

교수 엔티티 설계 및 API 구현하였는데 LabEntity는 미완성이고 학력, 경력, 연구 분야는 교수에만 종속적인 것 같아서 임의로 구현해보았습니다. 

### 상세 설명

[e63a6cc35065ce17dae25e558232c8018f03ddc1]: 교수 엔티티 및 DTO 설계

[25ab76056f4b801245fcffc1483a3686721306ec]: 교수 생성 및 조회 API 구현

### TODO

이미지 업로드 구현
