### PR TITLE
feat: seminar 패키지 추가

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/api/SeminarController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/api/SeminarController.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.csereal.core.seminar.api
 
 import com.wafflestudio.csereal.core.seminar.dto.SeminarDto
+import com.wafflestudio.csereal.core.seminar.dto.SeminarSearchResponse
 import com.wafflestudio.csereal.core.seminar.service.SeminarService
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
@@ -11,6 +12,13 @@ import org.springframework.web.bind.annotation.*
 class SeminarController (
     private val seminarService: SeminarService,
 ) {
+    @GetMapping
+    fun searchSeminar(
+        @RequestParam(required = false) keyword: String?,
+        @RequestParam(required = false, defaultValue = "0") pageNum: Long
+    ) : ResponseEntity<SeminarSearchResponse> {
+        return ResponseEntity.ok(seminarService.searchSeminar(keyword, pageNum))
+    }
     @PostMapping
     fun createSeminar(
         @Valid @RequestBody request: SeminarDto
@@ -32,5 +40,12 @@ class SeminarController (
         @Valid @RequestBody request: SeminarDto,
     ) : ResponseEntity<SeminarDto> {
         return ResponseEntity.ok(seminarService.updateSeminar(seminarId, request))
+    }
+
+    @DeleteMapping("/{seminarId}")
+    fun deleteSeminar(
+        @PathVariable seminarId: Long
+    ) {
+        seminarService.deleteSeminar(seminarId)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/api/SeminarController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/api/SeminarController.kt
@@ -1,0 +1,36 @@
+package com.wafflestudio.csereal.core.seminar.api
+
+import com.wafflestudio.csereal.core.seminar.dto.SeminarDto
+import com.wafflestudio.csereal.core.seminar.service.SeminarService
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RequestMapping("/seminar")
+@RestController
+class SeminarController (
+    private val seminarService: SeminarService,
+) {
+    @PostMapping
+    fun createSeminar(
+        @Valid @RequestBody request: SeminarDto
+    ) : ResponseEntity<SeminarDto> {
+        return ResponseEntity.ok(seminarService.createSeminar(request))
+    }
+
+    @GetMapping("/{seminarId}")
+    fun readSeminar(
+        @PathVariable seminarId: Long,
+        @RequestParam(required = false) keyword: String?,
+    ) : ResponseEntity<SeminarDto> {
+        return ResponseEntity.ok(seminarService.readSeminar(seminarId, keyword))
+    }
+
+    @PatchMapping("/{seminarId}")
+    fun updateSeminar(
+        @PathVariable seminarId: Long,
+        @Valid @RequestBody request: SeminarDto,
+    ) : ResponseEntity<SeminarDto> {
+        return ResponseEntity.ok(seminarService.updateSeminar(seminarId, request))
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarEntity.kt
@@ -1,0 +1,96 @@
+package com.wafflestudio.csereal.core.seminar.database
+
+import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.core.seminar.dto.SeminarDto
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+
+@Entity(name = "seminar")
+class SeminarEntity(
+
+    var isDeleted: Boolean = false,
+
+    var title: String,
+
+    @Column(columnDefinition = "text")
+    var description: String,
+
+    @Column(columnDefinition = "text")
+    var introduction: String,
+
+    var category: String,
+
+    // 연사 정보
+    var name: String,
+    var speakerUrl: String?,
+    var speakerTitle: String?,
+    var affiliation: String,
+    var affiliationUrl: String?,
+
+    var startDate: String?,
+    var startTime: String?,
+    var endDate: String?,
+    var endTime: String?,
+
+    var location: String,
+
+    var host: String?,
+
+    // var profileImage: File,
+
+    // var seminarFile: File,
+
+    var isPublic: Boolean,
+
+    var isSlide: Boolean,
+
+    var additionalNote: String?
+): BaseTimeEntity() {
+
+    companion object {
+        fun of(seminarDto: SeminarDto): SeminarEntity {
+            return SeminarEntity(
+                title = seminarDto.title,
+                description = seminarDto.description,
+                introduction = seminarDto.introduction,
+                category = seminarDto.category,
+                name = seminarDto.name,
+                speakerUrl = seminarDto.speakerUrl,
+                speakerTitle = seminarDto.speakerTitle,
+                affiliation = seminarDto.affiliation,
+                affiliationUrl = seminarDto.affiliationUrl,
+                startDate = seminarDto.startDate,
+                startTime = seminarDto.startTime,
+                endDate = seminarDto.endDate,
+                endTime = seminarDto.endTime,
+                location = seminarDto.location,
+                host = seminarDto.host,
+                additionalNote = seminarDto.additionalNote,
+                isPublic = seminarDto.isPublic,
+                isSlide = seminarDto.isSlide
+            )
+        }
+
+    }
+
+    fun update(updateSeminarRequest: SeminarDto) {
+        title = updateSeminarRequest.title
+        description = updateSeminarRequest.description
+        introduction = updateSeminarRequest.introduction
+        category = updateSeminarRequest.category
+        name = updateSeminarRequest.name
+        speakerUrl = updateSeminarRequest.speakerUrl
+        speakerTitle = updateSeminarRequest.speakerTitle
+        affiliation = updateSeminarRequest.affiliation
+        affiliationUrl = updateSeminarRequest.affiliationUrl
+        startDate = updateSeminarRequest.startDate
+        startTime = updateSeminarRequest.startTime
+        endDate = updateSeminarRequest.endDate
+        endTime = updateSeminarRequest.endTime
+        location = updateSeminarRequest.location
+        host = updateSeminarRequest.host
+        additionalNote = updateSeminarRequest.additionalNote
+        isPublic = updateSeminarRequest.isPublic
+        isSlide = updateSeminarRequest.isSlide
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarRepository.kt
@@ -1,0 +1,65 @@
+package com.wafflestudio.csereal.core.seminar.database
+
+import com.querydsl.core.BooleanBuilder
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.wafflestudio.csereal.common.CserealException
+import com.wafflestudio.csereal.core.seminar.database.QSeminarEntity.seminarEntity
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Component
+
+interface SeminarRepository : JpaRepository<SeminarEntity, Long>, CustomSeminarRepository {
+}
+
+interface CustomSeminarRepository {
+    fun findPrevNextId(seminarId: Long, keyword: String?): Array<SeminarEntity?>?
+}
+
+@Component
+class SeminarRepositoryImpl(
+    private val queryFactory: JPAQueryFactory,
+) : CustomSeminarRepository {
+    override fun findPrevNextId(seminarId: Long, keyword: String?): Array<SeminarEntity?>? {
+        val keywordBooleanBuilder = BooleanBuilder()
+
+        if (!keyword.isNullOrEmpty()) {
+            val keywordList = keyword.split("[^a-zA-Z0-9가-힣]".toRegex())
+            keywordList.forEach {
+                if (it.length == 1) {
+                    throw CserealException.Csereal400("각각의 키워드는 한글자 이상이어야 합니다.")
+                } else {
+                    keywordBooleanBuilder.and(
+                        seminarEntity.title.contains(it)
+                            .or(seminarEntity.description.contains(it))
+                    )
+                }
+            }
+        }
+        val seminarSearchDtoList = queryFactory.select(seminarEntity).from(seminarEntity)
+            .where(seminarEntity.isDeleted.eq(false), seminarEntity.isPublic.eq(true))
+            .where(keywordBooleanBuilder)
+            .orderBy(seminarEntity.createdAt.desc())
+            .distinct()
+            .fetch()
+
+        val findingId = seminarSearchDtoList.indexOfFirst { it.id == seminarId }
+
+        val prevNext: Array<SeminarEntity?>?
+
+        if (findingId == -1) {
+            return null
+        } else if (findingId != 0 && findingId != seminarSearchDtoList.size - 1) {
+            prevNext = arrayOf(seminarSearchDtoList[findingId + 1], seminarSearchDtoList[findingId - 1])
+        } else if (findingId == 0) {
+            if (seminarSearchDtoList.size == 1) {
+                prevNext = arrayOf(null, null)
+            } else {
+                prevNext = arrayOf(seminarSearchDtoList[1], null)
+            }
+        } else {
+            prevNext = arrayOf(null, seminarSearchDtoList[seminarSearchDtoList.size - 2])
+        }
+
+        return prevNext
+
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarRepository.kt
@@ -4,6 +4,8 @@ import com.querydsl.core.BooleanBuilder
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.wafflestudio.csereal.common.CserealException
 import com.wafflestudio.csereal.core.seminar.database.QSeminarEntity.seminarEntity
+import com.wafflestudio.csereal.core.seminar.dto.SeminarSearchDto
+import com.wafflestudio.csereal.core.seminar.dto.SeminarSearchResponse
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Component
 
@@ -11,6 +13,7 @@ interface SeminarRepository : JpaRepository<SeminarEntity, Long>, CustomSeminarR
 }
 
 interface CustomSeminarRepository {
+    fun searchSeminar(keyword: String?, pageNum: Long): SeminarSearchResponse
     fun findPrevNextId(seminarId: Long, keyword: String?): Array<SeminarEntity?>?
 }
 
@@ -18,6 +21,62 @@ interface CustomSeminarRepository {
 class SeminarRepositoryImpl(
     private val queryFactory: JPAQueryFactory,
 ) : CustomSeminarRepository {
+    override fun searchSeminar(keyword: String?, pageNum: Long): SeminarSearchResponse {
+        val keywordBooleanBuilder = BooleanBuilder()
+
+        if (!keyword.isNullOrEmpty()) {
+            val keywordList = keyword.split("[^a-zA-Z0-9가-힣]".toRegex())
+            keywordList.forEach {
+                if (it.length == 1) {
+                    throw CserealException.Csereal400("각각의 키워드는 한글자 이상이어야 합니다.")
+                } else {
+                    keywordBooleanBuilder.and(
+                        seminarEntity.title.contains(it)
+                            .or(seminarEntity.name.contains(it))
+                            .or(seminarEntity.affiliation.contains(it))
+                            .or(seminarEntity.location.contains(it))
+                    )
+                }
+            }
+        }
+
+        val jpaQuery = queryFactory.select(seminarEntity).from(seminarEntity)
+            .where(seminarEntity.isDeleted.eq(false))
+            .where(keywordBooleanBuilder)
+
+        val total = jpaQuery.distinct().fetch().size
+
+        val seminarEntityList = jpaQuery.orderBy(seminarEntity.createdAt.desc())
+            .offset(10*pageNum)
+            .limit(20)
+            .distinct()
+            .fetch()
+
+        val seminarSearchDtoList : MutableList<SeminarSearchDto> = mutableListOf()
+
+        for(i: Int in 0 until seminarEntityList.size) {
+            var isYearLast = false
+            if(i == seminarEntityList.size-1) {
+                isYearLast = true
+            } else if(seminarEntityList[i].startDate?.substring(0,4) != seminarEntityList[i+1].startDate?.substring(0,4)) {
+                isYearLast = true
+            }
+
+            seminarSearchDtoList.add(
+                SeminarSearchDto(
+                    id = seminarEntityList[i].id,
+                    title = seminarEntityList[i].title,
+                    startDate = seminarEntityList[i].startDate,
+                    isYearLast = isYearLast,
+                    name = seminarEntityList[i].name,
+                    affiliation = seminarEntityList[i].affiliation,
+                    location = seminarEntityList[i].location
+                )
+            )
+        }
+
+        return SeminarSearchResponse(total, seminarSearchDtoList)
+    }
     override fun findPrevNextId(seminarId: Long, keyword: String?): Array<SeminarEntity?>? {
         val keywordBooleanBuilder = BooleanBuilder()
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/dto/SeminarDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/dto/SeminarDto.kt
@@ -1,0 +1,64 @@
+package com.wafflestudio.csereal.core.seminar.dto
+
+import com.wafflestudio.csereal.core.seminar.database.SeminarEntity
+
+data class SeminarDto(
+    val id: Long,
+    val title: String,
+    val description: String,
+    val introduction: String,
+    val category: String,
+    val name: String,
+    val speakerUrl: String?,
+    val speakerTitle: String?,
+    val affiliation: String,
+    val affiliationUrl: String?,
+    val startDate: String?,
+    val startTime: String?,
+    val endDate: String?,
+    val endTime: String?,
+    val location: String,
+    val host: String?,
+    // val profileImage: File,
+    // val seminarFile: File,
+    val additionalNote: String?,
+    val isPublic: Boolean,
+    val isSlide: Boolean,
+    val prevId: Long?,
+    val prevTitle: String?,
+    val nextId: Long?,
+    val nextTitle: String?
+) {
+
+    companion object {
+        fun of(entity: SeminarEntity, prevNext: Array<SeminarEntity?>?): SeminarDto = entity.run {
+            SeminarDto(
+                id = this.id,
+                title = this.title,
+                description = this.description,
+                introduction = this.introduction,
+                category = this.category,
+                name = this.name,
+                speakerUrl = this.speakerUrl,
+                speakerTitle = this.speakerTitle,
+                affiliation = this.affiliation,
+                affiliationUrl = this.affiliationUrl,
+                startDate = this.startDate,
+                startTime = this.startTime,
+                endDate = this.endDate,
+                endTime = this.endTime,
+                location = this.location,
+                host = this.host,
+                additionalNote = this.additionalNote,
+                isPublic = this.isPublic,
+                isSlide = this.isSlide,
+                prevId = prevNext?.get(0)?.id,
+                prevTitle = prevNext?.get(0)?.title,
+                nextId = prevNext?.get(1)?.id,
+                nextTitle = prevNext?.get(1)?.title
+            )
+        }
+
+    }
+
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/dto/SeminarSearchDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/dto/SeminarSearchDto.kt
@@ -1,0 +1,14 @@
+package com.wafflestudio.csereal.core.seminar.dto
+
+import com.querydsl.core.annotations.QueryProjection
+
+data class SeminarSearchDto @QueryProjection constructor(
+    val id: Long,
+    val title: String,
+    val startDate: String?,
+    val isYearLast: Boolean,
+    val name: String,
+    val affiliation: String?,
+    val location: String
+) {
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/dto/SeminarSearchResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/dto/SeminarSearchResponse.kt
@@ -1,0 +1,7 @@
+package com.wafflestudio.csereal.core.seminar.dto
+
+data class SeminarSearchResponse(
+    val total: Int,
+    val searchList: List<SeminarSearchDto>
+) {
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/service/SeminarService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/service/SeminarService.kt
@@ -1,0 +1,53 @@
+package com.wafflestudio.csereal.core.seminar.service
+
+import com.wafflestudio.csereal.common.CserealException
+import com.wafflestudio.csereal.core.seminar.database.SeminarEntity
+import com.wafflestudio.csereal.core.seminar.database.SeminarRepository
+import com.wafflestudio.csereal.core.seminar.dto.SeminarDto
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+interface SeminarService {
+    fun createSeminar(request: SeminarDto): SeminarDto
+    fun readSeminar(seminarId: Long, keyword: String?): SeminarDto
+    fun updateSeminar(seminarId: Long, request: SeminarDto): SeminarDto
+}
+
+@Service
+class SeminarServiceImpl(
+    private val seminarRepository: SeminarRepository
+) : SeminarService {
+
+    @Transactional
+    override fun createSeminar(request: SeminarDto): SeminarDto {
+        val newSeminar = SeminarEntity.of(request)
+
+        seminarRepository.save(newSeminar)
+
+        return SeminarDto.of(newSeminar, null)
+    }
+
+    @Transactional(readOnly = true)
+    override fun readSeminar(seminarId: Long, keyword: String?): SeminarDto {
+        val seminar: SeminarEntity = seminarRepository.findByIdOrNull(seminarId)
+            ?: throw CserealException.Csereal404("존재하지 않는 세미나입니다.(seminarId: $seminarId)")
+
+        if (seminar.isDeleted) throw CserealException.Csereal400("삭제된 세미나입니다. (seminarId: $seminarId)")
+
+        val prevNext = seminarRepository.findPrevNextId(seminarId, keyword)
+
+        return SeminarDto.of(seminar, prevNext)
+    }
+
+    @Transactional
+    override fun updateSeminar(seminarId: Long, request: SeminarDto): SeminarDto {
+        val seminar: SeminarEntity = seminarRepository.findByIdOrNull(seminarId)
+            ?: throw CserealException.Csereal404("존재하지 않는 세미나입니다")
+        if(seminar.isDeleted) throw CserealException.Csereal404("삭제된 세미나입니다. (seminarId: $seminarId)")
+
+        seminar.update(request)
+
+        return SeminarDto.of(seminar, null)
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/service/SeminarService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/service/SeminarService.kt
@@ -4,20 +4,27 @@ import com.wafflestudio.csereal.common.CserealException
 import com.wafflestudio.csereal.core.seminar.database.SeminarEntity
 import com.wafflestudio.csereal.core.seminar.database.SeminarRepository
 import com.wafflestudio.csereal.core.seminar.dto.SeminarDto
+import com.wafflestudio.csereal.core.seminar.dto.SeminarSearchResponse
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 interface SeminarService {
+    fun searchSeminar(keyword: String?, pageNum: Long): SeminarSearchResponse
     fun createSeminar(request: SeminarDto): SeminarDto
     fun readSeminar(seminarId: Long, keyword: String?): SeminarDto
     fun updateSeminar(seminarId: Long, request: SeminarDto): SeminarDto
+    fun deleteSeminar(seminarId: Long)
 }
 
 @Service
 class SeminarServiceImpl(
     private val seminarRepository: SeminarRepository
 ) : SeminarService {
+    @Transactional(readOnly = true)
+    override fun searchSeminar(keyword: String?, pageNum: Long): SeminarSearchResponse {
+        return seminarRepository.searchSeminar(keyword, pageNum)
+    }
 
     @Transactional
     override fun createSeminar(request: SeminarDto): SeminarDto {
@@ -49,5 +56,12 @@ class SeminarServiceImpl(
         seminar.update(request)
 
         return SeminarDto.of(seminar, null)
+    }
+    @Transactional
+    override fun deleteSeminar(seminarId: Long) {
+        val seminar: SeminarEntity = seminarRepository.findByIdOrNull(seminarId)
+            ?: throw CserealException.Csereal404("존재하지 않는 세미나입니다.(seminarId=$seminarId")
+
+        seminar.isDeleted = true
     }
 }


### PR DESCRIPTION
## 제목
seminar 패키지 추가

### 한줄 요약
세미나의 crud+검색 만들었습니다

### 상세 설명

[54ad2ff]: createSeminar, readSeminar, updateSeminar을 만들었습니다. 세미나의 항목들이 다양해서 새로운 칼럼을 많이 추가했습니다. 크게 다른 건 없습니다.

[53a5674]: deleteSeminar, searchSeminar을 만들었습니다. 세미나를 한번에 검색할 때 연도별 마지막 게시글에는 true라는 값을 보내주면 좋겠다고 해서(프론트의 컴포넌트를 적용하려고 한다고 알고있습니다) isYearLast라는 칼럼을 추가했습니다.

### TODO
notice, news, seminar에서 사진과 파일 추가가 가능하게 하려고 합니다
TODO가 있다면 작성해주시고, 없다면 생략해주세요.
`Commit Hash2`