### PR TITLE
[CICD] mainImage, attachment 경로 mount 설정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,21 @@
 FROM openjdk:17-slim
 
+# Set profile
 ARG PROFILE
 ENV profile=$PROFILE
 
+# Set workdir as /app
 RUN mkdir /app
 WORKDIR /app
 
+# Copy jar file
 COPY ./build/libs/*.jar /app/app.jar
 
+# Make directories to mount
+RUN mkdir /app/mainImage
+RUN mkdir /app/attachment
+
+# Expose port 8080
 EXPOSE 8080
 
 ENTRYPOINT java -Dspring.profiles.active=$profile -jar app.jar

--- a/docker-compose-backend.yml
+++ b/docker-compose-backend.yml
@@ -7,6 +7,9 @@ services:
         PROFILE: ${PROFILE}
     ports:
       - 8080:8080
+    volumes:
+      - ./mainImage:/app/mainImage
+      - ./attachment:/app/attachment
     environment:
       SPRING_DATASOURCE_URL: "jdbc:mysql://host.docker.internal:3306/${MYSQL_DATABASE}?serverTimezone=Asia/Seoul&useSSL=false&allowPublicKeyRetrieval=true"
       SPRING_DATASOURCE_USERNAME: ${MYSQL_USER}
@@ -25,6 +28,9 @@ services:
 #        PROFILE: ${PROFILE}
 #    ports:
 #      - 8081:8080
+#    volumes:
+#      - ./mainImage:/app/mainImage
+#      - ./attachment:/app/attachment
 #    environment:
 #      SPRING_DATASOURCE_URL: "jdbc:mysql://host.docker.internal:3306/${MYSQL_DATABASE}?serverTimezone=Asia/Seoul&useSSL=false&allowPublicKeyRetrieval=true"
 #      SPRING_DATASOURCE_USERNAME: ${MYSQL_USER}


### PR DESCRIPTION
## [CICD] mainImage, attachment 경로 mount 설정

### 상세 설명

[c976e84bc317a8073526b6f924318ffdddc8b309]: [CICD: Add mainImage, attachment directory for mounting](https://github.com/wafflestudio/csereal-server/commit/c976e84bc317a8073526b6f924318ffdddc8b309)

[d01df3a8c4e3d0512addcce5ae9dcb5457b487fd]: [CICD: Add volumes to mount with server directory. (for attachment)](https://github.com/wafflestudio/csereal-server/commit/d01df3a8c4e3d0512addcce5ae9dcb5457b487fd)

