### PR TITLE
Test: Deploy to 8080

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       args:
         PROFILE: ${PROFILE}
     ports:
-      - 80:8080
+      - 8080:8080
     environment:
       SPRING_DATASOURCE_URL: "jdbc:mysql://csereal_db_container:3306/${MYSQL_DATABASE}?serverTimezone=Asia/Seoul&useSSL=false&allowPublicKeyRetrieval=true"
       SPRING_DATASOURCE_USERNAME: ${MYSQL_USER}


### PR DESCRIPTION
### 한 줄 요약
https 적용 테스트를 위하여 배포 port를 8080으로 변경합니다.

### 상세 설명
68fb5bf074706ec78e235d185583eb406a02838c: [CICD: Change deploy port to 8080](https://github.com/wafflestudio/csereal-server/commit/68fb5bf074706ec78e235d185583eb406a02838c)
