### PR TITLE
Refactor: HTML로부터 텍스트 추출 함수 Utils로 이동

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/common/Utils.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/Utils.kt
@@ -1,0 +1,10 @@
+package com.wafflestudio.csereal.common
+
+import org.jsoup.Jsoup
+import org.jsoup.parser.Parser
+import org.jsoup.safety.Safelist
+
+fun cleanTextFromHtml(description: String): String {
+    val cleanDescription = Jsoup.clean(description, Safelist.none())
+    return Parser.unescapeEntities(cleanDescription, false)
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsRepository.kt
@@ -9,9 +9,6 @@ import com.wafflestudio.csereal.core.news.database.QNewsTagEntity.newsTagEntity
 import com.wafflestudio.csereal.core.news.dto.NewsSearchDto
 import com.wafflestudio.csereal.core.news.dto.NewsSearchResponse
 import com.wafflestudio.csereal.core.resource.mainImage.service.MainImageService
-import org.jsoup.Jsoup
-import org.jsoup.parser.Parser
-import org.jsoup.safety.Safelist
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Component
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsRepository.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.csereal.core.news.database
 import com.querydsl.core.BooleanBuilder
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.wafflestudio.csereal.common.CserealException
+import com.wafflestudio.csereal.common.cleanTextFromHtml
 import com.wafflestudio.csereal.core.news.database.QNewsEntity.newsEntity
 import com.wafflestudio.csereal.core.news.database.QNewsTagEntity.newsTagEntity
 import com.wafflestudio.csereal.core.news.dto.NewsSearchDto
@@ -73,7 +74,7 @@ class NewsRepositoryImpl(
             NewsSearchDto(
                 id = it.id,
                 title = it.title,
-                description = clean(it.description),
+                description = cleanTextFromHtml(it.description),
                 createdAt = it.createdAt,
                 tags = it.newsTags.map { newsTagEntity -> newsTagEntity.tag.name },
                 imageURL = imageURL
@@ -135,10 +136,5 @@ class NewsRepositoryImpl(
         }
 
         return prevNext
-    }
-    
-    private fun clean(description: String): String {
-        val cleanDescription = Jsoup.clean(description, Safelist.none())
-        return Parser.unescapeEntities(cleanDescription, false)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarRepository.kt
@@ -8,9 +8,6 @@ import com.wafflestudio.csereal.core.resource.mainImage.service.MainImageService
 import com.wafflestudio.csereal.core.seminar.database.QSeminarEntity.seminarEntity
 import com.wafflestudio.csereal.core.seminar.dto.SeminarSearchDto
 import com.wafflestudio.csereal.core.seminar.dto.SeminarSearchResponse
-import org.jsoup.Jsoup
-import org.jsoup.parser.Parser
-import org.jsoup.safety.Safelist
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Component
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarRepository.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.csereal.core.seminar.database
 import com.querydsl.core.BooleanBuilder
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.wafflestudio.csereal.common.CserealException
+import com.wafflestudio.csereal.common.cleanTextFromHtml
 import com.wafflestudio.csereal.core.resource.mainImage.service.MainImageService
 import com.wafflestudio.csereal.core.seminar.database.QSeminarEntity.seminarEntity
 import com.wafflestudio.csereal.core.seminar.dto.SeminarSearchDto
@@ -78,7 +79,7 @@ class SeminarRepositoryImpl(
                 SeminarSearchDto(
                     id = seminarEntityList[i].id,
                     title = seminarEntityList[i].title,
-                    description = clean(seminarEntityList[i].description),
+                    description = cleanTextFromHtml(seminarEntityList[i].description),
                     name = seminarEntityList[i].name,
                     affiliation = seminarEntityList[i].affiliation,
                     startDate = seminarEntityList[i].startDate,
@@ -134,10 +135,5 @@ class SeminarRepositoryImpl(
 
         return prevNext
 
-    }
-
-    private fun clean(description: String): String {
-        val cleanDescription = Jsoup.clean(description, Safelist.none())
-        return Parser.unescapeEntities(cleanDescription, false)
     }
 }


### PR DESCRIPTION
## Refactor: HTML로부터 텍스트 추출 함수 Utils로 이동

PR 요약해주세요

### 상세 설명

[0bba532] Feat: Add cleanTextFromHtml.
[e15d181] Refactor: Remove private clean method, replace to Utils.cleanTextFromHtml.
[834b847] Refactor: Remove unused imports.