### PR TITLE
feat: 구성원(행정직원) CRUD API

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/api/StaffController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/api/StaffController.kt
@@ -1,0 +1,46 @@
+package com.wafflestudio.csereal.core.member.api
+
+import com.wafflestudio.csereal.core.member.dto.StaffDto
+import com.wafflestudio.csereal.core.member.service.StaffService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RequestMapping("/staff")
+@RestController
+class StaffController(
+    private val staffService: StaffService
+) {
+
+    @PostMapping
+    fun createStaff(@RequestBody createStaffRequest: StaffDto): ResponseEntity<StaffDto> {
+        return ResponseEntity.ok(staffService.createStaff(createStaffRequest))
+    }
+
+    @GetMapping("/{staffId}")
+    fun getStaff(@PathVariable staffId: Long): ResponseEntity<StaffDto> {
+        return ResponseEntity.ok(staffService.getStaff(staffId))
+    }
+
+    @GetMapping
+    fun getAllStaff(): ResponseEntity<List<StaffDto>> {
+        return ResponseEntity.ok(staffService.getAllStaff())
+    }
+
+    @PatchMapping
+    fun updateStaff(@RequestBody updateStaffRequest: StaffDto): ResponseEntity<StaffDto> {
+        return ResponseEntity.ok(staffService.updateStaff(updateStaffRequest))
+    }
+
+    @DeleteMapping("/{staffId}")
+    fun deleteStaff(@PathVariable staffId: Long): ResponseEntity<Any> {
+        staffService.deleteStaff(staffId)
+        return ResponseEntity.ok().build()
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/api/StaffController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/api/StaffController.kt
@@ -33,9 +33,9 @@ class StaffController(
         return ResponseEntity.ok(staffService.getAllStaff())
     }
 
-    @PatchMapping
-    fun updateStaff(@RequestBody updateStaffRequest: StaffDto): ResponseEntity<StaffDto> {
-        return ResponseEntity.ok(staffService.updateStaff(updateStaffRequest))
+    @PatchMapping("/{staffId}")
+    fun updateStaff(@PathVariable staffId: Long, @RequestBody updateStaffRequest: StaffDto): ResponseEntity<StaffDto> {
+        return ResponseEntity.ok(staffService.updateStaff(staffId, updateStaffRequest))
     }
 
     @DeleteMapping("/{staffId}")

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/database/ProfessorEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/database/ProfessorEntity.kt
@@ -34,7 +34,7 @@ class ProfessorEntity(
     val educations: MutableList<EducationEntity> = mutableListOf(),
 
     @OneToMany(mappedBy = "professor", cascade = [CascadeType.ALL], orphanRemoval = true)
-    val researchAreas: MutableSet<ResearchAreaEntity> = mutableSetOf(),
+    val researchAreas: MutableList<ResearchAreaEntity> = mutableListOf(),
 
     @OneToMany(mappedBy = "professor", cascade = [CascadeType.ALL], orphanRemoval = true)
     val careers: MutableList<CareerEntity> = mutableListOf(),

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/database/StaffEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/database/StaffEntity.kt
@@ -1,0 +1,44 @@
+package com.wafflestudio.csereal.core.member.database
+
+import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.core.member.dto.StaffDto
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Entity
+import jakarta.persistence.OneToMany
+
+@Entity(name = "staff")
+class StaffEntity(
+    var name: String,
+    var role: String,
+
+    // profileImage
+
+    var office: String,
+    var phone: String,
+    var email: String,
+
+    @OneToMany(mappedBy = "staff", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val tasks: MutableList<TaskEntity> = mutableListOf()
+
+) : BaseTimeEntity() {
+
+    companion object {
+        fun of(staffDto: StaffDto): StaffEntity {
+            return StaffEntity(
+                name = staffDto.name,
+                role = staffDto.role,
+                office = staffDto.office,
+                phone = staffDto.phone,
+                email = staffDto.email
+            )
+        }
+    }
+
+    fun update(staffDto: StaffDto) {
+        this.name = staffDto.name
+        this.role = staffDto.role
+        this.office = staffDto.office
+        this.phone = staffDto.phone
+        this.email = staffDto.email
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/database/StaffRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/database/StaffRepository.kt
@@ -1,0 +1,6 @@
+package com.wafflestudio.csereal.core.member.database
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface StaffRepository : JpaRepository<StaffEntity, Long> {
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/database/TaskEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/database/TaskEntity.kt
@@ -1,0 +1,27 @@
+package com.wafflestudio.csereal.core.member.database
+
+import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+
+@Entity
+class TaskEntity(
+    val name: String,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "staff_id")
+    val staff: StaffEntity
+) : BaseTimeEntity() {
+    companion object {
+        fun create(name: String, staff: StaffEntity): TaskEntity {
+            val task = TaskEntity(
+                name = name,
+                staff = staff
+            )
+            staff.tasks.add(task)
+            return task
+        }
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/dto/StaffDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/dto/StaffDto.kt
@@ -1,0 +1,29 @@
+package com.wafflestudio.csereal.core.member.dto
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.wafflestudio.csereal.core.member.database.StaffEntity
+
+data class StaffDto(
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    var id: Long? = null,
+    val name: String,
+    val role: String,
+    val office: String,
+    val phone: String,
+    val email: String,
+    val tasks: List<String>
+) {
+    companion object {
+        fun of(staffEntity: StaffEntity): StaffDto {
+            return StaffDto(
+                id = staffEntity.id,
+                name = staffEntity.name,
+                role = staffEntity.role,
+                office = staffEntity.office,
+                phone = staffEntity.phone,
+                email = staffEntity.email,
+                tasks = staffEntity.tasks.map { it.name }
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/service/ProfessorService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/service/ProfessorService.kt
@@ -60,12 +60,12 @@ class ProfessorServiceImpl(
 
     @Transactional(readOnly = true)
     override fun getActiveProfessors(): List<SimpleProfessorDto> {
-        return professorRepository.findByIsActiveTrue().map { SimpleProfessorDto.of(it) }
+        return professorRepository.findByIsActiveTrue().map { SimpleProfessorDto.of(it) }.sortedBy { it.name }
     }
 
     @Transactional(readOnly = true)
     override fun getInactiveProfessors(): List<SimpleProfessorDto> {
-        return professorRepository.findByIsActiveFalse().map { SimpleProfessorDto.of(it) }
+        return professorRepository.findByIsActiveFalse().map { SimpleProfessorDto.of(it) }.sortedBy { it.name }
     }
 
     override fun updateProfessor(updateProfessorRequest: ProfessorDto): ProfessorDto {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/service/StaffService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/service/StaffService.kt
@@ -1,0 +1,67 @@
+package com.wafflestudio.csereal.core.member.service
+
+import com.wafflestudio.csereal.common.CserealException
+import com.wafflestudio.csereal.core.member.database.StaffEntity
+import com.wafflestudio.csereal.core.member.database.StaffRepository
+import com.wafflestudio.csereal.core.member.database.TaskEntity
+import com.wafflestudio.csereal.core.member.dto.StaffDto
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+interface StaffService {
+    fun createStaff(staffDto: StaffDto): StaffDto
+    fun getStaff(staffId: Long): StaffDto
+    fun getAllStaff(): List<StaffDto>
+    fun updateStaff(staffDto: StaffDto): StaffDto
+    fun deleteStaff(staffId: Long)
+}
+
+@Service
+@Transactional
+class StaffServiceImpl(
+    private val staffRepository: StaffRepository
+) : StaffService {
+    override fun createStaff(staffDto: StaffDto): StaffDto {
+        val staff = StaffEntity.of(staffDto)
+
+        for (task in staffDto.tasks) {
+            TaskEntity.create(task, staff)
+        }
+
+        staffRepository.save(staff)
+
+        return StaffDto.of(staff)
+    }
+
+    @Transactional(readOnly = true)
+    override fun getStaff(staffId: Long): StaffDto {
+        val staff = staffRepository.findByIdOrNull(staffId)
+            ?: throw CserealException.Csereal404("해당 행정직원을 찾을 수 없습니다. staffId: ${staffId}")
+        return StaffDto.of(staff)
+    }
+
+    @Transactional(readOnly = true)
+    override fun getAllStaff(): List<StaffDto> {
+        return staffRepository.findAll().map { StaffDto.of(it) }.sortedBy { it.name }
+    }
+
+    override fun updateStaff(staffDto: StaffDto): StaffDto {
+        val staffId = staffDto.id ?: throw CserealException.Csereal400("업데이트 시 행정직원 id가 필요합니다.")
+
+        val staff = staffRepository.findByIdOrNull(staffId)
+            ?: throw CserealException.Csereal404("해당 행정직원을 찾을 수 없습니다. staffId: ${staffId}")
+
+        staff.update(staffDto)
+
+        // 주요 업무 업데이트
+
+        return StaffDto.of(staff)
+    }
+
+    override fun deleteStaff(staffId: Long) {
+        staffRepository.deleteById(staffId)
+    }
+
+
+}


### PR DESCRIPTION
## 행정직원 CRUD

### 한줄 요약

교수 API와 거의 동일하게 행정직원 엔티티 설계 및 API 개발하였습니다.

### 상세 설명

[0f18287e01d1fb62dc1ee92b583163c4d1dd0a7a]: 엔티티 및 DTO 설계

[1d4d2283ee4a828eabe3b40ca77dee4f4834dfcd]: CRUD API

[8d272a54f421d7c4d1480b39fc51ca7b091d7420]: 교수 조회 시 이름순 정렬 (행정직원 조회 만들다 생각나서 추가)

[e2f94ce1b825836806d5006a60e0014aa263fbc9]: 교수 연구분야 Set->List 변경 (행정직원 주요 업무 만들다 연구 분야도 중요도별 순서가 있을수 있나 싶어 List로 변경하였습니다

[c4f1f7efc51465344b1556d5c4116b0bb4d22d78]: 행정직원 주요업무 업데이트 구현

### TODO

로그인 구현
