### PR TITLE
feat: Top Conference List GET API

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/conference/api/ConferenceController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/conference/api/ConferenceController.kt
@@ -1,0 +1,21 @@
+package com.wafflestudio.csereal.core.conference.api
+
+import com.wafflestudio.csereal.core.conference.dto.ConferencePage
+import com.wafflestudio.csereal.core.conference.service.ConferenceService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RequestMapping("/conference")
+@RestController
+class ConferenceController(
+    private val conferenceService: ConferenceService
+) {
+
+    @GetMapping("/page")
+    fun getConferencePage(): ResponseEntity<ConferencePage> {
+        return ResponseEntity.ok(conferenceService.getConferencePage())
+    }
+
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/conference/database/ConferenceEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/conference/database/ConferenceEntity.kt
@@ -1,0 +1,19 @@
+package com.wafflestudio.csereal.core.conference.database
+
+import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+
+@Entity(name = "conference")
+class ConferenceEntity(
+    val code: String,
+    val abbreviation: String,
+    val name: String,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "conference_page_id")
+    val conferencePage: ConferencePageEntity
+
+) : BaseTimeEntity()

--- a/src/main/kotlin/com/wafflestudio/csereal/core/conference/database/ConferencePageEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/conference/database/ConferencePageEntity.kt
@@ -12,6 +12,7 @@ class ConferencePageEntity(
     val author: UserEntity,
 
     @OneToMany(mappedBy = "conferencePage")
+    @OrderBy("code ASC")
     val conferences: List<ConferenceEntity> = mutableListOf()
 
 ) : BaseTimeEntity()

--- a/src/main/kotlin/com/wafflestudio/csereal/core/conference/database/ConferencePageEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/conference/database/ConferencePageEntity.kt
@@ -1,0 +1,17 @@
+package com.wafflestudio.csereal.core.conference.database
+
+import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.core.user.database.UserEntity
+import jakarta.persistence.*
+
+@Entity(name = "conferencePage")
+class ConferencePageEntity(
+
+    @OneToOne
+    @JoinColumn(name = "author_id")
+    val author: UserEntity,
+
+    @OneToMany(mappedBy = "conferencePage")
+    val conferences: List<ConferenceEntity> = mutableListOf()
+
+) : BaseTimeEntity()

--- a/src/main/kotlin/com/wafflestudio/csereal/core/conference/database/ConferencePageRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/conference/database/ConferencePageRepository.kt
@@ -1,0 +1,6 @@
+package com.wafflestudio.csereal.core.conference.database
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ConferencePageRepository : JpaRepository<ConferencePageEntity, Long> {
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/conference/dto/ConferenceDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/conference/dto/ConferenceDto.kt
@@ -1,0 +1,19 @@
+package com.wafflestudio.csereal.core.conference.dto
+
+import com.wafflestudio.csereal.core.conference.database.ConferenceEntity
+
+data class ConferenceDto(
+    val code: String,
+    val abbreviation: String,
+    val name: String
+) {
+    companion object {
+        fun of(conferenceEntity: ConferenceEntity): ConferenceDto {
+            return ConferenceDto(
+                code = conferenceEntity.code,
+                abbreviation = conferenceEntity.abbreviation,
+                name = conferenceEntity.name
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/conference/dto/ConferencePage.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/conference/dto/ConferencePage.kt
@@ -1,0 +1,22 @@
+package com.wafflestudio.csereal.core.conference.dto
+
+import com.wafflestudio.csereal.core.conference.database.ConferencePageEntity
+import java.time.LocalDateTime
+
+data class ConferencePage(
+    val createdAt: LocalDateTime,
+    val modifiedAt: LocalDateTime,
+    val author: String,
+    val conferenceList: List<ConferenceDto>
+) {
+    companion object {
+        fun of(conferencePageEntity: ConferencePageEntity): ConferencePage {
+            return ConferencePage(
+                createdAt = conferencePageEntity.createdAt!!,
+                modifiedAt = conferencePageEntity.modifiedAt!!,
+                author = conferencePageEntity.author.name,
+                conferenceList = conferencePageEntity.conferences.map { ConferenceDto.of(it) }.sortedBy { it.code }
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/conference/dto/ConferencePage.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/conference/dto/ConferencePage.kt
@@ -15,7 +15,7 @@ data class ConferencePage(
                 createdAt = conferencePageEntity.createdAt!!,
                 modifiedAt = conferencePageEntity.modifiedAt!!,
                 author = conferencePageEntity.author.name,
-                conferenceList = conferencePageEntity.conferences.map { ConferenceDto.of(it) }.sortedBy { it.code }
+                conferenceList = conferencePageEntity.conferences.map { ConferenceDto.of(it) }
             )
         }
     }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/conference/service/ConferenceService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/conference/service/ConferenceService.kt
@@ -1,0 +1,26 @@
+package com.wafflestudio.csereal.core.conference.service
+
+import com.wafflestudio.csereal.core.conference.database.ConferencePageRepository
+import com.wafflestudio.csereal.core.conference.dto.ConferenceDto
+import com.wafflestudio.csereal.core.conference.dto.ConferencePage
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+
+interface ConferenceService {
+    fun getConferencePage(): ConferencePage
+}
+
+@Service
+@Transactional
+class ConferenceServiceImpl(
+    private val conferencePageRepository: ConferencePageRepository
+) : ConferenceService {
+
+    @Transactional(readOnly = true)
+    override fun getConferencePage(): ConferencePage {
+        val conferencePage = conferencePageRepository.findAll()[0]
+        return ConferencePage.of(conferencePage)
+    }
+
+}


### PR DESCRIPTION
## Top Conference List

### 한줄 요약

Conference 엔티티에 개별 항목 정보를 저장하고 ConferencePage에서 생성/수정일, 저자와 함께 Conference 리스트를 응답하도록 구성하였습니다.

### 상세 설명

[7b43b86b0c8ff8aad73a97e8386f911fde617257]: GET API

[d732a589584ca33f7ea1f6fc95afbaf2e545c126]: DB에서 가져올때 정렬
