### PR TITLE
fix: 예약 dto에 지도교수, 반복 횟수 추가

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/reservation/database/ReservationEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/reservation/database/ReservationEntity.kt
@@ -30,6 +30,8 @@ class ReservationEntity(
     val purpose: String,
     val startTime: LocalDateTime,
     val endTime: LocalDateTime,
+    val professor: String,
+    val recurringWeeks: Int = 1,
 
     val recurrenceId: UUID? = null
 
@@ -61,6 +63,8 @@ class ReservationEntity(
                 purpose = reserveRequest.purpose,
                 startTime = start,
                 endTime = end,
+                professor = reserveRequest.professor,
+                recurringWeeks = reserveRequest.recurringWeeks,
                 recurrenceId = recurrenceId
             )
         }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/reservation/dto/ReservationDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/reservation/dto/ReservationDto.kt
@@ -11,11 +11,13 @@ data class ReservationDto(
     val purpose: String,
     val startTime: LocalDateTime,
     val endTime: LocalDateTime,
+    val recurringWeeks: Int = 1,
     val roomName: String?,
     val roomLocation: String,
     val userName: String,
     val contactEmail: String,
-    val contactPhone: String
+    val contactPhone: String,
+    val professor: String
 ) {
     companion object {
         fun of(reservationEntity: ReservationEntity): ReservationDto {
@@ -26,11 +28,13 @@ data class ReservationDto(
                 purpose = reservationEntity.purpose,
                 startTime = reservationEntity.startTime,
                 endTime = reservationEntity.endTime,
+                recurringWeeks = reservationEntity.recurringWeeks,
                 roomName = reservationEntity.room.name,
                 roomLocation = reservationEntity.room.location,
                 userName = reservationEntity.user.username,
                 contactEmail = reservationEntity.contactEmail,
-                contactPhone = reservationEntity.contactPhone
+                contactPhone = reservationEntity.contactPhone,
+                professor = reservationEntity.professor
             )
         }
     }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/reservation/dto/ReserveRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/reservation/dto/ReserveRequest.kt
@@ -7,8 +7,9 @@ data class ReserveRequest(
     val title: String,
     val contactEmail: String,
     val contactPhone: String,
+    val professor: String,
     val purpose: String,
     val startTime: LocalDateTime,
     val endTime: LocalDateTime,
-    val recurringWeeks: Int? = null
+    val recurringWeeks: Int = 1
 )

--- a/src/main/kotlin/com/wafflestudio/csereal/core/reservation/service/ReservationService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/reservation/service/ReservationService.kt
@@ -52,7 +52,7 @@ class ReservationServiceImpl(
 
         val recurrenceId = UUID.randomUUID()
 
-        val numberOfWeeks = reserveRequest.recurringWeeks ?: 1
+        val numberOfWeeks = reserveRequest.recurringWeeks
 
         for (week in 0 until numberOfWeeks) {
             val start = reserveRequest.startTime.plusWeeks(week.toLong())


### PR DESCRIPTION
## 예약 dto 변경

### 한줄 요약

예약 GET API 응답에 지도교수, 반복 횟수를 추가하였습니다. 반복 횟수는 처음 설정한 횟수이고 개별 삭제에 따른 변경은 없습니다.

### 상세 설명

[df3516d7a7d3d05ba3e44b4856728273fd300498]: 예약 응답 수정
