### PR TITLE
feat: attachments 패키지 추가, news와 seminar request에 attachments 추가

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/common/controller/AttachmentContentEntityType.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/controller/AttachmentContentEntityType.kt
@@ -1,0 +1,7 @@
+package com.wafflestudio.csereal.common.controller
+
+import com.wafflestudio.csereal.core.resource.attachment.database.AttachmentEntity
+
+interface AttachmentContentEntityType {
+    fun bringAttachments(): List<AttachmentEntity>?
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/common/controller/AttachmentContentEntityType.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/controller/AttachmentContentEntityType.kt
@@ -3,5 +3,5 @@ package com.wafflestudio.csereal.common.controller
 import com.wafflestudio.csereal.core.resource.attachment.database.AttachmentEntity
 
 interface AttachmentContentEntityType {
-    fun bringAttachments(): List<AttachmentEntity>?
+    fun bringAttachments(): List<AttachmentEntity>
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/common/controller/ImageContentEntityType.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/controller/ImageContentEntityType.kt
@@ -2,6 +2,6 @@ package com.wafflestudio.csereal.common.controller
 
 import com.wafflestudio.csereal.core.resource.mainImage.database.MainImageEntity
 
-interface ContentEntityType {
+interface ImageContentEntityType {
     fun bringMainImage(): MainImageEntity?
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/database/AboutEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/database/AboutEntity.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.about.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
-import com.wafflestudio.csereal.common.controller.ContentEntityType
+import com.wafflestudio.csereal.common.controller.ImageContentEntityType
 import com.wafflestudio.csereal.core.about.dto.AboutDto
 import com.wafflestudio.csereal.core.resource.mainImage.database.MainImageEntity
 import jakarta.persistence.*
@@ -21,7 +21,7 @@ class AboutEntity(
     @OneToOne
     var mainImage: MainImageEntity? = null,
 
-) : BaseTimeEntity(), ContentEntityType {
+) : BaseTimeEntity(), ImageContentEntityType {
     override fun bringMainImage(): MainImageEntity? = mainImage
 
     companion object {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/database/ProfessorEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/database/ProfessorEntity.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.member.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
-import com.wafflestudio.csereal.common.controller.ContentEntityType
+import com.wafflestudio.csereal.common.controller.ImageContentEntityType
 import com.wafflestudio.csereal.core.member.dto.ProfessorDto
 import com.wafflestudio.csereal.core.research.database.LabEntity
 import com.wafflestudio.csereal.core.resource.mainImage.database.MainImageEntity
@@ -44,7 +44,7 @@ class ProfessorEntity(
     @OneToOne
     var mainImage: MainImageEntity? = null,
 
-) : BaseTimeEntity(), ContentEntityType {
+) : BaseTimeEntity(), ImageContentEntityType {
     override fun bringMainImage(): MainImageEntity? = mainImage
 
     companion object {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/database/StaffEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/database/StaffEntity.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.member.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
-import com.wafflestudio.csereal.common.controller.ContentEntityType
+import com.wafflestudio.csereal.common.controller.ImageContentEntityType
 import com.wafflestudio.csereal.core.member.dto.StaffDto
 import com.wafflestudio.csereal.core.resource.mainImage.database.MainImageEntity
 import jakarta.persistence.CascadeType
@@ -24,7 +24,7 @@ class StaffEntity(
     @OneToOne
     var mainImage: MainImageEntity? = null,
 
-    ) : BaseTimeEntity(), ContentEntityType {
+    ) : BaseTimeEntity(), ImageContentEntityType {
     override fun bringMainImage(): MainImageEntity? = mainImage
 
     companion object {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/api/NewsController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/api/NewsController.kt
@@ -35,8 +35,9 @@ class NewsController(
     fun createNews(
         @Valid @RequestPart("request") request: NewsDto,
         @RequestPart("image") image: MultipartFile?,
+        @RequestPart("attachments") attachments: List<MultipartFile>?
     ) : ResponseEntity<NewsDto> {
-        return ResponseEntity.ok(newsService.createNews(request,image))
+        return ResponseEntity.ok(newsService.createNews(request,image, attachments))
     }
 
     @PatchMapping("/{newsId}")

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsEntity.kt
@@ -27,7 +27,7 @@ class NewsEntity(
     @OneToOne
     var mainImage: MainImageEntity? = null,
 
-    @OneToMany
+    @OneToMany(mappedBy = "news", cascade = [CascadeType.ALL], orphanRemoval = true)
     var attachments: MutableList<AttachmentEntity> = mutableListOf(),
 
     @OneToMany(mappedBy = "news", cascade = [CascadeType.ALL])

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsEntity.kt
@@ -1,8 +1,10 @@
 package com.wafflestudio.csereal.core.news.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
-import com.wafflestudio.csereal.common.controller.ContentEntityType
+import com.wafflestudio.csereal.common.controller.AttachmentContentEntityType
+import com.wafflestudio.csereal.common.controller.ImageContentEntityType
 import com.wafflestudio.csereal.core.news.dto.NewsDto
+import com.wafflestudio.csereal.core.resource.attachment.database.AttachmentEntity
 import com.wafflestudio.csereal.core.resource.mainImage.database.MainImageEntity
 import jakarta.persistence.*
 
@@ -25,11 +27,16 @@ class NewsEntity(
     @OneToOne
     var mainImage: MainImageEntity? = null,
 
+    @OneToMany
+    var attachments: MutableList<AttachmentEntity> = mutableListOf(),
+
     @OneToMany(mappedBy = "news", cascade = [CascadeType.ALL])
     var newsTags: MutableSet<NewsTagEntity> = mutableSetOf()
 
-): BaseTimeEntity(), ContentEntityType {
+): BaseTimeEntity(), ImageContentEntityType, AttachmentContentEntityType {
     override fun bringMainImage() = mainImage
+    override fun bringAttachments() = attachments
+
     companion object {
         fun of(newsDto: NewsDto): NewsEntity {
             return NewsEntity(

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/dto/NewsDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/dto/NewsDto.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.csereal.core.news.dto
 
 import com.wafflestudio.csereal.core.news.database.NewsEntity
+import com.wafflestudio.csereal.core.resource.attachment.dto.AttachmentResponse
 import java.time.LocalDateTime
 
 data class NewsDto(
@@ -18,9 +19,10 @@ data class NewsDto(
     val nextId: Long?,
     val nextTitle: String?,
     val imageURL: String?,
+    val attachments: List<AttachmentResponse>?,
 ) {
     companion object {
-        fun of(entity: NewsEntity, imageURL: String?, prevNext: Array<NewsEntity?>?) : NewsDto = entity.run {
+        fun of(entity: NewsEntity, imageURL: String?, attachments: List<AttachmentResponse>?, prevNext: Array<NewsEntity?>?) : NewsDto = entity.run {
             NewsDto(
                 id = this.id,
                 title = this.title,
@@ -36,6 +38,7 @@ data class NewsDto(
                 nextId = prevNext?.get(1)?.id,
                 nextTitle = prevNext?.get(1)?.title,
                 imageURL = imageURL,
+                attachments = attachments,
             )
         }
     }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/api/AttachmentController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/api/AttachmentController.kt
@@ -1,0 +1,13 @@
+package com.wafflestudio.csereal.core.resource.attachment.api
+
+import com.wafflestudio.csereal.core.resource.attachment.service.AttachmentService
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RequestMapping("/attachment")
+@RestController
+class AttachmentController(
+    private val attachmentService: AttachmentService
+) {
+
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/database/AttachmentEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/database/AttachmentEntity.kt
@@ -1,6 +1,9 @@
 package com.wafflestudio.csereal.core.resource.attachment.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.core.news.database.NewsEntity
+import com.wafflestudio.csereal.core.notice.database.TagInNoticeEntity
+import com.wafflestudio.csereal.core.seminar.database.SeminarEntity
 import jakarta.persistence.*
 
 @Entity(name = "attachment")
@@ -12,6 +15,14 @@ class AttachmentEntity(
 
     val attachmentsOrder: Int,
     val size: Long,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "news_id")
+    var news: NewsEntity? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "seminar_id")
+    var seminar: SeminarEntity? = null,
 
     ) : BaseTimeEntity() {
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/database/AttachmentEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/database/AttachmentEntity.kt
@@ -8,7 +8,7 @@ import jakarta.persistence.*
 
 @Entity(name = "attachment")
 class AttachmentEntity(
-    val isDeleted : Boolean? = true,
+    val isDeleted : Boolean? = false,
 
     @Column(unique = true)
     val filename: String,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/database/AttachmentEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/database/AttachmentEntity.kt
@@ -1,0 +1,18 @@
+package com.wafflestudio.csereal.core.resource.attachment.database
+
+import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import jakarta.persistence.*
+
+@Entity(name = "attachment")
+class AttachmentEntity(
+    val isDeleted : Boolean? = true,
+
+    @Column(unique = true)
+    val filename: String,
+
+    val attachmentsOrder: Int,
+    val size: Long,
+
+    ) : BaseTimeEntity() {
+
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/database/AttachmentRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/database/AttachmentRepository.kt
@@ -1,0 +1,8 @@
+package com.wafflestudio.csereal.core.resource.attachment.database
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface AttachmentRepository: JpaRepository<AttachmentEntity, Long> {
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/dto/AttachmentDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/dto/AttachmentDto.kt
@@ -1,0 +1,8 @@
+package com.wafflestudio.csereal.core.resource.attachment.dto
+
+data class AttachmentDto(
+    val filename: String,
+    val attachmentsOrder: Int,
+    val size: Long,
+) {
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/dto/AttachmentResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/dto/AttachmentResponse.kt
@@ -1,0 +1,8 @@
+package com.wafflestudio.csereal.core.resource.attachment.dto
+
+data class AttachmentResponse(
+    val name: String,
+    val url: String,
+    val bytes: Long,
+) {
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/service/AttachmentService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/service/AttachmentService.kt
@@ -6,6 +6,7 @@ import com.wafflestudio.csereal.core.resource.attachment.database.AttachmentEnti
 import com.wafflestudio.csereal.core.resource.attachment.database.AttachmentRepository
 import com.wafflestudio.csereal.core.resource.attachment.dto.AttachmentDto
 import com.wafflestudio.csereal.core.resource.attachment.dto.AttachmentResponse
+import com.wafflestudio.csereal.core.seminar.database.SeminarEntity
 import org.apache.commons.io.FilenameUtils
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
@@ -87,6 +88,9 @@ class AttachmentServiceImpl(
     private fun connectAttachmentToEntity(contentEntity: AttachmentContentEntityType, attachment: AttachmentEntity) {
         when (contentEntity) {
             is NewsEntity -> {
+                contentEntity.attachments.add(attachment)
+            }
+            is SeminarEntity -> {
                 contentEntity.attachments.add(attachment)
             }
         }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/service/AttachmentService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/service/AttachmentService.kt
@@ -1,0 +1,94 @@
+package com.wafflestudio.csereal.core.resource.attachment.service
+
+import com.wafflestudio.csereal.common.controller.AttachmentContentEntityType
+import com.wafflestudio.csereal.core.news.database.NewsEntity
+import com.wafflestudio.csereal.core.resource.attachment.database.AttachmentEntity
+import com.wafflestudio.csereal.core.resource.attachment.database.AttachmentRepository
+import com.wafflestudio.csereal.core.resource.attachment.dto.AttachmentDto
+import com.wafflestudio.csereal.core.resource.attachment.dto.AttachmentResponse
+import org.apache.commons.io.FilenameUtils
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.multipart.MultipartFile
+import java.nio.file.Files
+import java.nio.file.Paths
+
+interface AttachmentService {
+    fun uploadAttachments(
+        contentEntityType: AttachmentContentEntityType,
+        requestAttachments: List<MultipartFile>,
+    ): List<AttachmentDto>
+
+    fun createAttachments(attachments: List<AttachmentEntity>?): List<AttachmentResponse>?
+}
+
+@Service
+class AttachmentServiceImpl(
+    private val attachmentRepository: AttachmentRepository,
+    @Value("\${csereal_attachment.upload.path}")
+    private val path: String,
+) : AttachmentService {
+    @Transactional
+    override fun uploadAttachments(
+        contentEntity: AttachmentContentEntityType,
+        requestAttachments: List<MultipartFile>,
+    ): List<AttachmentDto> {
+        Files.createDirectories(Paths.get(path))
+
+        val attachmentsList = mutableListOf<AttachmentDto>()
+
+        for ((index, requestAttachment) in requestAttachments.withIndex()) {
+            val extension = FilenameUtils.getExtension(requestAttachment.originalFilename)
+
+            val timeMillis = System.currentTimeMillis()
+
+            val filename = "${timeMillis}_${requestAttachment.originalFilename}"
+            val totalFilename = path + filename
+            val saveFile = Paths.get("$totalFilename.$extension")
+            requestAttachment.transferTo(saveFile)
+
+            val attachment = AttachmentEntity(
+                filename = filename,
+                attachmentsOrder = index + 1,
+                size = requestAttachment.size,
+            )
+
+            connectAttachmentToEntity(contentEntity, attachment)
+            attachmentRepository.save(attachment)
+
+            attachmentsList.add(
+                AttachmentDto(
+                    filename = filename,
+                    attachmentsOrder = index + 1,
+                    size = requestAttachment.size
+                )
+            )
+        }
+        return attachmentsList
+    }
+
+    @Transactional
+    override fun createAttachments(attachments: List<AttachmentEntity>?): List<AttachmentResponse>? {
+        val list = mutableListOf<AttachmentResponse>()
+        if (attachments != null) {
+            for (attachment in attachments) {
+                val attachmentDto = AttachmentResponse(
+                    name = attachment.filename,
+                    url = "http://cse-dev-waffle.bacchus.io/attachment/${attachment.filename}",
+                    bytes = attachment.size,
+                )
+                list.add(attachmentDto)
+            }
+        }
+        return list
+    }
+
+    private fun connectAttachmentToEntity(contentEntity: AttachmentContentEntityType, attachment: AttachmentEntity) {
+        when (contentEntity) {
+            is NewsEntity -> {
+                contentEntity.attachments.add(attachment)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/service/AttachmentService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/service/AttachmentService.kt
@@ -89,9 +89,11 @@ class AttachmentServiceImpl(
         when (contentEntity) {
             is NewsEntity -> {
                 contentEntity.attachments.add(attachment)
+                attachment.news = contentEntity
             }
             is SeminarEntity -> {
                 contentEntity.attachments.add(attachment)
+                attachment.seminar = contentEntity
             }
         }
     }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/mainImage/database/MainImageEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/mainImage/database/MainImageEntity.kt
@@ -6,7 +6,7 @@ import jakarta.persistence.*
 
 @Entity(name = "mainImage")
 class MainImageEntity(
-    val isDeleted : Boolean? = true,
+    val isDeleted : Boolean? = false,
 
     @Column(unique = true)
     val filename: String,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/mainImage/service/MainImageService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/mainImage/service/MainImageService.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.resource.mainImage.service
 
 import com.wafflestudio.csereal.common.CserealException
-import com.wafflestudio.csereal.common.controller.ContentEntityType
+import com.wafflestudio.csereal.common.controller.ImageContentEntityType
 import com.wafflestudio.csereal.core.about.database.AboutEntity
 import com.wafflestudio.csereal.core.member.database.ProfessorEntity
 import com.wafflestudio.csereal.core.member.database.StaffEntity
@@ -25,7 +25,7 @@ import kotlin.io.path.name
 
 interface ImageService {
     fun uploadImage(
-        contentEntityType: ContentEntityType,
+        contentEntityType: ImageContentEntityType,
         requestImage: MultipartFile,
     ): MainImageDto
     fun createImageURL(image: MainImageEntity?) : String?
@@ -34,13 +34,13 @@ interface ImageService {
 @Service
 class ImageServiceImpl(
     private val imageRepository: MainImageRepository,
-    @Value("\${csereal.upload.path}")
+    @Value("\${csereal_image.upload.path}")
     private val path: String,
 ) : ImageService {
 
     @Transactional
     override fun uploadImage(
-        contentEntity: ContentEntityType,
+        contentEntity: ImageContentEntityType,
         requestImage: MultipartFile,
     ): MainImageDto {
         Files.createDirectories(Paths.get(path))
@@ -92,7 +92,7 @@ class ImageServiceImpl(
         } else null
     }
 
-    private fun connectImageToEntity(contentEntity: ContentEntityType, image: MainImageEntity) {
+    private fun connectImageToEntity(contentEntity: ImageContentEntityType, image: MainImageEntity) {
         when (contentEntity) {
             is NewsEntity -> {
                 contentEntity.mainImage = image

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/api/SeminarController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/api/SeminarController.kt
@@ -23,9 +23,11 @@ class SeminarController (
     @PostMapping
     fun createSeminar(
         @Valid @RequestPart("request") request: SeminarDto,
-        @RequestPart("image") image: MultipartFile?
+        @RequestPart("image") image: MultipartFile?,
+        @RequestPart("attachments") attachments: List<MultipartFile>?
     ) : ResponseEntity<SeminarDto> {
-        return ResponseEntity.ok(seminarService.createSeminar(request,image))    }
+        return ResponseEntity.ok(seminarService.createSeminar(request, image, attachments))
+    }
 
     @GetMapping("/{seminarId}")
     fun readSeminar(

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarEntity.kt
@@ -1,11 +1,14 @@
 package com.wafflestudio.csereal.core.seminar.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.controller.AttachmentContentEntityType
 import com.wafflestudio.csereal.common.controller.ImageContentEntityType
+import com.wafflestudio.csereal.core.resource.attachment.database.AttachmentEntity
 import com.wafflestudio.csereal.core.resource.mainImage.database.MainImageEntity
 import com.wafflestudio.csereal.core.seminar.dto.SeminarDto
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.OneToMany
 import jakarta.persistence.OneToOne
 
 @Entity(name = "seminar")
@@ -49,8 +52,13 @@ class SeminarEntity(
 
     @OneToOne
     var mainImage: MainImageEntity? = null,
-): BaseTimeEntity(), ImageContentEntityType {
+
+    @OneToMany
+    var attachments: MutableList<AttachmentEntity> = mutableListOf(),
+
+    ): BaseTimeEntity(), ImageContentEntityType, AttachmentContentEntityType {
     override fun bringMainImage(): MainImageEntity? = mainImage
+    override fun bringAttachments() = attachments
 
     companion object {
         fun of(seminarDto: SeminarDto): SeminarEntity {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarEntity.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.seminar.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
-import com.wafflestudio.csereal.common.controller.ContentEntityType
+import com.wafflestudio.csereal.common.controller.ImageContentEntityType
 import com.wafflestudio.csereal.core.resource.mainImage.database.MainImageEntity
 import com.wafflestudio.csereal.core.seminar.dto.SeminarDto
 import jakarta.persistence.Column
@@ -49,7 +49,7 @@ class SeminarEntity(
 
     @OneToOne
     var mainImage: MainImageEntity? = null,
-): BaseTimeEntity(), ContentEntityType {
+): BaseTimeEntity(), ImageContentEntityType {
     override fun bringMainImage(): MainImageEntity? = mainImage
 
     companion object {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarEntity.kt
@@ -6,10 +6,7 @@ import com.wafflestudio.csereal.common.controller.ImageContentEntityType
 import com.wafflestudio.csereal.core.resource.attachment.database.AttachmentEntity
 import com.wafflestudio.csereal.core.resource.mainImage.database.MainImageEntity
 import com.wafflestudio.csereal.core.seminar.dto.SeminarDto
-import jakarta.persistence.Column
-import jakarta.persistence.Entity
-import jakarta.persistence.OneToMany
-import jakarta.persistence.OneToOne
+import jakarta.persistence.*
 
 @Entity(name = "seminar")
 class SeminarEntity(
@@ -53,7 +50,7 @@ class SeminarEntity(
     @OneToOne
     var mainImage: MainImageEntity? = null,
 
-    @OneToMany
+    @OneToMany(mappedBy = "seminar", cascade = [CascadeType.ALL], orphanRemoval = true)
     var attachments: MutableList<AttachmentEntity> = mutableListOf(),
 
     ): BaseTimeEntity(), ImageContentEntityType, AttachmentContentEntityType {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/dto/SeminarDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/dto/SeminarDto.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.csereal.core.seminar.dto
 
+import com.wafflestudio.csereal.core.resource.attachment.dto.AttachmentResponse
 import com.wafflestudio.csereal.core.seminar.database.SeminarEntity
 
 data class SeminarDto(
@@ -28,10 +29,11 @@ data class SeminarDto(
     val nextId: Long?,
     val nextTitle: String?,
     val imageURL: String?,
+    val attachments: List<AttachmentResponse>?,
 ) {
 
     companion object {
-        fun of(entity: SeminarEntity, imageURL: String?, prevNext: Array<SeminarEntity?>?): SeminarDto = entity.run {
+        fun of(entity: SeminarEntity, imageURL: String?, attachments: List<AttachmentResponse>?, prevNext: Array<SeminarEntity?>?): SeminarDto = entity.run {
             SeminarDto(
                 id = this.id,
                 title = this.title,
@@ -57,6 +59,7 @@ data class SeminarDto(
                 nextId = prevNext?.get(1)?.id,
                 nextTitle = prevNext?.get(1)?.title,
                 imageURL = imageURL,
+                attachments = attachments,
             )
         }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -62,7 +62,7 @@ csereal_image:
 
 csereal_attachment:
   upload:
-    path: /app/image/
+    path: /app/attachment/
 ---
 spring:
   config.activate.on-profile: prod
@@ -79,4 +79,4 @@ csereal_image:
 
 csereal_attachment:
   upload:
-    path: /app/image/
+    path: /app/attachment/

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -56,7 +56,11 @@ logging.level:
     springframework:
       security: DEBUG
 
-csereal:
+csereal_image:
+  upload:
+    path: /app/image/
+
+csereal_attachment:
   upload:
     path: /app/image/
 ---
@@ -69,7 +73,10 @@ spring:
 
 
 
-csereal:
+csereal_image:
   upload:
     path: /app/image/
 
+csereal_attachment:
+  upload:
+    path: /app/image/


### PR DESCRIPTION
## 제목
feat: attachments 패키지 추가, news와 seminar request에 attachments 추가

### 한줄 요약
image 하는 것에서 attachments 버전을 추가시켰습니다. 첨부파일은 대부분의 패키지에 들어가야 하는데 그중에서 news, seminar을 올려요

PR 요약해주세요

### 상세 설명

[33d20e0]: attachments 패키지를 추가했고, news에서 attachments를 추가할 수 있도록 했습니다.

[3149e2d]: seminar에서 attachments를 추가할 수 있도록 했습니다.

[c47e1ad]: mappedBy 추가했습니다.

[18152d2]: 경로 분리했습니다.

### TODO

공지사항, academics 등등에서 다 추가할 수 있도록 해야죠
