### PR TITLE
fix: about, academics, admissions 패키지 수정

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/api/AboutController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/api/AboutController.kt
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RequestMapping("/about")
@@ -24,11 +25,12 @@ class AboutController(
     // postType: directions / name -> by-public-transit, by-car, from-far-away
 
     // Todo: 전체 image, file, 학부장 인사말(greetings) signature
-    @PostMapping
+    @PostMapping("/{postType}")
     fun createAbout(
+        @PathVariable postType: String,
         @Valid @RequestBody request: AboutDto
     ) : ResponseEntity<AboutDto> {
-        return ResponseEntity.ok(aboutService.createAbout(request))
+        return ResponseEntity.ok(aboutService.createAbout(postType, request))
     }
 
     // read 목록이 하나

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/api/AboutController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/api/AboutController.kt
@@ -17,9 +17,6 @@ import org.springframework.web.bind.annotation.RestController
 class AboutController(
     private val aboutService: AboutService
 ) {
-    // postType -> 학부 소개: overview, 연혁: history, 졸업생 진로: future-careers, 연락처: contact
-    // 위에 있는 항목은 name = null
-
     // postType: student-clubs / name -> 가디언, 바쿠스, 사커301, 슈타인, 스눕스, 와플스튜디오, 유피넬
     // postType: facilities / name -> 학부-행정실, S-Lab, 소프트웨어-실습실, 하드웨어-실습실, 해동학술정보실, 학생-공간-및-동아리-방, 세미나실, 서버실
     // postType: directions / name -> by-public-transit, by-car, from-far-away

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/database/AboutEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/database/AboutEntity.kt
@@ -2,36 +2,28 @@ package com.wafflestudio.csereal.core.about.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
 import com.wafflestudio.csereal.core.about.dto.AboutDto
-import jakarta.persistence.CascadeType
-import jakarta.persistence.Entity
-import jakarta.persistence.OneToMany
+import jakarta.persistence.*
 
 @Entity(name = "about")
 class AboutEntity(
-    var postType: String,
-
+    @Enumerated(EnumType.STRING)
+    var postType: AboutPostType,
     var name: String,
-
     var engName: String?,
-
     var description: String,
-
     var year: Int?,
-
-    var isPublic: Boolean,
 
     @OneToMany(mappedBy = "about", cascade = [CascadeType.ALL], orphanRemoval = true)
     val locations: MutableList<LocationEntity> = mutableListOf()
 ) : BaseTimeEntity() {
     companion object {
-        fun of(aboutDto: AboutDto): AboutEntity {
+        fun of(postType: AboutPostType, aboutDto: AboutDto): AboutEntity {
             return AboutEntity(
-                postType = aboutDto.postType,
+                postType = postType,
                 name = aboutDto.name,
                 engName = aboutDto.engName,
                 description = aboutDto.description,
                 year = aboutDto.year,
-                isPublic = aboutDto.isPublic,
             )
         }
     }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/database/AboutEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/database/AboutEntity.kt
@@ -8,7 +8,7 @@ import jakarta.persistence.*
 class AboutEntity(
     @Enumerated(EnumType.STRING)
     var postType: AboutPostType,
-    var name: String,
+    var name: String?,
     var engName: String?,
     var description: String,
     var year: Int?,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/database/AboutPostType.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/database/AboutPostType.kt
@@ -1,0 +1,5 @@
+package com.wafflestudio.csereal.core.about.database
+
+enum class AboutPostType {
+    OVERVIEW, HISTORY, FUTURE_CAREERS, CONTACT, STUDENT_CLUBS, FACILITIES, DIRECTIONS,
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/database/AboutRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/database/AboutRepository.kt
@@ -3,6 +3,6 @@ package com.wafflestudio.csereal.core.about.database
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface AboutRepository : JpaRepository<AboutEntity, Long> {
-    fun findAllByPostTypeOrderByName(postType: String): List<AboutEntity>
-    fun findByPostType(postType: String): AboutEntity
+    fun findAllByPostTypeOrderByName(postType: AboutPostType): List<AboutEntity>
+    fun findByPostType(postType: AboutPostType): AboutEntity
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/AboutDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/AboutDto.kt
@@ -6,28 +6,24 @@ import java.time.LocalDateTime
 
 data class AboutDto(
     val id: Long,
-    val postType: String,
     val name: String,
     val engName: String?,
     val description: String,
     val year: Int?,
     val createdAt: LocalDateTime?,
     val modifiedAt: LocalDateTime?,
-    val isPublic: Boolean,
     val locations: List<String>?
 ) {
     companion object {
         fun of(entity: AboutEntity) : AboutDto = entity.run {
             AboutDto(
                 id = this.id,
-                postType = this.postType,
                 name = this.name,
                 engName = this.engName,
                 description = this.description,
                 year = this.year,
                 createdAt = this.createdAt,
                 modifiedAt = this.modifiedAt,
-                isPublic = this.isPublic,
                 locations = this.locations.map { it.name }
             )
         }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/AboutDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/AboutDto.kt
@@ -6,7 +6,7 @@ import java.time.LocalDateTime
 
 data class AboutDto(
     val id: Long,
-    val name: String,
+    val name: String?,
     val engName: String?,
     val description: String,
     val year: Int?,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/service/AboutService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/service/AboutService.kt
@@ -31,6 +31,7 @@ class AboutServiceImpl(
         AboutPostType.FACILITIES,
         AboutPostType.DIRECTIONS
     )
+
     @Transactional
     override fun createAbout(postType: String, request: AboutDto): AboutDto {
         if(!stringPostTypes.contains(postType)) {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/api/AcademicsController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/api/AcademicsController.kt
@@ -1,6 +1,5 @@
 package com.wafflestudio.csereal.core.academics.api
 
-import com.wafflestudio.csereal.core.academics.database.StudentType
 import com.wafflestudio.csereal.core.academics.dto.CourseDto
 import com.wafflestudio.csereal.core.academics.dto.AcademicsDto
 import com.wafflestudio.csereal.core.academics.service.AcademicsService
@@ -11,6 +10,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RequestMapping("/academics")
@@ -19,30 +19,28 @@ class AcademicsController(
     private val academicsService: AcademicsService
 ) {
 
-    // postType -> 학부 안내: guide, 필수 교양 과목: general-studies-requirements,
-    // 전공 이수 표준 형태: curriculum, 졸업 규청: degree-requirements,
-    // 교과목 변경 내역: course-changes, 장학제도: scholarship
     //Todo: 이미지, 파일 추가 필요
     @PostMapping("/{studentType}")
     fun createAcademics(
-        @PathVariable studentType: StudentType,
+        @PathVariable studentType: String,
+        @RequestParam postType: String,
         @Valid @RequestBody request: AcademicsDto
     ) : ResponseEntity<AcademicsDto> {
-        return ResponseEntity.ok(academicsService.createAcademics(studentType, request))
+        return ResponseEntity.ok(academicsService.createAcademics(studentType, postType, request))
     }
 
-    @GetMapping("/{studentType}/{postType}")
+    @GetMapping("/{studentType}")
     fun readAcademics(
-        @PathVariable studentType: StudentType,
-        @PathVariable postType: String,
+        @PathVariable studentType: String,
+        @RequestParam postType: String,
     ): ResponseEntity<AcademicsDto> {
         return ResponseEntity.ok(academicsService.readAcademics(studentType, postType))
     }
 
-    //교과목 정보: courses
+    //교과목 정보
     @PostMapping("/{studentType}/course")
     fun createCourse(
-        @PathVariable studentType: StudentType,
+        @PathVariable studentType: String,
         @Valid @RequestBody request: CourseDto
     ) : ResponseEntity<CourseDto> {
         return ResponseEntity.ok(academicsService.createCourse(studentType, request))
@@ -50,14 +48,14 @@ class AcademicsController(
 
     @GetMapping("/{studentType}/courses")
     fun readAllCourses(
-        @PathVariable studentType: StudentType,
+        @PathVariable studentType: String,
     ) : ResponseEntity<List<CourseDto>> {
         return ResponseEntity.ok(academicsService.readAllCourses(studentType))
     }
 
-    @GetMapping("/course/{name}")
+    @GetMapping("/course")
     fun readCourse(
-        @PathVariable name: String
+        @RequestParam name: String
     ): ResponseEntity<CourseDto> {
         return ResponseEntity.ok(academicsService.readCourse(name))
     }
@@ -65,15 +63,15 @@ class AcademicsController(
     // 장학금
     @PostMapping("/{studentType}/scholarship")
     fun createScholarship(
-        @PathVariable studentType: StudentType,
+        @PathVariable studentType: String,
         @Valid @RequestBody request: AcademicsDto
     ) : ResponseEntity<AcademicsDto> {
-        return ResponseEntity.ok(academicsService.createAcademics(studentType, request))
+        return ResponseEntity.ok(academicsService.createAcademics(studentType, "scholarship", request))
     }
 
-    @GetMapping("/scholarship/{name}")
+    @GetMapping("/scholarship")
     fun readScholarship(
-        @PathVariable name: String
+        @RequestParam name: String
     ) : ResponseEntity<AcademicsDto> {
         return ResponseEntity.ok(academicsService.readScholarship(name))
     }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/api/AcademicsController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/api/AcademicsController.kt
@@ -20,19 +20,19 @@ class AcademicsController(
 ) {
 
     //Todo: 이미지, 파일 추가 필요
-    @PostMapping("/{studentType}")
+    @PostMapping("/{studentType}/{postType}")
     fun createAcademics(
         @PathVariable studentType: String,
-        @RequestParam postType: String,
+        @PathVariable postType: String,
         @Valid @RequestBody request: AcademicsDto
     ) : ResponseEntity<AcademicsDto> {
         return ResponseEntity.ok(academicsService.createAcademics(studentType, postType, request))
     }
 
-    @GetMapping("/{studentType}")
+    @GetMapping("/{studentType}/{postType}")
     fun readAcademics(
         @PathVariable studentType: String,
-        @RequestParam postType: String,
+        @PathVariable postType: String,
     ): ResponseEntity<AcademicsDto> {
         return ResponseEntity.ok(academicsService.readAcademics(studentType, postType))
     }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsEntity.kt
@@ -8,25 +8,22 @@ import jakarta.persistence.Enumerated
 
 @Entity(name = "academics")
 class AcademicsEntity(
-    @Enumerated(EnumType.STRING)
-    var studentType: StudentType,
+    var studentType: String,
 
-    var postType: String,
+    @Enumerated(EnumType.STRING)
+    var postType: AcademicsPostType,
 
     var name: String,
-
     var description: String,
-
     var year: Int?,
-
     var isPublic: Boolean,
 
 ): BaseTimeEntity() {
     companion object {
-        fun of(studentType: StudentType, academicsDto: AcademicsDto): AcademicsEntity {
+        fun of(studentType: String, postType: AcademicsPostType, academicsDto: AcademicsDto): AcademicsEntity {
             return AcademicsEntity(
                 studentType = studentType,
-                postType = academicsDto.postType,
+                postType = postType,
                 name = academicsDto.name,
                 description = academicsDto.description,
                 year = academicsDto.year,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsEntity.kt
@@ -8,7 +8,8 @@ import jakarta.persistence.Enumerated
 
 @Entity(name = "academics")
 class AcademicsEntity(
-    var studentType: String,
+    @Enumerated(EnumType.STRING)
+    var studentType: AcademicsStudentType,
 
     @Enumerated(EnumType.STRING)
     var postType: AcademicsPostType,
@@ -20,7 +21,7 @@ class AcademicsEntity(
 
 ): BaseTimeEntity() {
     companion object {
-        fun of(studentType: String, postType: AcademicsPostType, academicsDto: AcademicsDto): AcademicsEntity {
+        fun of(studentType: AcademicsStudentType, postType: AcademicsPostType, academicsDto: AcademicsDto): AcademicsEntity {
             return AcademicsEntity(
                 studentType = studentType,
                 postType = postType,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsPostType.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsPostType.kt
@@ -1,0 +1,5 @@
+package com.wafflestudio.csereal.core.academics.database
+
+enum class AcademicsPostType {
+    GUIDE, GENERAL_STUDIES_REQUIREMENTS, CURRICULUM, DEGREE_REQUIREMENTS, COURSE_CHANGES, SCHOLARSHIP
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsRepository.kt
@@ -3,6 +3,6 @@ package com.wafflestudio.csereal.core.academics.database
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface AcademicsRepository : JpaRepository<AcademicsEntity, Long> {
-    fun findByStudentTypeAndPostType(studentType: StudentType, postType: String) : AcademicsEntity
+    fun findByStudentTypeAndPostType(studentType: String, postType: AcademicsPostType) : AcademicsEntity
     fun findByName(name: String): AcademicsEntity
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsRepository.kt
@@ -3,6 +3,6 @@ package com.wafflestudio.csereal.core.academics.database
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface AcademicsRepository : JpaRepository<AcademicsEntity, Long> {
-    fun findByStudentTypeAndPostType(studentType: String, postType: AcademicsPostType) : AcademicsEntity
+    fun findByStudentTypeAndPostType(studentType: AcademicsStudentType, postType: AcademicsPostType) : AcademicsEntity
     fun findByName(name: String): AcademicsEntity
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsStudentType.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsStudentType.kt
@@ -1,0 +1,5 @@
+package com.wafflestudio.csereal.core.academics.database
+
+enum class AcademicsStudentType {
+    UNDERGRADUATE, GRADUATE
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/CourseEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/CourseEntity.kt
@@ -8,7 +8,7 @@ import jakarta.persistence.Entity
 class CourseEntity(
     var isDeleted: Boolean = false,
 
-    var studentType: StudentType,
+    var studentType: AcademicsStudentType,
 
     var classification: String,
 
@@ -25,7 +25,7 @@ class CourseEntity(
     var description: String?
 ): BaseTimeEntity() {
     companion object {
-        fun of(studentType: StudentType, courseDto: CourseDto): CourseEntity {
+        fun of(studentType: AcademicsStudentType, courseDto: CourseDto): CourseEntity {
             return CourseEntity(
                 studentType = studentType,
                 classification = courseDto.classification,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/CourseRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/CourseRepository.kt
@@ -3,6 +3,6 @@ package com.wafflestudio.csereal.core.academics.database
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface CourseRepository : JpaRepository<CourseEntity, Long> {
-    fun findAllByStudentTypeOrderByYearAsc(studentType: String) : List<CourseEntity>
+    fun findAllByStudentTypeOrderByYearAsc(studentType: AcademicsStudentType) : List<CourseEntity>
     fun findByName(name: String) : CourseEntity
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/CourseRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/CourseRepository.kt
@@ -3,6 +3,6 @@ package com.wafflestudio.csereal.core.academics.database
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface CourseRepository : JpaRepository<CourseEntity, Long> {
-    fun findAllByStudentTypeOrderByYearAsc(studentType: StudentType) : List<CourseEntity>
+    fun findAllByStudentTypeOrderByYearAsc(studentType: String) : List<CourseEntity>
     fun findByName(name: String) : CourseEntity
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/StudentType.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/StudentType.kt
@@ -1,5 +1,0 @@
-package com.wafflestudio.csereal.core.academics.database
-
-enum class StudentType {
-    GRADUATE,UNDERGRADUATE
-}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/dto/AcademicsDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/dto/AcademicsDto.kt
@@ -5,7 +5,6 @@ import java.time.LocalDateTime
 
 data class AcademicsDto(
     val id: Long,
-    val postType: String,
     val name: String,
     val description: String,
     val year: Int?,
@@ -17,7 +16,6 @@ data class AcademicsDto(
         fun of(entity: AcademicsEntity) : AcademicsDto = entity.run {
             AcademicsDto(
                 id = this.id,
-                postType = this.postType,
                 name = this.name,
                 description = this.description,
                 year = this.year,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/admissions/api/AdmissionsController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admissions/api/AdmissionsController.kt
@@ -1,7 +1,5 @@
 package com.wafflestudio.csereal.core.admissions.api
 
-import com.wafflestudio.csereal.core.admissions.database.AdmissionPostType
-import com.wafflestudio.csereal.core.admissions.database.StudentType
 import com.wafflestudio.csereal.core.admissions.dto.AdmissionsDto
 import com.wafflestudio.csereal.core.admissions.service.AdmissionsService
 import jakarta.validation.Valid
@@ -19,26 +17,34 @@ import org.springframework.web.bind.annotation.RestController
 class AdmissionsController(
     private val admissionsService: AdmissionsService
 ) {
-    @PostMapping
-    fun createAdmissions(
-        @RequestParam studentType: StudentType,
+    @PostMapping("/undergraduate")
+    fun createUndergraduateAdmissions(
+        @RequestParam postType: String,
         @Valid @RequestBody request: AdmissionsDto
     ) : AdmissionsDto {
-        return admissionsService.createAdmissions(studentType, request)
+        return admissionsService.createUndergraduateAdmissions(postType, request)
     }
 
-    @GetMapping
-    fun readAdmissionsMain(
-        @RequestParam studentType: StudentType,
-    ) : ResponseEntity<AdmissionsDto> {
-        return ResponseEntity.ok(admissionsService.readAdmissionsMain(studentType))
+    @PostMapping("/graduate")
+    fun createGraduateAdmissions(
+        @Valid @RequestBody request: AdmissionsDto
+    ) : AdmissionsDto {
+        return admissionsService.createGraduateAdmissions(request)
     }
+
     @GetMapping("/undergraduate")
     fun readUndergraduateAdmissions(
-        @RequestParam postType: AdmissionPostType
+        @RequestParam postType: String
     ) : ResponseEntity<AdmissionsDto> {
         return ResponseEntity.ok(admissionsService.readUndergraduateAdmissions(postType))
     }
+
+    @GetMapping("/graduate")
+    fun readGraduateAdmissions() : ResponseEntity<AdmissionsDto> {
+        return ResponseEntity.ok(admissionsService.readGraduateAdmissions())
+    }
+
+
 
 
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/admissions/database/AdmissionPostType.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admissions/database/AdmissionPostType.kt
@@ -1,5 +1,5 @@
 package com.wafflestudio.csereal.core.admissions.database
 
 enum class AdmissionPostType {
-    MAIN, EARLY_ADMISSION, REGULAR_ADMISSION,
+    GRADUATE, UNDERGRADUATE_EARLY_ADMISSION, UNDERGRADUATE_REGULAR_ADMISSION,
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/admissions/database/AdmissionsEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admissions/database/AdmissionsEntity.kt
@@ -9,12 +9,12 @@ import jakarta.persistence.Enumerated
 @Entity(name = "admissions")
 class AdmissionsEntity(
     @Enumerated(EnumType.STRING)
-    val postType: AdmissionPostType,
+    val postType: AdmissionsPostType,
     val title: String,
     val description: String,
 ): BaseTimeEntity() {
     companion object {
-        fun of(postType: AdmissionPostType, admissionsDto: AdmissionsDto) : AdmissionsEntity {
+        fun of(postType: AdmissionsPostType, admissionsDto: AdmissionsDto) : AdmissionsEntity {
             return AdmissionsEntity(
                 postType = postType,
                 title = admissionsDto.title,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/admissions/database/AdmissionsEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admissions/database/AdmissionsEntity.kt
@@ -9,21 +9,16 @@ import jakarta.persistence.Enumerated
 @Entity(name = "admissions")
 class AdmissionsEntity(
     @Enumerated(EnumType.STRING)
-    var studentType: StudentType,
-    @Enumerated(EnumType.STRING)
     val postType: AdmissionPostType,
     val title: String,
     val description: String,
-    val isPublic: Boolean,
 ): BaseTimeEntity() {
     companion object {
-        fun of(studentType: StudentType, admissionsDto: AdmissionsDto) : AdmissionsEntity {
+        fun of(postType: AdmissionPostType, admissionsDto: AdmissionsDto) : AdmissionsEntity {
             return AdmissionsEntity(
-                studentType = studentType,
-                postType = admissionsDto.postType,
+                postType = postType,
                 title = admissionsDto.title,
                 description = admissionsDto.description,
-                isPublic = admissionsDto.isPublic
             )
         }
     }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/admissions/database/AdmissionsPostType.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admissions/database/AdmissionsPostType.kt
@@ -1,5 +1,5 @@
 package com.wafflestudio.csereal.core.admissions.database
 
-enum class AdmissionPostType {
+enum class AdmissionsPostType {
     GRADUATE, UNDERGRADUATE_EARLY_ADMISSION, UNDERGRADUATE_REGULAR_ADMISSION,
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/admissions/database/AdmissionsRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admissions/database/AdmissionsRepository.kt
@@ -3,6 +3,5 @@ package com.wafflestudio.csereal.core.admissions.database
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface AdmissionsRepository : JpaRepository<AdmissionsEntity, Long> {
-    fun findByStudentTypeAndPostType(studentType: StudentType, postType: AdmissionPostType): AdmissionsEntity
     fun findByPostType(postType: AdmissionPostType) : AdmissionsEntity
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/admissions/database/AdmissionsRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admissions/database/AdmissionsRepository.kt
@@ -3,5 +3,5 @@ package com.wafflestudio.csereal.core.admissions.database
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface AdmissionsRepository : JpaRepository<AdmissionsEntity, Long> {
-    fun findByPostType(postType: AdmissionPostType) : AdmissionsEntity
+    fun findByPostType(postType: AdmissionsPostType) : AdmissionsEntity
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/admissions/database/StudentType.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admissions/database/StudentType.kt
@@ -1,5 +1,0 @@
-package com.wafflestudio.csereal.core.admissions.database
-
-enum class StudentType {
-    GRADUATE, UNDERGRADUATE
-}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/admissions/dto/AdmissionsDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admissions/dto/AdmissionsDto.kt
@@ -1,6 +1,5 @@
 package com.wafflestudio.csereal.core.admissions.dto
 
-import com.wafflestudio.csereal.core.admissions.database.AdmissionPostType
 import com.wafflestudio.csereal.core.admissions.database.AdmissionsEntity
 import java.time.LocalDateTime
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/admissions/dto/AdmissionsDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admissions/dto/AdmissionsDto.kt
@@ -6,23 +6,19 @@ import java.time.LocalDateTime
 
 data class AdmissionsDto(
     val id: Long,
-    val postType: AdmissionPostType,
     val title: String,
     val description: String,
     val createdAt: LocalDateTime?,
     val modifiedAt: LocalDateTime?,
-    val isPublic: Boolean,
 ) {
     companion object {
         fun of(entity: AdmissionsEntity) : AdmissionsDto = entity.run {
             AdmissionsDto(
                 id = this.id,
-                postType = this.postType,
                 title = this.title,
                 description = this.description,
                 createdAt = this.createdAt,
                 modifiedAt = this.modifiedAt,
-                isPublic = this.isPublic
             )
         }
     }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/admissions/service/AdmissionsService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admissions/service/AdmissionsService.kt
@@ -20,10 +20,11 @@ interface AdmissionsService {
 class AdmissionsServiceImpl(
     private val admissionsRepository: AdmissionsRepository
 ) : AdmissionsService {
+    val stringPostTypes = listOf("early", "regular")
+    val enumPostTypes = listOf(AdmissionPostType.UNDERGRADUATE_EARLY_ADMISSION, AdmissionPostType.UNDERGRADUATE_REGULAR_ADMISSION)
+
     @Transactional
     override fun createUndergraduateAdmissions(postType: String, request: AdmissionsDto): AdmissionsDto {
-        val stringPostTypes = listOf("early", "regular")
-        val enumPostTypes = listOf(AdmissionPostType.UNDERGRADUATE_EARLY_ADMISSION, AdmissionPostType.UNDERGRADUATE_REGULAR_ADMISSION)
 
         if(!stringPostTypes.contains(postType)) {
             throw CserealException.Csereal404("해당하는 내용을 전송할 수 없습니다.")

--- a/src/main/kotlin/com/wafflestudio/csereal/core/admissions/service/AdmissionsService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admissions/service/AdmissionsService.kt
@@ -25,7 +25,6 @@ class AdmissionsServiceImpl(
 
     @Transactional
     override fun createUndergraduateAdmissions(postType: String, request: AdmissionsDto): AdmissionsDto {
-
         if(!stringPostTypes.contains(postType)) {
             throw CserealException.Csereal404("해당하는 내용을 전송할 수 없습니다.")
         }
@@ -60,7 +59,6 @@ class AdmissionsServiceImpl(
     @Transactional(readOnly = true)
     override fun readGraduateAdmissions(): AdmissionsDto {
         return AdmissionsDto.of(admissionsRepository.findByPostType(AdmissionPostType.GRADUATE))
-
     }
 
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/api/MainController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/api/MainController.kt
@@ -1,0 +1,18 @@
+package com.wafflestudio.csereal.core.main.api
+
+import com.wafflestudio.csereal.core.main.dto.MainResponse
+import com.wafflestudio.csereal.core.main.service.MainService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RequestMapping
+@RestController
+class MainController(
+    private val mainService: MainService,
+) {
+    @GetMapping
+    fun readMain() : MainResponse {
+        return mainService.readMain()
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/database/MainRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/database/MainRepository.kt
@@ -1,0 +1,77 @@
+package com.wafflestudio.csereal.core.main.database
+
+import com.querydsl.core.QueryFactory
+import com.querydsl.core.types.Projections
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.sun.tools.javac.Main
+import com.wafflestudio.csereal.core.main.dto.MainResponse
+import com.wafflestudio.csereal.core.main.dto.NewsResponse
+import com.wafflestudio.csereal.core.main.dto.NoticeResponse
+import com.wafflestudio.csereal.core.news.database.QNewsEntity.newsEntity
+import com.wafflestudio.csereal.core.notice.database.QNoticeEntity.noticeEntity
+import com.wafflestudio.csereal.core.notice.database.QNoticeTagEntity.noticeTagEntity
+import com.wafflestudio.csereal.core.notice.database.QTagInNoticeEntity.tagInNoticeEntity
+
+import org.springframework.stereotype.Component
+
+interface MainRepository : CustomMainRepository {
+}
+
+interface CustomMainRepository {
+    fun readMain(): MainResponse
+}
+
+@Component
+class MainRepositoryImpl(
+    private val queryFactory: JPAQueryFactory,
+) : CustomMainRepository {
+    override fun readMain(): MainResponse {
+        val slideList = queryFactory.select(
+            Projections.constructor(
+                NewsResponse::class.java,
+                newsEntity.id,
+                newsEntity.title,
+                newsEntity.createdAt
+            )
+        ).from(newsEntity)
+            .where(newsEntity.isDeleted.eq(false), newsEntity.isPublic.eq(true), newsEntity.isSlide.eq(true))
+            .orderBy(newsEntity.isPinned.desc()).orderBy(newsEntity.createdAt.desc())
+            .limit(10).fetch()
+
+        val noticeTotalList = queryFactory.select(
+            Projections.constructor(
+                NoticeResponse::class.java,
+                noticeEntity.id,
+                noticeEntity.title,
+                noticeEntity.createdAt
+            )
+        ).from(noticeEntity)
+            .where(noticeEntity.isDeleted.eq(false), noticeEntity.isPublic.eq(true))
+            .orderBy(noticeEntity.isPinned.desc()).orderBy(noticeEntity.createdAt.desc())
+            .limit(5).fetch()
+
+        val noticeAdmissionsList = makeNoticeEntityTagList("admissions")
+        val noticeUndergraduateList = makeNoticeEntityTagList("undergraduate")
+        val noticeGraduateList = makeNoticeEntityTagList("graduate")
+
+        return MainResponse(slideList, noticeTotalList, noticeAdmissionsList, noticeUndergraduateList, noticeGraduateList)
+    }
+
+    private fun makeNoticeEntityTagList(tag: String) : List<NoticeResponse> {
+        return queryFactory.select(
+            Projections.constructor(
+                NoticeResponse::class.java,
+                noticeTagEntity.notice.id,
+                noticeTagEntity.notice.title,
+                noticeTagEntity.notice.createdAt,
+            )
+        ).from(noticeTagEntity)
+            .rightJoin(noticeEntity).on(noticeTagEntity.notice.eq(noticeEntity))
+            .rightJoin(tagInNoticeEntity).on(noticeTagEntity.tag.eq(tagInNoticeEntity))
+            .where(noticeTagEntity.tag.name.eq(tag))
+            .where(noticeEntity.isDeleted.eq(false), noticeEntity.isPublic.eq(true))
+            .orderBy(noticeEntity.isPinned.desc()).orderBy(noticeEntity.createdAt.desc())
+            .limit(5).distinct().fetch()
+
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/dto/MainResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/dto/MainResponse.kt
@@ -1,0 +1,11 @@
+package com.wafflestudio.csereal.core.main.dto
+
+data class MainResponse(
+    val slide: List<NewsResponse>,
+    val noticeTotal: List<NoticeResponse>,
+    val noticeAdmissions: List<NoticeResponse>,
+    val noticeUndergraduate: List<NoticeResponse>,
+    val noticeGraduate: List<NoticeResponse>
+) {
+
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/dto/NewsResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/dto/NewsResponse.kt
@@ -1,0 +1,12 @@
+package com.wafflestudio.csereal.core.main.dto
+
+import com.querydsl.core.annotations.QueryProjection
+import java.time.LocalDateTime
+
+data class NewsResponse @QueryProjection constructor(
+    val id: Long,
+    val title: String,
+    val createdAt: LocalDateTime?
+) {
+
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/dto/NoticeResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/dto/NoticeResponse.kt
@@ -1,0 +1,11 @@
+package com.wafflestudio.csereal.core.main.dto
+
+import com.querydsl.core.annotations.QueryProjection
+import java.time.LocalDateTime
+
+data class NoticeResponse @QueryProjection constructor(
+    val id: Long,
+    val title: String,
+    val createdAt: LocalDateTime?,
+){
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/service/MainService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/service/MainService.kt
@@ -1,6 +1,5 @@
 package com.wafflestudio.csereal.core.main.service
 
-import com.wafflestudio.csereal.core.main.database.CustomMainRepository
 import com.wafflestudio.csereal.core.main.database.MainRepository
 import com.wafflestudio.csereal.core.main.dto.MainResponse
 import org.springframework.stereotype.Service
@@ -12,10 +11,15 @@ interface MainService {
 
 @Service
 class MainServiceImpl(
-    private val mainRepository: CustomMainRepository
+    private val mainRepository: MainRepository
 ) : MainService {
-    @Transactional
+    @Transactional(readOnly = true)
     override fun readMain(): MainResponse {
-        return mainRepository.readMain()
+        val slide = mainRepository.readMainSlide()
+        val noticeTotal = mainRepository.readMainNoticeTotal()
+        val noticeAdmissions = mainRepository.readMainNoticeTag("admissions")
+        val noticeUndergraduate = mainRepository.readMainNoticeTag("undergraduate")
+        val noticeGraduate = mainRepository.readMainNoticeTag("graduate")
+        return MainResponse(slide, noticeTotal, noticeAdmissions, noticeUndergraduate, noticeGraduate)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/service/MainService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/service/MainService.kt
@@ -1,0 +1,21 @@
+package com.wafflestudio.csereal.core.main.service
+
+import com.wafflestudio.csereal.core.main.database.CustomMainRepository
+import com.wafflestudio.csereal.core.main.database.MainRepository
+import com.wafflestudio.csereal.core.main.dto.MainResponse
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+interface MainService {
+    fun readMain() : MainResponse
+}
+
+@Service
+class MainServiceImpl(
+    private val mainRepository: CustomMainRepository
+) : MainService {
+    @Transactional
+    override fun readMain(): MainResponse {
+        return mainRepository.readMain()
+    }
+}


### PR DESCRIPTION
## 제목
fix: about, academics, admissions 패키지 수정

### 한줄 요약
세 패키지에서 api 주소를 바꾸고, 각각의 패키지에 postType을 추가했습니다. 

### 상세 설명

[9d33d4a] , [b6fb6f4]: 두 패키지에서 한 게 거의 같아서 합치겠습니다
주소를 정한 규칙이 화요일에 준형이랑 얘기한 거랑도 달라지고, 프론트에게 전달되는 것도 많이 바뀌는 규칙이라서 설명드리겠습니다.
규칙은 postType을 enum으로 따로 두고, studentType은 그냥 string으로 두기로 했습니다
또한 postType은 requestParam으로 받고 about, admissions 같은 대항목이나 studentType은 pathVariable로 받고 있습니다
가장 마지막 항목 전까지는 /로 받고, 가장 마지막 항목이 세부항목들로 갈리면 postType(requestParam)으로 받도록 했습니다.

이러한 규칙으로 나머지 패키지 모두 바꿀 예정입니다.
만약 개선했으면 하는 점, 혹은 반대하는 점이 있다면 pr로 리뷰 부탁드려요

### 드리고자 하는 말

이러한 규칙을 적용하게 되면 프론트도 변경점이 상당하기 때문에 빨리 메인까지 pr로 보내야 할 거 같아요.
제 계획은, 일부 패키지 수정한걸로 백에서 허락 맡고, 얘를 develop으로 pr하고,  나머지 패키지를 합의된 규칙으로 바꾸고, 다시 develop으로 pr해서, 한번에 프론트에게 통일된 규칙을 전달하고 싶습니다.

원래는 모든 패키지를 한번에 pr하는 것도 생각했지만, 그렇게 패키지에 많은 점이 변경되면 리뷰가 배로 느려진다는 것을 저번주에 알게 되어서요. 절반만 보내드려요.

만약 리뷰가 늦어진다면, 현재 pr에서 커밋을 추가하여 다른 패키지들을 모두 수정할 예정입니다.

오늘 밤부터 다시 작업을 시작할테니 그전에 리뷰 부탁드려요!

### TODO

다른 패키지들도 수정