### PR TITLE
Feat: Add plain text description for notice

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/common/Utils.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/Utils.kt
@@ -1,0 +1,10 @@
+package com.wafflestudio.csereal.common
+
+import org.jsoup.Jsoup
+import org.jsoup.parser.Parser
+import org.jsoup.safety.Safelist
+
+fun cleanTextFromHtml(description: String): String {
+    val cleanDescription = Jsoup.clean(description, Safelist.none())
+    return Parser.unescapeEntities(cleanDescription, false)
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsRepository.kt
@@ -9,9 +9,6 @@ import com.wafflestudio.csereal.core.news.database.QNewsTagEntity.newsTagEntity
 import com.wafflestudio.csereal.core.news.dto.NewsSearchDto
 import com.wafflestudio.csereal.core.news.dto.NewsSearchResponse
 import com.wafflestudio.csereal.core.resource.mainImage.service.MainImageService
-import org.jsoup.Jsoup
-import org.jsoup.parser.Parser
-import org.jsoup.safety.Safelist
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Component
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsRepository.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.csereal.core.news.database
 import com.querydsl.core.BooleanBuilder
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.wafflestudio.csereal.common.CserealException
+import com.wafflestudio.csereal.common.cleanTextFromHtml
 import com.wafflestudio.csereal.core.news.database.QNewsEntity.newsEntity
 import com.wafflestudio.csereal.core.news.database.QNewsTagEntity.newsTagEntity
 import com.wafflestudio.csereal.core.news.dto.NewsSearchDto
@@ -73,7 +74,7 @@ class NewsRepositoryImpl(
             NewsSearchDto(
                 id = it.id,
                 title = it.title,
-                description = clean(it.description),
+                description = cleanTextFromHtml(it.description),
                 createdAt = it.createdAt,
                 tags = it.newsTags.map { newsTagEntity -> newsTagEntity.tag.name },
                 imageURL = imageURL
@@ -135,10 +136,5 @@ class NewsRepositoryImpl(
         }
 
         return prevNext
-    }
-    
-    private fun clean(description: String): String {
-        val cleanDescription = Jsoup.clean(description, Safelist.none())
-        return Parser.unescapeEntities(cleanDescription, false)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeEntity.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.csereal.core.notice.database
 
+import com.wafflestudio.csereal.common.cleanTextFromHtml
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
 import com.wafflestudio.csereal.common.controller.AttachmentContentEntityType
 import com.wafflestudio.csereal.core.notice.dto.NoticeDto
@@ -36,6 +37,11 @@ class NoticeEntity(
     override fun bringAttachments() = attachments
 
     fun update(updateNoticeRequest: NoticeDto) {
+        // Update plainTextDescription if description is changed
+        if (updateNoticeRequest.description != this.description) {
+            this.plainTextDescription = cleanTextFromHtml(updateNoticeRequest.description)
+        }
+
         this.title = updateNoticeRequest.title
         this.description = updateNoticeRequest.description
         this.isPublic = updateNoticeRequest.isPublic

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeEntity.kt
@@ -14,6 +14,10 @@ class NoticeEntity(
     var title: String,
     @Column(columnDefinition = "mediumtext")
     var description: String,
+
+    @Column(columnDefinition = "mediumtext")
+    var plainTextDescription: String,
+
     var isPublic: Boolean,
     var isPinned: Boolean,
     var isImportant: Boolean,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
@@ -138,8 +138,6 @@ class NoticeServiceImpl(
         val attachmentResponses = attachmentService.createAttachmentResponses(notice.attachments)
 
         return NoticeDto.of(notice, attachmentResponses, null)
-
-
     }
 
     @Transactional

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.csereal.core.notice.service
 
 import com.wafflestudio.csereal.common.CserealException
+import com.wafflestudio.csereal.common.cleanTextFromHtml
 import com.wafflestudio.csereal.core.notice.database.*
 import com.wafflestudio.csereal.core.notice.dto.*
 import com.wafflestudio.csereal.core.resource.attachment.service.AttachmentService
@@ -79,6 +80,7 @@ class NoticeServiceImpl(
         val newNotice = NoticeEntity(
             title = request.title,
             description = request.description,
+            plainTextDescription = cleanTextFromHtml(request.description),
             isPublic = request.isPublic,
             isPinned = request.isPinned,
             isImportant = request.isImportant,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarRepository.kt
@@ -8,9 +8,6 @@ import com.wafflestudio.csereal.core.resource.mainImage.service.MainImageService
 import com.wafflestudio.csereal.core.seminar.database.QSeminarEntity.seminarEntity
 import com.wafflestudio.csereal.core.seminar.dto.SeminarSearchDto
 import com.wafflestudio.csereal.core.seminar.dto.SeminarSearchResponse
-import org.jsoup.Jsoup
-import org.jsoup.parser.Parser
-import org.jsoup.safety.Safelist
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Component
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarRepository.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.csereal.core.seminar.database
 import com.querydsl.core.BooleanBuilder
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.wafflestudio.csereal.common.CserealException
+import com.wafflestudio.csereal.common.cleanTextFromHtml
 import com.wafflestudio.csereal.core.resource.mainImage.service.MainImageService
 import com.wafflestudio.csereal.core.seminar.database.QSeminarEntity.seminarEntity
 import com.wafflestudio.csereal.core.seminar.dto.SeminarSearchDto
@@ -78,7 +79,7 @@ class SeminarRepositoryImpl(
                 SeminarSearchDto(
                     id = seminarEntityList[i].id,
                     title = seminarEntityList[i].title,
-                    description = clean(seminarEntityList[i].description),
+                    description = cleanTextFromHtml(seminarEntityList[i].description),
                     name = seminarEntityList[i].name,
                     affiliation = seminarEntityList[i].affiliation,
                     startDate = seminarEntityList[i].startDate,
@@ -134,10 +135,5 @@ class SeminarRepositoryImpl(
 
         return prevNext
 
-    }
-
-    private fun clean(description: String): String {
-        val cleanDescription = Jsoup.clean(description, Safelist.none())
-        return Parser.unescapeEntities(cleanDescription, false)
     }
 }


### PR DESCRIPTION
## Feat: Add plain text description for notice

### 한줄 요약

Notice description을 create, upate 시에 html 태그를 지운 clean text를 db에 저장 및 업데이트 하도록 변경하였습니다.

### 상세 설명

2232c09 Feat: Add plainTextDescription.
6c76291 Feat: Add plainTextDescription in createNotice.
b4b8682 Feat: add updating plainTextDescription when updating description.
