### PR TITLE
Fix: additional note column type to text

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarEntity.kt
@@ -40,6 +40,7 @@ class SeminarEntity(
     var isPublic: Boolean,
     var isImportant: Boolean,
 
+    @Column(columnDefinition = "text")
     var additionalNote: String?,
 
     @OneToOne


### PR DESCRIPTION
## Fix: additional note column type to text

### 한줄 요약

seminar 테이블의 additional note의 경우 길어지는 데이터가 존재하여 TEXT type으로 변경합니다.

### 상세 설명

[`fb68ba97be8abbbd959d1d0e7b3b3df0704f1443`]: [Fix: Change type of additionalNote column on SeminarEntity to "TEXT"](https://github.com/wafflestudio/csereal-server/commit/fb68ba97be8abbbd959d1d0e7b3b3df0704f1443)

