### PR TITLE
[Fix] Notice, News Description TEXT type으로 변환

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsEntity.kt
@@ -15,7 +15,7 @@ class NewsEntity(
 
     var title: String,
 
-    @Column(columnDefinition = "text")
+    @Column(columnDefinition = "mediumtext")
     var description: String,
 
     var isPublic: Boolean,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsEntity.kt
@@ -15,6 +15,7 @@ class NewsEntity(
 
     var title: String,
 
+    @Column(columnDefinition = "text")
     var description: String,
 
     var isPublic: Boolean,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeEntity.kt
@@ -13,7 +13,7 @@ class NoticeEntity(
     var isDeleted: Boolean = false,
     var title: String,
 
-    @Column(columnDefinition = "text")
+    @Column(columnDefinition = "mediumtext")
     var description: String,
 
     var isPublic: Boolean,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeEntity.kt
@@ -12,7 +12,10 @@ import jakarta.persistence.*
 class NoticeEntity(
     var isDeleted: Boolean = false,
     var title: String,
+
+    @Column(columnDefinition = "text")
     var description: String,
+
     var isPublic: Boolean,
     var isPinned: Boolean,
     var isImportant: Boolean,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarEntity.kt
@@ -15,10 +15,10 @@ class SeminarEntity(
 
     var title: String,
 
-    @Column(columnDefinition = "text")
+    @Column(columnDefinition = "mediumtext")
     var description: String,
 
-    @Column(columnDefinition = "text")
+    @Column(columnDefinition = "mediumtext")
     var introduction: String,
 
     // 연사 정보


### PR DESCRIPTION
## [Fix] Notice, News Description TEXT type으로 변환

### 상세 설명

[`fe64775d26a5c30d7cc4949eb31f5264b160aa78`]: [Fix: Change notice and news entity description type as TEXT.](https://github.com/wafflestudio/csereal-server/commit/fe64775d26a5c30d7cc4949eb31f5264b160aa78)

### ELSE

서버 DB는 제가 수동으로 수정하였습니다.