### PR TITLE
fix: total 쿼리 최적화

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/dto/NewsSearchResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/dto/NewsSearchResponse.kt
@@ -4,7 +4,7 @@ import com.querydsl.core.annotations.QueryProjection
 import java.time.LocalDateTime
 
 class NewsSearchResponse @QueryProjection constructor(
-    val total: Int,
+    val total: Long,
     val searchList: List<NewsSearchDto>
 ) {
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/NoticeSearchResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/NoticeSearchResponse.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.notice.dto
 
 data class NoticeSearchResponse(
-    val total: Int,
+    val total: Long,
     val searchList: List<NoticeSearchDto>
 ) {
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarRepository.kt
@@ -44,20 +44,25 @@ class SeminarRepositoryImpl(
             .where(seminarEntity.isDeleted.eq(false))
             .where(keywordBooleanBuilder)
 
-        val total = jpaQuery.fetch().size
+        val countQuery = jpaQuery.clone()
+        val total = countQuery.select(seminarEntity.countDistinct()).fetchOne()
 
         val seminarEntityList = jpaQuery.orderBy(seminarEntity.createdAt.desc())
-            .offset(10*pageNum)
+            .offset(10 * pageNum)
             .limit(20)
             .fetch()
 
-        val seminarSearchDtoList : MutableList<SeminarSearchDto> = mutableListOf()
+        val seminarSearchDtoList: MutableList<SeminarSearchDto> = mutableListOf()
 
-        for(i: Int in 0 until seminarEntityList.size) {
+        for (i: Int in 0 until seminarEntityList.size) {
             var isYearLast = false
-            if(i == seminarEntityList.size-1) {
+            if (i == seminarEntityList.size - 1) {
                 isYearLast = true
-            } else if(seminarEntityList[i].startDate?.substring(0,4) != seminarEntityList[i+1].startDate?.substring(0,4)) {
+            } else if (seminarEntityList[i].startDate?.substring(0, 4) != seminarEntityList[i + 1].startDate?.substring(
+                    0,
+                    4
+                )
+            ) {
                 isYearLast = true
             }
 
@@ -74,8 +79,9 @@ class SeminarRepositoryImpl(
             )
         }
 
-        return SeminarSearchResponse(total, seminarSearchDtoList)
+        return SeminarSearchResponse(total!!, seminarSearchDtoList)
     }
+
     override fun findPrevNextId(seminarId: Long, keyword: String?): Array<SeminarEntity?>? {
         val keywordBooleanBuilder = BooleanBuilder()
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/dto/SeminarSearchResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/dto/SeminarSearchResponse.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.seminar.dto
 
 data class SeminarSearchResponse(
-    val total: Int,
+    val total: Long,
     val searchList: List<SeminarSearchDto>
 ) {
 }


### PR DESCRIPTION
## 공지사항,새소식,세미나 total 쿼리 수정

### 한줄 요약

프론트에서 공지사항 GET이 너무 느리다는 얘기가 있어서(4초가 넘음) total 쿼리를 갯수만 가져오도록 해보았습니다. 실제로 어느정도 성능 이점이 있을지는 배포 후 테스트 해봐야 할것 같습니다.

### 상세 설명

[aa10834605cfef10a5c85cc41e5c546d2cdc0256]: 쿼리 최적화
