### PR TITLE
[Hotfix] Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ COPY ./build/libs/*.jar /app/app.jar
 
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=$PROFILE", "app.jar"]
+ENTRYPOINT java -Dspring.profiles.active=$PROFILE -jar app.jar


### PR DESCRIPTION
## 제목

Dockerfile에서 $Profile이 environment variable로 대체되지 않고 그대로 string으로 들어가는 문제가 있어, 배포되었을 시 제대로 profiile 적용이 되지 않는 현상이 있었습니다.

### 상세 설명

4bfadc27d8185c87c106b45e5cd6694c57497004: Entrypoint를 String list가 아닌 하나의 string으로 하여 variable의 대체가 잘 일어나도록 하였습니다.
