### PR TITLE
fix: newsSearchResponse, seminarSearchResponse 수정

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsRepository.kt
@@ -136,7 +136,7 @@ class NewsRepositoryImpl(
         return prevNext
     }
     private fun clean(description: String): String {
-        val summary = Jsoup.clean(description, Safelist.none())
-        return Parser.unescapeEntities(summary, false)
+        val cleanDescription = Jsoup.clean(description, Safelist.none())
+        return Parser.unescapeEntities(cleanDescription, false)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsRepository.kt
@@ -7,6 +7,7 @@ import com.wafflestudio.csereal.core.news.database.QNewsEntity.newsEntity
 import com.wafflestudio.csereal.core.news.database.QNewsTagEntity.newsTagEntity
 import com.wafflestudio.csereal.core.news.dto.NewsSearchDto
 import com.wafflestudio.csereal.core.news.dto.NewsSearchResponse
+import com.wafflestudio.csereal.core.resource.mainImage.service.MainImageService
 import org.jsoup.Jsoup
 import org.jsoup.parser.Parser
 import org.jsoup.safety.Safelist
@@ -25,6 +26,7 @@ interface CustomNewsRepository {
 @Component
 class NewsRepositoryImpl(
     private val queryFactory: JPAQueryFactory,
+    private val mainImageService: MainImageService,
 ) : CustomNewsRepository {
     override fun searchNews(tag: List<String>?, keyword: String?, pageNum: Long): NewsSearchResponse {
         val keywordBooleanBuilder = BooleanBuilder()
@@ -66,12 +68,14 @@ class NewsRepositoryImpl(
             .fetch()
 
         val newsSearchDtoList : List<NewsSearchDto> = newsEntityList.map {
+            val imageURL = mainImageService.createImageURL(it.mainImage)
             NewsSearchDto(
                 id = it.id,
                 title = it.title,
-                summary = summary(it.description),
+                description = clean(it.description),
                 createdAt = it.createdAt,
-                tags = it.newsTags.map { newsTagEntity -> newsTagEntity.tag.id }
+                tags = it.newsTags.map { newsTagEntity -> newsTagEntity.tag.name },
+                imageURL = imageURL
             )
         }
         return NewsSearchResponse(total, newsSearchDtoList)
@@ -131,7 +135,7 @@ class NewsRepositoryImpl(
 
         return prevNext
     }
-    private fun summary(description: String): String {
+    private fun clean(description: String): String {
         val summary = Jsoup.clean(description, Safelist.none())
         return Parser.unescapeEntities(summary, false)
     }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/dto/NewsSearchDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/dto/NewsSearchDto.kt
@@ -6,7 +6,8 @@ import java.time.LocalDateTime
 data class NewsSearchDto @QueryProjection constructor(
     val id: Long,
     val title: String,
-    var summary: String,
+    var description: String,
     val createdAt: LocalDateTime?,
-    var tags: List<Long>?
+    var tags: List<String>?,
+    var imageURL: String?,
 )

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarRepository.kt
@@ -3,9 +3,13 @@ package com.wafflestudio.csereal.core.seminar.database
 import com.querydsl.core.BooleanBuilder
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.wafflestudio.csereal.common.CserealException
+import com.wafflestudio.csereal.core.resource.mainImage.service.MainImageService
 import com.wafflestudio.csereal.core.seminar.database.QSeminarEntity.seminarEntity
 import com.wafflestudio.csereal.core.seminar.dto.SeminarSearchDto
 import com.wafflestudio.csereal.core.seminar.dto.SeminarSearchResponse
+import org.jsoup.Jsoup
+import org.jsoup.parser.Parser
+import org.jsoup.safety.Safelist
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Component
 
@@ -20,6 +24,7 @@ interface CustomSeminarRepository {
 @Component
 class SeminarRepositoryImpl(
     private val queryFactory: JPAQueryFactory,
+    private val mainImageService: MainImageService,
 ) : CustomSeminarRepository {
     override fun searchSeminar(keyword: String?, pageNum: Long): SeminarSearchResponse {
         val keywordBooleanBuilder = BooleanBuilder()
@@ -61,15 +66,19 @@ class SeminarRepositoryImpl(
                 isYearLast = true
             }
 
+            val imageURL = mainImageService.createImageURL(seminarEntityList[i].mainImage)
+
             seminarSearchDtoList.add(
                 SeminarSearchDto(
                     id = seminarEntityList[i].id,
                     title = seminarEntityList[i].title,
-                    startDate = seminarEntityList[i].startDate,
-                    isYearLast = isYearLast,
+                    description = clean(seminarEntityList[i].description),
                     name = seminarEntityList[i].name,
                     affiliation = seminarEntityList[i].affiliation,
-                    location = seminarEntityList[i].location
+                    startDate = seminarEntityList[i].startDate,
+                    location = seminarEntityList[i].location,
+                    imageURL = imageURL,
+                    isYearLast = isYearLast,
                 )
             )
         }
@@ -118,5 +127,10 @@ class SeminarRepositoryImpl(
 
         return prevNext
 
+    }
+
+    private fun clean(description: String): String {
+        val cleanDescription = Jsoup.clean(description, Safelist.none())
+        return Parser.unescapeEntities(cleanDescription, false)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/dto/SeminarSearchDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/dto/SeminarSearchDto.kt
@@ -7,7 +7,7 @@ data class SeminarSearchDto @QueryProjection constructor(
     val title: String,
     val description: String,
     val name: String,
-    val affiliation: String?,
+    val affiliation: String,
     val startDate: String?,
     val location: String,
     val imageURL: String?,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/dto/SeminarSearchDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/dto/SeminarSearchDto.kt
@@ -5,10 +5,12 @@ import com.querydsl.core.annotations.QueryProjection
 data class SeminarSearchDto @QueryProjection constructor(
     val id: Long,
     val title: String,
-    val startDate: String?,
-    val isYearLast: Boolean,
+    val description: String,
     val name: String,
     val affiliation: String?,
-    val location: String
+    val startDate: String?,
+    val location: String,
+    val imageURL: String?,
+    val isYearLast: Boolean,
 ) {
 }


### PR DESCRIPTION
## 제목
fix: newsSearchResponse, seminarSearchResponse 수정

### 한줄 요약
newsSearchResponse, seminarSearchResponse을 프론트가 원하는 정보로 수정했습니다.

PR 요약해주세요

### 상세 설명

[42bf4afc10c4164494cd762447e0ab6e656a5c5b]: newsSearchResponse에서 imageURL을 추가했고, 태그를 이름으로 바꿨습니다.

[bf94c43c7d21892ddae2fdd132473dcfe97584e6]: SeminarSearchResponse에서 imageURL과 description을 추가했습니다. 원래 백에서 글자수를 짧게 해달라고 들었는데, 프론트에서 딱히 그런 이야기가 없어서 풀로 보내드리고, 이름을 summary에서 clean으로 바꿨습니다.

### TODO

원래 fix_with_front3을 만들다가, news와 seminar 전체목록을 알려달라고 해서 이걸 먼저 만들었습니다. 지금 3에서는 학사 및 교과와 관리자 페이지를 만들고 있습니다.
