### PR TITLE
fix: research 패키지 프론트에 맞춰 협의

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/common/controller/MainImageContentEntityType.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/controller/MainImageContentEntityType.kt
@@ -2,6 +2,6 @@ package com.wafflestudio.csereal.common.controller
 
 import com.wafflestudio.csereal.core.resource.mainImage.database.MainImageEntity
 
-interface ImageContentEntityType {
+interface MainImageContentEntityType {
     fun bringMainImage(): MainImageEntity?
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/database/AboutEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/database/AboutEntity.kt
@@ -2,7 +2,7 @@ package com.wafflestudio.csereal.core.about.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
 import com.wafflestudio.csereal.common.controller.AttachmentContentEntityType
-import com.wafflestudio.csereal.common.controller.ImageContentEntityType
+import com.wafflestudio.csereal.common.controller.MainImageContentEntityType
 import com.wafflestudio.csereal.core.about.dto.AboutDto
 import com.wafflestudio.csereal.core.resource.attachment.database.AttachmentEntity
 import com.wafflestudio.csereal.core.resource.mainImage.database.MainImageEntity
@@ -26,7 +26,7 @@ class AboutEntity(
     @OneToOne
     var mainImage: MainImageEntity? = null,
 
-    ) : BaseTimeEntity(), ImageContentEntityType, AttachmentContentEntityType {
+    ) : BaseTimeEntity(), MainImageContentEntityType, AttachmentContentEntityType {
     override fun bringMainImage(): MainImageEntity? = mainImage
     override fun bringAttachments(): List<AttachmentEntity> = attachments
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/AboutDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/AboutDto.kt
@@ -18,7 +18,7 @@ data class AboutDto(
     val attachments: List<AttachmentResponse>?,
 ) {
     companion object {
-        fun of(entity: AboutEntity, imageURL: String?, attachments: List<AttachmentResponse>?) : AboutDto = entity.run {
+        fun of(entity: AboutEntity, imageURL: String?, attachmentResponses: List<AttachmentResponse>) : AboutDto = entity.run {
             AboutDto(
                 id = this.id,
                 name = this.name,
@@ -29,7 +29,7 @@ data class AboutDto(
                 modifiedAt = this.modifiedAt,
                 locations = this.locations.map { it.name },
                 imageURL = imageURL,
-                attachments = attachments,
+                attachments = attachmentResponses,
             )
         }
     }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/service/AboutService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/service/AboutService.kt
@@ -47,9 +47,9 @@ class AboutServiceImpl(
         aboutRepository.save(newAbout)
 
         val imageURL = mainImageService.createImageURL(newAbout.mainImage)
-        val attachments = attachmentService.createAttachments(newAbout.attachments)
+        val attachmentResponses = attachmentService.createAttachmentResponses(newAbout.attachments)
 
-        return AboutDto.of(newAbout, imageURL, attachments)
+        return AboutDto.of(newAbout, imageURL, attachmentResponses)
     }
 
     @Transactional(readOnly = true)
@@ -57,18 +57,18 @@ class AboutServiceImpl(
         val enumPostType = makeStringToEnum(postType)
         val about = aboutRepository.findByPostType(enumPostType)
         val imageURL = mainImageService.createImageURL(about.mainImage)
-        val attachments = attachmentService.createAttachments(about.attachments)
+        val attachmentResponses = attachmentService.createAttachmentResponses(about.attachments)
 
 
-        return AboutDto.of(about, imageURL, attachments)
+        return AboutDto.of(about, imageURL, attachmentResponses)
     }
 
     @Transactional(readOnly = true)
     override fun readAllClubs(): List<AboutDto> {
         val clubs = aboutRepository.findAllByPostTypeOrderByName(AboutPostType.STUDENT_CLUBS).map {
             val imageURL = mainImageService.createImageURL(it.mainImage)
-            val attachments = attachmentService.createAttachments(it.attachments)
-            AboutDto.of(it, imageURL, attachments)
+            val attachmentResponses = attachmentService.createAttachmentResponses(it.attachments)
+            AboutDto.of(it, imageURL, attachmentResponses)
         }
 
         return clubs
@@ -78,8 +78,8 @@ class AboutServiceImpl(
     override fun readAllFacilities(): List<AboutDto> {
         val facilities = aboutRepository.findAllByPostTypeOrderByName(AboutPostType.FACILITIES).map {
             val imageURL = mainImageService.createImageURL(it.mainImage)
-            val attachments = attachmentService.createAttachments(it.attachments)
-            AboutDto.of(it, imageURL, attachments)
+            val attachmentResponses = attachmentService.createAttachmentResponses(it.attachments)
+            AboutDto.of(it, imageURL, attachmentResponses)
         }
 
         return facilities
@@ -89,7 +89,7 @@ class AboutServiceImpl(
     override fun readAllDirections(): List<AboutDto> {
         val directions = aboutRepository.findAllByPostTypeOrderByName(AboutPostType.DIRECTIONS).map {
             val imageURL = mainImageService.createImageURL(it.mainImage)
-            val attachments = attachmentService.createAttachments(it.attachments)
+            val attachments = attachmentService.createAttachmentResponses(it.attachments)
             AboutDto.of(it, imageURL, attachments)
         }
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/service/AboutService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/service/AboutService.kt
@@ -42,7 +42,7 @@ class AboutServiceImpl(
         }
 
         if(attachments != null) {
-            attachmentService.uploadAttachments(newAbout, attachments)
+            attachmentService.uploadAllAttachments(newAbout, attachments)
         }
         aboutRepository.save(newAbout)
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/dto/AcademicsDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/dto/AcademicsDto.kt
@@ -14,7 +14,7 @@ data class AcademicsDto(
     val attachments: List<AttachmentResponse>?,
 ) {
     companion object {
-        fun of(entity: AcademicsEntity, attachments: List<AttachmentResponse>?) : AcademicsDto = entity.run {
+        fun of(entity: AcademicsEntity, attachmentResponses: List<AttachmentResponse>) : AcademicsDto = entity.run {
             AcademicsDto(
                 id = this.id,
                 name = this.name,
@@ -22,7 +22,7 @@ data class AcademicsDto(
                 year = this.year,
                 createdAt = this.createdAt,
                 modifiedAt = this.modifiedAt,
-                attachments = attachments,
+                attachments = attachmentResponses,
             )
         }
     }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/service/AcademicsService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/service/AcademicsService.kt
@@ -37,7 +37,7 @@ class AcademicsServiceImpl(
         val newAcademics = AcademicsEntity.of(enumStudentType, enumPostType, request)
 
         if(attachments != null) {
-            attachmentService.uploadAttachments(newAcademics, attachments)
+            attachmentService.uploadAllAttachments(newAcademics, attachments)
         }
 
         academicsRepository.save(newAcademics)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/service/AcademicsService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/service/AcademicsService.kt
@@ -42,10 +42,10 @@ class AcademicsServiceImpl(
 
         academicsRepository.save(newAcademics)
 
-        val attachments = attachmentService.createAttachments(newAcademics.attachments)
+        val attachmentResponses = attachmentService.createAttachmentResponses(newAcademics.attachments)
 
 
-        return AcademicsDto.of(newAcademics, attachments)
+        return AcademicsDto.of(newAcademics, attachmentResponses)
     }
 
     @Transactional(readOnly = true)
@@ -56,9 +56,9 @@ class AcademicsServiceImpl(
 
         val academics = academicsRepository.findByStudentTypeAndPostType(enumStudentType, enumPostType)
 
-        val attachments = attachmentService.createAttachments(academics.attachments)
+        val attachmentResponses = attachmentService.createAttachmentResponses(academics.attachments)
 
-        return AcademicsDto.of(academics, attachments)
+        return AcademicsDto.of(academics, attachmentResponses)
     }
 
     @Transactional
@@ -68,9 +68,9 @@ class AcademicsServiceImpl(
 
         courseRepository.save(course)
 
-        val attachments = attachmentService.createAttachments(course.attachments)
+        val attachmentResponses = attachmentService.createAttachmentResponses(course.attachments)
 
-        return CourseDto.of(course, attachments)
+        return CourseDto.of(course, attachmentResponses)
     }
 
     @Transactional(readOnly = true)
@@ -78,8 +78,8 @@ class AcademicsServiceImpl(
         val enumStudentType = makeStringToAcademicsStudentType(studentType)
 
         val courseDtoList = courseRepository.findAllByStudentTypeOrderByNameAsc(enumStudentType).map {
-            val attachments = attachmentService.createAttachments(it.attachments)
-            CourseDto.of(it, attachments)
+            val attachmentResponses = attachmentService.createAttachmentResponses(it.attachments)
+            CourseDto.of(it, attachmentResponses)
         }
         return courseDtoList
     }
@@ -87,9 +87,9 @@ class AcademicsServiceImpl(
     @Transactional(readOnly = true)
     override fun readCourse(name: String): CourseDto {
         val course = courseRepository.findByName(name)
-        val attachments = attachmentService.createAttachments(course.attachments)
+        val attachmentResponses = attachmentService.createAttachmentResponses(course.attachments)
 
-        return CourseDto.of(course, attachments)
+        return CourseDto.of(course, attachmentResponses)
     }
 
     @Transactional(readOnly = true)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/api/ProfessorController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/api/ProfessorController.kt
@@ -40,9 +40,10 @@ class ProfessorController(
     @PatchMapping("/{professorId}")
     fun updateProfessor(
         @PathVariable professorId: Long,
-        @RequestBody updateProfessorRequest: ProfessorDto
+        @RequestPart("request") updateProfessorRequest: ProfessorDto,
+        @RequestPart("mainImage") mainImage: MultipartFile?,
     ): ResponseEntity<ProfessorDto> {
-        return ResponseEntity.ok(professorService.updateProfessor(professorId, updateProfessorRequest))
+        return ResponseEntity.ok(professorService.updateProfessor(professorId, updateProfessorRequest, mainImage))
     }
 
     @DeleteMapping("/{professorId}")

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/api/StaffController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/api/StaffController.kt
@@ -31,9 +31,12 @@ class StaffController(
         return ResponseEntity.ok(staffService.getAllStaff())
     }
 
-    @PatchMapping("/{staffId}")
-    fun updateStaff(@PathVariable staffId: Long, @RequestBody updateStaffRequest: StaffDto): ResponseEntity<StaffDto> {
-        return ResponseEntity.ok(staffService.updateStaff(staffId, updateStaffRequest))
+    fun updateStaff(
+        @PathVariable staffId: Long,
+        @RequestPart("request") updateStaffRequest: StaffDto,
+        @RequestPart("mainImage") mainImage: MultipartFile?,
+    ): ResponseEntity<StaffDto> {
+        return ResponseEntity.ok(staffService.updateStaff(staffId, updateStaffRequest, mainImage))
     }
 
     @DeleteMapping("/{staffId}")

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/database/ProfessorEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/database/ProfessorEntity.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.member.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
-import com.wafflestudio.csereal.common.controller.ImageContentEntityType
+import com.wafflestudio.csereal.common.controller.MainImageContentEntityType
 import com.wafflestudio.csereal.core.member.dto.ProfessorDto
 import com.wafflestudio.csereal.core.research.database.LabEntity
 import com.wafflestudio.csereal.core.resource.mainImage.database.MainImageEntity
@@ -44,7 +44,7 @@ class ProfessorEntity(
     @OneToOne
     var mainImage: MainImageEntity? = null,
 
-) : BaseTimeEntity(), ImageContentEntityType {
+) : BaseTimeEntity(), MainImageContentEntityType {
     override fun bringMainImage(): MainImageEntity? = mainImage
 
     companion object {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/database/StaffEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/database/StaffEntity.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.member.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
-import com.wafflestudio.csereal.common.controller.ImageContentEntityType
+import com.wafflestudio.csereal.common.controller.MainImageContentEntityType
 import com.wafflestudio.csereal.core.member.dto.StaffDto
 import com.wafflestudio.csereal.core.resource.mainImage.database.MainImageEntity
 import jakarta.persistence.CascadeType
@@ -24,7 +24,7 @@ class StaffEntity(
     @OneToOne
     var mainImage: MainImageEntity? = null,
 
-    ) : BaseTimeEntity(), ImageContentEntityType {
+    ) : BaseTimeEntity(), MainImageContentEntityType {
     override fun bringMainImage(): MainImageEntity? = mainImage
 
     companion object {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/service/ProfessorService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/service/ProfessorService.kt
@@ -17,7 +17,7 @@ interface ProfessorService {
     fun getProfessor(professorId: Long): ProfessorDto
     fun getActiveProfessors(): ProfessorPageDto
     fun getInactiveProfessors(): List<SimpleProfessorDto>
-    fun updateProfessor(professorId: Long, updateProfessorRequest: ProfessorDto): ProfessorDto
+    fun updateProfessor(professorId: Long, updateProfessorRequest: ProfessorDto, mainImage: MultipartFile?): ProfessorDto
     fun deleteProfessor(professorId: Long)
 }
 
@@ -94,8 +94,7 @@ class ProfessorServiceImpl(
             .sortedBy { it.name }
     }
 
-    override fun updateProfessor(professorId: Long, updateProfessorRequest: ProfessorDto): ProfessorDto {
-
+    override fun updateProfessor(professorId: Long, updateProfessorRequest: ProfessorDto, mainImage: MultipartFile?): ProfessorDto {
         val professor = professorRepository.findByIdOrNull(professorId)
             ?: throw CserealException.Csereal404("해당 교수님을 찾을 수 없습니다. professorId: ${professorId}")
 
@@ -106,6 +105,10 @@ class ProfessorServiceImpl(
         }
 
         professor.update(updateProfessorRequest)
+
+        if(mainImage != null) {
+            mainImageService.uploadMainImage(professor, mainImage)
+        }
 
         // 학력 업데이트
         val oldEducations = professor.educations.map { it.name }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/service/StaffService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/service/StaffService.kt
@@ -71,7 +71,7 @@ class StaffServiceImpl(
         if(mainImage != null) {
             mainImageService.uploadMainImage(staff, mainImage)
         }
-        
+
         // 주요 업무 업데이트
         val oldTasks = staff.tasks.map { it.name }
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/service/StaffService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/service/StaffService.kt
@@ -16,7 +16,7 @@ interface StaffService {
     fun createStaff(createStaffRequest: StaffDto, mainImage: MultipartFile?): StaffDto
     fun getStaff(staffId: Long): StaffDto
     fun getAllStaff(): List<SimpleStaffDto>
-    fun updateStaff(staffId: Long, updateStaffRequest: StaffDto): StaffDto
+    fun updateStaff(staffId: Long, updateStaffRequest: StaffDto, mainImage: MultipartFile?): StaffDto
     fun deleteStaff(staffId: Long)
 }
 
@@ -62,13 +62,16 @@ class StaffServiceImpl(
         }.sortedBy { it.name }
     }
 
-    override fun updateStaff(staffId: Long, updateStaffRequest: StaffDto): StaffDto {
-
+    override fun updateStaff(staffId: Long, updateStaffRequest: StaffDto, mainImage: MultipartFile?): StaffDto {
         val staff = staffRepository.findByIdOrNull(staffId)
             ?: throw CserealException.Csereal404("해당 행정직원을 찾을 수 없습니다. staffId: ${staffId}")
 
         staff.update(updateStaffRequest)
 
+        if(mainImage != null) {
+            mainImageService.uploadMainImage(staff, mainImage)
+        }
+        
         // 주요 업무 업데이트
         val oldTasks = staff.tasks.map { it.name }
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsEntity.kt
@@ -2,7 +2,7 @@ package com.wafflestudio.csereal.core.news.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
 import com.wafflestudio.csereal.common.controller.AttachmentContentEntityType
-import com.wafflestudio.csereal.common.controller.ImageContentEntityType
+import com.wafflestudio.csereal.common.controller.MainImageContentEntityType
 import com.wafflestudio.csereal.core.news.dto.NewsDto
 import com.wafflestudio.csereal.core.resource.attachment.database.AttachmentEntity
 import com.wafflestudio.csereal.core.resource.mainImage.database.MainImageEntity
@@ -30,7 +30,7 @@ class NewsEntity(
     @OneToMany(mappedBy = "news", cascade = [CascadeType.ALL])
     var newsTags: MutableSet<NewsTagEntity> = mutableSetOf()
 
-): BaseTimeEntity(), ImageContentEntityType, AttachmentContentEntityType {
+): BaseTimeEntity(), MainImageContentEntityType, AttachmentContentEntityType {
     override fun bringMainImage() = mainImage
     override fun bringAttachments() = attachments
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/dto/NewsDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/dto/NewsDto.kt
@@ -21,7 +21,7 @@ data class NewsDto(
     val attachments: List<AttachmentResponse>?,
 ) {
     companion object {
-        fun of(entity: NewsEntity, imageURL: String?, attachments: List<AttachmentResponse>?, prevNext: Array<NewsEntity?>?) : NewsDto = entity.run {
+        fun of(entity: NewsEntity, imageURL: String?, attachmentResponses: List<AttachmentResponse>, prevNext: Array<NewsEntity?>?) : NewsDto = entity.run {
             NewsDto(
                 id = this.id,
                 title = this.title,
@@ -36,7 +36,7 @@ data class NewsDto(
                 nextId = prevNext?.get(1)?.id,
                 nextTitle = prevNext?.get(1)?.title,
                 imageURL = imageURL,
-                attachments = attachments,
+                attachments = attachmentResponses,
             )
         }
     }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/service/NewsService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/service/NewsService.kt
@@ -71,11 +71,11 @@ class NewsServiceImpl(
         }
 
         if(attachments != null) {
-            attachmentService.uploadAttachments(newNews, attachments)
+            attachmentService.uploadAllAttachments(newNews, attachments)
         }
 
         if(attachments != null) {
-            attachmentService.uploadAttachments(newNews, attachments)
+            attachmentService.uploadAllAttachments(newNews, attachments)
         }
 
         newsRepository.save(newNews)
@@ -99,7 +99,7 @@ class NewsServiceImpl(
 
         if(attachments != null) {
             news.attachments.clear()
-            attachmentService.uploadAttachments(news, attachments)
+            attachmentService.uploadAllAttachments(news, attachments)
         }
 
         val oldTags = news.newsTags.map { it.tag.name }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/service/NewsService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/service/NewsService.kt
@@ -49,12 +49,12 @@ class NewsServiceImpl(
         if (news.isDeleted) throw CserealException.Csereal404("삭제된 새소식입니다.(newsId: $newsId)")
 
         val imageURL = mainImageService.createImageURL(news.mainImage)
-        val attachments = attachmentService.createAttachments(news.attachments)
+        val attachmentResponses = attachmentService.createAttachmentResponses(news.attachments)
 
         val prevNext = newsRepository.findPrevNextId(newsId, tag, keyword)
             ?: throw CserealException.Csereal400("이전글 다음글이 존재하지 않습니다.(newsId=$newsId)")
 
-        return NewsDto.of(news, imageURL, attachments, prevNext)
+        return NewsDto.of(news, imageURL, attachmentResponses, prevNext)
     }
 
     @Transactional
@@ -81,9 +81,9 @@ class NewsServiceImpl(
         newsRepository.save(newNews)
 
         val imageURL = mainImageService.createImageURL(newNews.mainImage)
-        val attachments = attachmentService.createAttachments(newNews.attachments)
+        val attachmentResponses = attachmentService.createAttachmentResponses(newNews.attachments)
 
-        return NewsDto.of(newNews, imageURL, attachments, null)
+        return NewsDto.of(newNews, imageURL, attachmentResponses, null)
     }
 
     @Transactional
@@ -119,9 +119,9 @@ class NewsServiceImpl(
         }
 
         val imageURL = mainImageService.createImageURL(news.mainImage)
-        val attachments = attachmentService.createAttachments(news.attachments)
+        val attachmentResponses = attachmentService.createAttachmentResponses(news.attachments)
 
-        return NewsDto.of(news, imageURL, attachments, null)
+        return NewsDto.of(news, imageURL, attachmentResponses, null)
     }
 
     @Transactional

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/service/NewsService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/service/NewsService.kt
@@ -74,10 +74,6 @@ class NewsServiceImpl(
             attachmentService.uploadAllAttachments(newNews, attachments)
         }
 
-        if(attachments != null) {
-            attachmentService.uploadAllAttachments(newNews, attachments)
-        }
-
         newsRepository.save(newNews)
 
         val imageURL = mainImageService.createImageURL(newNews.mainImage)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/api/ResearchController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/api/ResearchController.kt
@@ -42,9 +42,9 @@ class ResearchController(
     @PostMapping("/lab")
     fun createLab(
         @Valid @RequestPart("request") request: LabDto,
-        @RequestPart("attachments") attachments: List<MultipartFile>?
+        @RequestPart("pdf") pdf: MultipartFile?
     ) : ResponseEntity<LabDto> {
-        return ResponseEntity.ok(researchService.createLab(request, attachments))
+        return ResponseEntity.ok(researchService.createLab(request, pdf))
     }
 
     @GetMapping("/labs")

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/api/ResearchController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/api/ResearchController.kt
@@ -51,4 +51,11 @@ class ResearchController(
     fun readAllLabs() : ResponseEntity<List<LabDto>> {
         return ResponseEntity.ok(researchService.readAllLabs())
     }
+
+    @GetMapping("/lab/{labId}")
+    fun readLab(
+        @PathVariable labId: Long,
+    ) : ResponseEntity<LabDto> {
+        return ResponseEntity.ok(researchService.readLab(labId))
+    }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/api/ResearchController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/api/ResearchController.kt
@@ -16,46 +16,50 @@ class ResearchController(
 ) {
     @PostMapping
     fun createResearchDetail(
-        @Valid @RequestBody request: ResearchDto
-    ) : ResponseEntity<ResearchDto> {
-        return ResponseEntity.ok(researchService.createResearchDetail(request))
+        @Valid @RequestPart("request") request: ResearchDto,
+        @RequestPart("mainImage") mainImage: MultipartFile?,
+        @RequestPart("attachments") attachments: List<MultipartFile>?
+    ): ResponseEntity<ResearchDto> {
+        return ResponseEntity.ok(researchService.createResearchDetail(request, mainImage, attachments))
     }
 
     @GetMapping("/groups")
-    fun readAllResearchGroups() : ResponseEntity<ResearchGroupResponse> {
+    fun readAllResearchGroups(): ResponseEntity<ResearchGroupResponse> {
         return ResponseEntity.ok(researchService.readAllResearchGroups())
     }
 
     @GetMapping("/centers")
-    fun readAllResearchCenters() : ResponseEntity<List<ResearchDto>> {
+    fun readAllResearchCenters(): ResponseEntity<List<ResearchDto>> {
         return ResponseEntity.ok(researchService.readAllResearchCenters())
     }
 
     @PatchMapping("/{researchId}")
     fun updateResearchDetail(
         @PathVariable researchId: Long,
-        @Valid @RequestBody request: ResearchDto
-    ) : ResponseEntity<ResearchDto> {
-        return ResponseEntity.ok(researchService.updateResearchDetail(researchId, request))
+        @Valid @RequestPart("request") request: ResearchDto,
+        @RequestPart("mainImage") mainImage: MultipartFile?,
+        @RequestPart("attachments") attachments: List<MultipartFile>?
+    ): ResponseEntity<ResearchDto> {
+        return ResponseEntity.ok(researchService.updateResearchDetail(researchId, request, mainImage, attachments))
     }
 
     @PostMapping("/lab")
     fun createLab(
         @Valid @RequestPart("request") request: LabDto,
         @RequestPart("pdf") pdf: MultipartFile?
-    ) : ResponseEntity<LabDto> {
+    ): ResponseEntity<LabDto> {
         return ResponseEntity.ok(researchService.createLab(request, pdf))
     }
 
     @GetMapping("/labs")
-    fun readAllLabs() : ResponseEntity<List<LabDto>> {
+    fun readAllLabs(): ResponseEntity<List<LabDto>> {
         return ResponseEntity.ok(researchService.readAllLabs())
     }
 
     @GetMapping("/lab/{labId}")
     fun readLab(
         @PathVariable labId: Long,
-    ) : ResponseEntity<LabDto> {
+    ): ResponseEntity<LabDto> {
         return ResponseEntity.ok(researchService.readLab(labId))
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/api/ResearchController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/api/ResearchController.kt
@@ -7,6 +7,7 @@ import com.wafflestudio.csereal.core.research.service.ResearchService
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
+import org.springframework.web.multipart.MultipartFile
 
 @RequestMapping("/api/v1/research")
 @RestController
@@ -40,9 +41,10 @@ class ResearchController(
 
     @PostMapping("/lab")
     fun createLab(
-        @Valid @RequestBody request: LabDto
+        @Valid @RequestPart("request") request: LabDto,
+        @RequestPart("attachments") attachments: List<MultipartFile>?
     ) : ResponseEntity<LabDto> {
-        return ResponseEntity.ok(researchService.createLab(request))
+        return ResponseEntity.ok(researchService.createLab(request, attachments))
     }
 
     @GetMapping("/labs")

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/database/LabEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/database/LabEntity.kt
@@ -32,7 +32,7 @@ class LabEntity(
 
 ) : BaseTimeEntity() {
     companion object {
-        fun of(researchGroup: ResearchEntity, labDto: LabDto) : LabEntity {
+        fun of(labDto: LabDto, researchGroup: ResearchEntity) : LabEntity {
             return LabEntity(
                 name = labDto.name,
                 location = labDto.location,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/database/LabEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/database/LabEntity.kt
@@ -17,7 +17,10 @@ class LabEntity(
     val location: String?,
     val tel: String?,
     val acronym: String?,
-    val pdf: String?,
+
+    @OneToOne
+    var pdf: AttachmentEntity? = null,
+
     val youtube: String?,
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -27,11 +30,7 @@ class LabEntity(
     val description: String?,
     val websiteURL: String?,
 
-    @OneToMany(mappedBy = "lab", cascade = [CascadeType.ALL], orphanRemoval = true)
-    var attachments: MutableList<AttachmentEntity> = mutableListOf(),
-
-) : BaseTimeEntity(), AttachmentContentEntityType {
-    override fun bringAttachments() = attachments
+) : BaseTimeEntity() {
     companion object {
         fun of(researchGroup: ResearchEntity, labDto: LabDto) : LabEntity {
             return LabEntity(
@@ -39,8 +38,7 @@ class LabEntity(
                 location = labDto.location,
                 tel = labDto.tel,
                 acronym = labDto.acronym,
-                pdf = labDto.introductionMaterials?.pdf,
-                youtube = labDto.introductionMaterials?.youtube,
+                youtube = labDto.youtube,
                 research = researchGroup,
                 description = labDto.description,
                 websiteURL = labDto.websiteURL,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/database/LabEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/database/LabEntity.kt
@@ -1,13 +1,14 @@
 package com.wafflestudio.csereal.core.research.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.controller.AttachmentContentEntityType
 import com.wafflestudio.csereal.core.member.database.ProfessorEntity
 import com.wafflestudio.csereal.core.research.dto.LabDto
+import com.wafflestudio.csereal.core.resource.attachment.database.AttachmentEntity
 import jakarta.persistence.*
 
 @Entity(name = "lab")
 class LabEntity(
-    
     val name: String,
 
     @OneToMany(mappedBy = "lab")
@@ -24,11 +25,13 @@ class LabEntity(
     var research: ResearchEntity,
 
     val description: String?,
-
     val websiteURL: String?,
-    val isPublic: Boolean,
 
-) : BaseTimeEntity() {
+    @OneToMany(mappedBy = "lab", cascade = [CascadeType.ALL], orphanRemoval = true)
+    var attachments: MutableList<AttachmentEntity> = mutableListOf(),
+
+) : BaseTimeEntity(), AttachmentContentEntityType {
+    override fun bringAttachments() = attachments
     companion object {
         fun of(researchGroup: ResearchEntity, labDto: LabDto) : LabEntity {
             return LabEntity(
@@ -41,7 +44,6 @@ class LabEntity(
                 research = researchGroup,
                 description = labDto.description,
                 websiteURL = labDto.websiteURL,
-                isPublic = labDto.isPublic,
             )
         }
     }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/database/ResearchEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/database/ResearchEntity.kt
@@ -10,12 +10,8 @@ class ResearchEntity(
     var postType: ResearchPostType,
 
     var name: String,
-
     var description: String?,
-
     var websiteURL: String?,
-
-    var isPublic: Boolean,
 
     @OneToMany(mappedBy = "research", cascade = [CascadeType.ALL], orphanRemoval = true)
     var labs: MutableList<LabEntity> = mutableListOf()
@@ -27,7 +23,6 @@ class ResearchEntity(
                 name = researchDto.name,
                 description = researchDto.description,
                 websiteURL = researchDto.websiteURL,
-                isPublic = researchDto.isPublic
             )
         }
     }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/database/ResearchEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/database/ResearchEntity.kt
@@ -1,7 +1,11 @@
 package com.wafflestudio.csereal.core.research.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.controller.AttachmentContentEntityType
+import com.wafflestudio.csereal.common.controller.MainImageContentEntityType
 import com.wafflestudio.csereal.core.research.dto.ResearchDto
+import com.wafflestudio.csereal.core.resource.attachment.database.AttachmentEntity
+import com.wafflestudio.csereal.core.resource.mainImage.database.MainImageEntity
 import jakarta.persistence.*
 
 @Entity(name = "research")
@@ -11,18 +15,26 @@ class ResearchEntity(
 
     var name: String,
     var description: String?,
-    var websiteURL: String?,
 
     @OneToMany(mappedBy = "research", cascade = [CascadeType.ALL], orphanRemoval = true)
-    var labs: MutableList<LabEntity> = mutableListOf()
-): BaseTimeEntity() {
+    var labs: MutableList<LabEntity> = mutableListOf(),
+
+    @OneToOne
+    var mainImage: MainImageEntity? = null,
+
+    @OneToMany(mappedBy = "research", cascade = [CascadeType.ALL], orphanRemoval = true)
+    var attachments: MutableList<AttachmentEntity> = mutableListOf(),
+
+    ) : BaseTimeEntity(), MainImageContentEntityType, AttachmentContentEntityType {
+    override fun bringMainImage() = mainImage
+    override fun bringAttachments() = attachments
+
     companion object {
-        fun of(researchDto: ResearchDto) : ResearchEntity {
+        fun of(researchDto: ResearchDto): ResearchEntity {
             return ResearchEntity(
                 postType = researchDto.postType,
                 name = researchDto.name,
                 description = researchDto.description,
-                websiteURL = researchDto.websiteURL,
             )
         }
     }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/dto/LabDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/dto/LabDto.kt
@@ -1,7 +1,6 @@
 package com.wafflestudio.csereal.core.research.dto
 
 import com.wafflestudio.csereal.core.research.database.LabEntity
-import com.wafflestudio.csereal.core.resource.introductionMaterial.dto.IntroductionMaterialDto
 
 data class LabDto(
     val id: Long,
@@ -10,13 +9,14 @@ data class LabDto(
     val location: String?,
     val tel: String?,
     val acronym: String?,
-    val introductionMaterials: IntroductionMaterialDto?,
+    val pdf: String?,
+    val youtube: String?,
     val group: String,
     val description: String?,
     val websiteURL: String?,
 ) {
     companion object {
-        fun of(entity: LabEntity): LabDto = entity.run {
+        fun of(entity: LabEntity, pdfURL: String): LabDto = entity.run {
             LabDto(
                 id = this.id,
                 name = this.name,
@@ -24,7 +24,8 @@ data class LabDto(
                 location = this.location,
                 tel = this.tel,
                 acronym = this.acronym,
-                introductionMaterials = IntroductionMaterialDto(this.pdf, this.youtube),
+                pdf = pdfURL,
+                youtube = this.youtube,
                 group = this.research.name,
                 description = this.description,
                 websiteURL = this.websiteURL,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/dto/LabDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/dto/LabDto.kt
@@ -6,7 +6,7 @@ import com.wafflestudio.csereal.core.resource.introductionMaterial.dto.Introduct
 data class LabDto(
     val id: Long,
     val name: String,
-    val professors: List<String>?,
+    val professors: List<LabProfessorResponse>?,
     val location: String?,
     val tel: String?,
     val acronym: String?,
@@ -20,7 +20,7 @@ data class LabDto(
             LabDto(
                 id = this.id,
                 name = this.name,
-                professors = this.professors.map { it.name },
+                professors = this.professors.map { LabProfessorResponse(id = it.id, name = it.name) },
                 location = this.location,
                 tel = this.tel,
                 acronym = this.acronym,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/dto/LabDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/dto/LabDto.kt
@@ -14,7 +14,6 @@ data class LabDto(
     val group: String,
     val description: String?,
     val websiteURL: String?,
-    val isPublic: Boolean,
 ) {
     companion object {
         fun of(entity: LabEntity): LabDto = entity.run {
@@ -29,7 +28,6 @@ data class LabDto(
                 group = this.research.name,
                 description = this.description,
                 websiteURL = this.websiteURL,
-                isPublic = this.isPublic
             )
         }
     }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/dto/LabProfessorResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/dto/LabProfessorResponse.kt
@@ -1,0 +1,7 @@
+package com.wafflestudio.csereal.core.research.dto
+
+data class LabProfessorResponse(
+    val id: Long,
+    val name: String,
+) {
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/dto/ResearchDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/dto/ResearchDto.kt
@@ -12,7 +12,7 @@ data class ResearchDto(
     val websiteURL: String?,
     val createdAt: LocalDateTime?,
     val modifiedAt: LocalDateTime?,
-    val labsId: List<Long>?
+    val labs: List<ResearchLabResponse>?
 ) {
     companion object {
         fun of(entity: ResearchEntity) = entity.run {
@@ -24,7 +24,7 @@ data class ResearchDto(
                 websiteURL = this.websiteURL,
                 createdAt = this.createdAt,
                 modifiedAt = this.modifiedAt,
-                labsId = this.labs.map { it.id }
+                labs = this.labs.map { ResearchLabResponse(id = it.id, name = it.name) }
             )
         }
     }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/dto/ResearchDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/dto/ResearchDto.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.csereal.core.research.dto
 
 import com.wafflestudio.csereal.core.research.database.ResearchEntity
 import com.wafflestudio.csereal.core.research.database.ResearchPostType
+import com.wafflestudio.csereal.core.resource.attachment.dto.AttachmentResponse
 import java.time.LocalDateTime
 
 data class ResearchDto(
@@ -9,22 +10,24 @@ data class ResearchDto(
     val postType: ResearchPostType,
     val name: String,
     val description: String?,
-    val websiteURL: String?,
     val createdAt: LocalDateTime?,
     val modifiedAt: LocalDateTime?,
-    val labs: List<ResearchLabResponse>?
+    val labs: List<ResearchLabResponse>?,
+    val imageURL: String?,
+    val attachments: List<AttachmentResponse>?,
 ) {
     companion object {
-        fun of(entity: ResearchEntity) = entity.run {
+        fun of(entity: ResearchEntity, imageURL: String?, attachmentResponse: List<AttachmentResponse>) = entity.run {
             ResearchDto(
                 id = this.id,
                 postType = this.postType,
                 name = this.name,
                 description = this.description,
-                websiteURL = this.websiteURL,
                 createdAt = this.createdAt,
                 modifiedAt = this.modifiedAt,
-                labs = this.labs.map { ResearchLabResponse(id = it.id, name = it.name) }
+                labs = this.labs.map { ResearchLabResponse(id = it.id, name = it.name) },
+                imageURL = imageURL,
+                attachments = attachmentResponse
             )
         }
     }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/dto/ResearchDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/dto/ResearchDto.kt
@@ -12,7 +12,6 @@ data class ResearchDto(
     val websiteURL: String?,
     val createdAt: LocalDateTime?,
     val modifiedAt: LocalDateTime?,
-    val isPublic: Boolean,
     val labsId: List<Long>?
 ) {
     companion object {
@@ -25,7 +24,6 @@ data class ResearchDto(
                 websiteURL = this.websiteURL,
                 createdAt = this.createdAt,
                 modifiedAt = this.modifiedAt,
-                isPublic = this.isPublic,
                 labsId = this.labs.map { it.id }
             )
         }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/dto/ResearchLabResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/dto/ResearchLabResponse.kt
@@ -1,0 +1,7 @@
+package com.wafflestudio.csereal.core.research.dto
+
+data class ResearchLabResponse(
+    val id: Long,
+    val name: String,
+) {
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/service/ResearchService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/service/ResearchService.kt
@@ -126,7 +126,7 @@ class ResearchServiceImpl(
 
         labRepository.save(newLab)
 
-        val attachments = attachmentService.createAttachments(newLab.attachments)
+        val attachmentResponses = attachmentService.createAttachmentResponses(newLab.attachments)
 
         labRepository.save(newLab)
         return LabDto.of(newLab)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/service/ResearchService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/service/ResearchService.kt
@@ -4,6 +4,7 @@ import com.wafflestudio.csereal.common.CserealException
 import com.wafflestudio.csereal.core.member.database.ProfessorRepository
 import com.wafflestudio.csereal.core.research.database.*
 import com.wafflestudio.csereal.core.research.dto.LabDto
+import com.wafflestudio.csereal.core.research.dto.LabProfessorResponse
 import com.wafflestudio.csereal.core.research.dto.ResearchDto
 import com.wafflestudio.csereal.core.research.dto.ResearchGroupResponse
 import com.wafflestudio.csereal.core.resource.attachment.service.AttachmentService
@@ -119,6 +120,16 @@ class ResearchServiceImpl(
 
          */
         val newLab = LabEntity.of(researchGroup, request)
+
+        if(request.professors != null) {
+            for(professor in request.professors) {
+                val professorEntity = professorRepository.findByIdOrNull(professor.id)
+                    ?: throw CserealException.Csereal404("해당 교수님을 찾을 수 없습니다.(professorId = ${professor.id}")
+
+                newLab.professors.add(professorEntity)
+                professorEntity.lab = newLab
+            }
+        }
 
         if(attachments != null) {
             attachmentService.uploadAttachments(newLab, attachments)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/service/ResearchService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/service/ResearchService.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.csereal.core.research.service
 
 import com.wafflestudio.csereal.common.CserealException
+import com.wafflestudio.csereal.common.properties.EndpointProperties
 import com.wafflestudio.csereal.core.member.database.ProfessorRepository
 import com.wafflestudio.csereal.core.research.database.*
 import com.wafflestudio.csereal.core.research.dto.*
@@ -29,6 +30,7 @@ class ResearchServiceImpl(
     private val professorRepository: ProfessorRepository,
     private val mainImageService: MainImageService,
     private val attachmentService: AttachmentService,
+    private val endpointProperties: EndpointProperties,
 ) : ResearchService {
     @Transactional
     override fun createResearchDetail(request: ResearchDto, mainImage: MultipartFile?, attachments: List<MultipartFile>?): ResearchDto {
@@ -121,6 +123,7 @@ class ResearchServiceImpl(
         }
 
         if(attachments != null) {
+            research.attachments.clear()
             attachmentService.uploadAllAttachments(research, attachments)
         }
 
@@ -155,7 +158,7 @@ class ResearchServiceImpl(
         var pdfURL = ""
         if(pdf != null) {
             val attachmentDto = attachmentService.uploadAttachmentInLabEntity(newLab, pdf)
-            pdfURL = "http://cse-dev-waffle.bacchus.io/attachment/${attachmentDto.filename}"
+            pdfURL = "${endpointProperties.backend}/v1/attachment/${attachmentDto.filename}"
         }
 
         labRepository.save(newLab)
@@ -189,6 +192,6 @@ class ResearchServiceImpl(
     }
 
     private fun createPdfURL(pdf: AttachmentEntity) : String{
-        return "http://cse-dev-waffle.bacchus.io/attachment/${pdf.filename}"
+        return "${endpointProperties.backend}/v1/attachment/${pdf.filename}"
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/database/AttachmentEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/database/AttachmentEntity.kt
@@ -6,6 +6,7 @@ import com.wafflestudio.csereal.core.academics.database.AcademicsEntity
 import com.wafflestudio.csereal.core.academics.database.CourseEntity
 import com.wafflestudio.csereal.core.news.database.NewsEntity
 import com.wafflestudio.csereal.core.research.database.LabEntity
+import com.wafflestudio.csereal.core.research.database.ResearchEntity
 import com.wafflestudio.csereal.core.seminar.database.SeminarEntity
 import jakarta.persistence.*
 
@@ -42,6 +43,10 @@ class AttachmentEntity(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "lab_id")
     var lab: LabEntity? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "research_id")
+    var research: ResearchEntity? = null,
 ) : BaseTimeEntity() {
 
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/database/AttachmentEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/database/AttachmentEntity.kt
@@ -5,6 +5,7 @@ import com.wafflestudio.csereal.core.about.database.AboutEntity
 import com.wafflestudio.csereal.core.academics.database.AcademicsEntity
 import com.wafflestudio.csereal.core.academics.database.CourseEntity
 import com.wafflestudio.csereal.core.news.database.NewsEntity
+import com.wafflestudio.csereal.core.research.database.LabEntity
 import com.wafflestudio.csereal.core.seminar.database.SeminarEntity
 import jakarta.persistence.*
 
@@ -37,6 +38,10 @@ class AttachmentEntity(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "course_id")
     var course: CourseEntity? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lab_id")
+    var lab: LabEntity? = null,
 ) : BaseTimeEntity() {
 
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/service/AttachmentService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/service/AttachmentService.kt
@@ -6,6 +6,7 @@ import com.wafflestudio.csereal.core.academics.database.AcademicsEntity
 import com.wafflestudio.csereal.core.academics.database.CourseEntity
 import com.wafflestudio.csereal.core.news.database.NewsEntity
 import com.wafflestudio.csereal.core.research.database.LabEntity
+import com.wafflestudio.csereal.core.research.database.ResearchEntity
 import com.wafflestudio.csereal.core.resource.attachment.database.AttachmentEntity
 import com.wafflestudio.csereal.core.resource.attachment.database.AttachmentRepository
 import com.wafflestudio.csereal.core.resource.attachment.dto.AttachmentDto
@@ -141,6 +142,10 @@ class AttachmentServiceImpl(
             is CourseEntity -> {
                 contentEntity.attachments.add(attachment)
                 attachment.course = contentEntity
+            }
+            is ResearchEntity -> {
+                contentEntity.attachments.add(attachment)
+                attachment.research = contentEntity
             }
         }
     }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/service/AttachmentService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/service/AttachmentService.kt
@@ -5,6 +5,7 @@ import com.wafflestudio.csereal.core.about.database.AboutEntity
 import com.wafflestudio.csereal.core.academics.database.AcademicsEntity
 import com.wafflestudio.csereal.core.academics.database.CourseEntity
 import com.wafflestudio.csereal.core.news.database.NewsEntity
+import com.wafflestudio.csereal.core.research.database.LabEntity
 import com.wafflestudio.csereal.core.resource.attachment.database.AttachmentEntity
 import com.wafflestudio.csereal.core.resource.attachment.database.AttachmentRepository
 import com.wafflestudio.csereal.core.resource.attachment.dto.AttachmentDto
@@ -108,6 +109,10 @@ class AttachmentServiceImpl(
             is CourseEntity -> {
                 contentEntity.attachments.add(attachment)
                 attachment.course = contentEntity
+            }
+            is LabEntity -> {
+                contentEntity.attachments.add(attachment)
+                attachment.lab = contentEntity
             }
         }
     }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/service/AttachmentService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/service/AttachmentService.kt
@@ -24,7 +24,7 @@ interface AttachmentService {
         contentEntityType: AttachmentContentEntityType,
         requestAttachments: List<MultipartFile>,
     ): List<AttachmentDto>
-    fun createAttachments(attachments: List<AttachmentEntity>?): List<AttachmentResponse>?
+    fun createAttachmentResponses(attachments: List<AttachmentEntity>?): List<AttachmentResponse>
 }
 
 @Service
@@ -73,7 +73,7 @@ class AttachmentServiceImpl(
     }
 
     @Transactional
-    override fun createAttachments(attachments: List<AttachmentEntity>?): List<AttachmentResponse>? {
+    override fun createAttachmentResponses(attachments: List<AttachmentEntity>?): List<AttachmentResponse>{
         val list = mutableListOf<AttachmentResponse>()
         if (attachments != null) {
             for (attachment in attachments) {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/service/AttachmentService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/service/AttachmentService.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.csereal.core.resource.attachment.service
 
 import com.wafflestudio.csereal.common.controller.AttachmentContentEntityType
+import com.wafflestudio.csereal.common.properties.EndpointProperties
 import com.wafflestudio.csereal.core.about.database.AboutEntity
 import com.wafflestudio.csereal.core.academics.database.AcademicsEntity
 import com.wafflestudio.csereal.core.academics.database.CourseEntity
@@ -37,6 +38,7 @@ class AttachmentServiceImpl(
     private val attachmentRepository: AttachmentRepository,
     @Value("\${csereal_attachment.upload.path}")
     private val path: String,
+    private val endpointProperties: EndpointProperties,
 ) : AttachmentService {
     override fun uploadAttachmentInLabEntity(labEntity: LabEntity, requestAttachment: MultipartFile): AttachmentDto {
         Files.createDirectories(Paths.get(path))
@@ -112,7 +114,7 @@ class AttachmentServiceImpl(
             for (attachment in attachments) {
                 val attachmentDto = AttachmentResponse(
                     name = attachment.filename,
-                    url = "http://cse-dev-waffle.bacchus.io/attachment/${attachment.filename}",
+                    url = "${endpointProperties.backend}/v1/attachment/${attachment.filename}",
                     bytes = attachment.size,
                 )
                 list.add(attachmentDto)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/introductionMaterial/dto/introductionMaterialDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/introductionMaterial/dto/introductionMaterialDto.kt
@@ -1,8 +1,0 @@
-package com.wafflestudio.csereal.core.resource.introductionMaterial.dto
-
-// Todo: IntroductionMaterial이 연구실에만 쓰이는지 확인할 것
-data class IntroductionMaterialDto(
-    val pdf: String?,
-    val youtube: String?,
-) {
-}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/mainImage/service/MainImageService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/mainImage/service/MainImageService.kt
@@ -29,7 +29,6 @@ interface MainImageService {
         contentEntityType: MainImageContentEntityType,
         requestImage: MultipartFile,
     ): MainImageDto
-
     fun createImageURL(image: MainImageEntity?): String?
 }
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/mainImage/service/MainImageService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/mainImage/service/MainImageService.kt
@@ -1,12 +1,13 @@
 package com.wafflestudio.csereal.core.resource.mainImage.service
 
 import com.wafflestudio.csereal.common.CserealException
-import com.wafflestudio.csereal.common.controller.ImageContentEntityType
+import com.wafflestudio.csereal.common.controller.MainImageContentEntityType
 import com.wafflestudio.csereal.common.properties.EndpointProperties
 import com.wafflestudio.csereal.core.about.database.AboutEntity
 import com.wafflestudio.csereal.core.member.database.ProfessorEntity
 import com.wafflestudio.csereal.core.member.database.StaffEntity
 import com.wafflestudio.csereal.core.news.database.NewsEntity
+import com.wafflestudio.csereal.core.research.database.ResearchEntity
 import com.wafflestudio.csereal.core.resource.mainImage.database.MainImageRepository
 import com.wafflestudio.csereal.core.resource.mainImage.database.MainImageEntity
 import com.wafflestudio.csereal.core.resource.mainImage.dto.MainImageDto
@@ -25,7 +26,7 @@ import kotlin.io.path.name
 
 interface MainImageService {
     fun uploadMainImage(
-        contentEntityType: ImageContentEntityType,
+        contentEntityType: MainImageContentEntityType,
         requestImage: MultipartFile,
     ): MainImageDto
 
@@ -42,7 +43,7 @@ class MainImageServiceImpl(
 
     @Transactional
     override fun uploadMainImage(
-        contentEntityType: ImageContentEntityType,
+        contentEntityType: MainImageContentEntityType,
         requestImage: MultipartFile,
     ): MainImageDto {
         Files.createDirectories(Paths.get(path))
@@ -94,7 +95,7 @@ class MainImageServiceImpl(
         } else null
     }
 
-    private fun connectMainImageToEntity(contentEntity: ImageContentEntityType, mainImage: MainImageEntity) {
+    private fun connectMainImageToEntity(contentEntity: MainImageContentEntityType, mainImage: MainImageEntity) {
         when (contentEntity) {
             is NewsEntity -> {
                 contentEntity.mainImage = mainImage
@@ -116,6 +117,9 @@ class MainImageServiceImpl(
                 contentEntity.mainImage = mainImage
             }
 
+            is ResearchEntity -> {
+                contentEntity.mainImage = mainImage
+            }
             else -> {
                 throw WrongMethodTypeException("해당하는 엔티티가 없습니다")
             }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarEntity.kt
@@ -2,7 +2,7 @@ package com.wafflestudio.csereal.core.seminar.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
 import com.wafflestudio.csereal.common.controller.AttachmentContentEntityType
-import com.wafflestudio.csereal.common.controller.ImageContentEntityType
+import com.wafflestudio.csereal.common.controller.MainImageContentEntityType
 import com.wafflestudio.csereal.core.resource.attachment.database.AttachmentEntity
 import com.wafflestudio.csereal.core.resource.mainImage.database.MainImageEntity
 import com.wafflestudio.csereal.core.seminar.dto.SeminarDto
@@ -47,7 +47,7 @@ class SeminarEntity(
     @OneToMany(mappedBy = "seminar", cascade = [CascadeType.ALL], orphanRemoval = true)
     var attachments: MutableList<AttachmentEntity> = mutableListOf(),
 
-    ): BaseTimeEntity(), ImageContentEntityType, AttachmentContentEntityType {
+    ): BaseTimeEntity(), MainImageContentEntityType, AttachmentContentEntityType {
     override fun bringMainImage(): MainImageEntity? = mainImage
     override fun bringAttachments() = attachments
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/dto/SeminarDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/dto/SeminarDto.kt
@@ -34,7 +34,7 @@ data class SeminarDto(
 ) {
 
     companion object {
-        fun of(entity: SeminarEntity, imageURL: String?, attachments: List<AttachmentResponse>?, prevNext: Array<SeminarEntity?>?): SeminarDto = entity.run {
+        fun of(entity: SeminarEntity, imageURL: String?, attachmentResponses: List<AttachmentResponse>, prevNext: Array<SeminarEntity?>?): SeminarDto = entity.run {
             SeminarDto(
                 id = this.id,
                 title = this.title,
@@ -60,7 +60,7 @@ data class SeminarDto(
                 nextId = prevNext?.get(1)?.id,
                 nextTitle = prevNext?.get(1)?.title,
                 imageURL = imageURL,
-                attachments = attachments,
+                attachments = attachmentResponses,
             )
         }
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/service/SeminarService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/service/SeminarService.kt
@@ -84,8 +84,7 @@ class SeminarServiceImpl(
 
         val imageURL = mainImageService.createImageURL(seminar.mainImage)
         val attachmentResponses = attachmentService.createAttachmentResponses(seminar.attachments)
-
-
+        
         return SeminarDto.of(seminar, imageURL, attachmentResponses, null)
     }
     @Transactional

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/service/SeminarService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/service/SeminarService.kt
@@ -40,7 +40,7 @@ class SeminarServiceImpl(
         }
 
         if(attachments != null) {
-            attachmentService.uploadAttachments(newSeminar, attachments)
+            attachmentService.uploadAllAttachments(newSeminar, attachments)
         }
 
         seminarRepository.save(newSeminar)
@@ -79,7 +79,7 @@ class SeminarServiceImpl(
 
         if(attachments != null) {
             seminar.attachments.clear()
-            attachmentService.uploadAttachments(seminar, attachments)
+            attachmentService.uploadAllAttachments(seminar, attachments)
         }
 
         val imageURL = mainImageService.createImageURL(seminar.mainImage)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/service/SeminarService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/service/SeminarService.kt
@@ -46,8 +46,8 @@ class SeminarServiceImpl(
         seminarRepository.save(newSeminar)
 
         val imageURL = mainImageService.createImageURL(newSeminar.mainImage)
-        val attachments = attachmentService.createAttachments(newSeminar.attachments)
-        return SeminarDto.of(newSeminar, imageURL, attachments, null)
+        val attachmentResponses = attachmentService.createAttachmentResponses(newSeminar.attachments)
+        return SeminarDto.of(newSeminar, imageURL, attachmentResponses, null)
     }
 
     @Transactional(readOnly = true)
@@ -58,11 +58,11 @@ class SeminarServiceImpl(
         if (seminar.isDeleted) throw CserealException.Csereal400("삭제된 세미나입니다. (seminarId: $seminarId)")
 
         val imageURL = mainImageService.createImageURL(seminar.mainImage)
-        val attachments = attachmentService.createAttachments(seminar.attachments)
+        val attachmentResponses = attachmentService.createAttachmentResponses(seminar.attachments)
 
         val prevNext = seminarRepository.findPrevNextId(seminarId, keyword)
 
-        return SeminarDto.of(seminar, imageURL, attachments, prevNext)
+        return SeminarDto.of(seminar, imageURL, attachmentResponses, prevNext)
     }
 
     @Transactional
@@ -83,10 +83,10 @@ class SeminarServiceImpl(
         }
 
         val imageURL = mainImageService.createImageURL(seminar.mainImage)
-        val attachments = attachmentService.createAttachments(seminar.attachments)
+        val attachmentResponses = attachmentService.createAttachmentResponses(seminar.attachments)
 
 
-        return SeminarDto.of(seminar, imageURL, attachments, null)
+        return SeminarDto.of(seminar, imageURL, attachmentResponses, null)
     }
     @Transactional
     override fun deleteSeminar(seminarId: Long) {


### PR DESCRIPTION
## 제목
fix: research 패키지 프론트에 맞춰 협의

### 한줄 요약
research 패키지에서 프론트에서 요구하는 request을 맞췄으며, 이를 위해 mainImage와 첨부파일을 추가했습니다.
첨부파일은 원래는 없는데, 혹시나 필요할 수도 있어서 추가했습니다

### 상세 설명

[a1783da]: professor, staff의 update에서도 mainImage 등록이 가능하도록 추가했습니다.

[069212e]: research에서 isPublic을 제거했고, lab에도 첨부파일을 추가할 수 있도록 했습니다. 

[70c9e37]: 저번에 반영하라고 했던 attachmentResponses가 안보여서, 다시 반영했습니다. attachmentResponses는 null이 아니라 빈리스트를 반환하도록 했습니다.

[bda70ef]: 프론트의 request을 보니 교수님에서 id와 name을 같이 요구해서 그렇게 수정했습니다.

[b52619f]: lab은 첨부파일이 list가 아니라 단일항목이었습니다. 이걸 그냥 request는 list로 하고 단일항목만 제시할지, 아니면 request도 단일항목으로 할지 많이 고민했는데, lab에서는 request가 항상 하나일 거 같아서 단일항목으로 하도록 했습니다. uploadAttachments도 하나만 보낼 수 있도록 uploadAttachmentInLabEntity를 따로 만들었습니다. 단일항목을 받는게 labEntity 말고 하나가 더 생기면 contentEntityType을 추가할 거 같은데, 아직은 하나라서 labEntity를 받도록 했습니다.

[af19681]: 프론트의 요구조건을 보니 개별 lab을 보는 것도 있어서 추가했습니다.

[b5f6a6b]: 불필요한 내용을 삭제하고, 연구그룹에서 lab의 id와 이름을 동시에 물어서 response을 추가했습니다.

[2975ebdd6603a78a4a0c7af82e0c0d6e72451294]: 연구그룹에서 imageURL을 요구하고 있어 mainImage을 추가했고, 혹시 몰라서 attachments도 추가했습니다.

### TODO

다른 패키지들 프론트의 요구사항에 맞추고, 관리자 페이지 만들어야 합니다.
