### PR TITLE
[Test] Notice create, update 시 plainTextDescription 동작 테스트

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -40,7 +40,7 @@ servlet:
 spring:
   config.activate.on-profile: local
   datasource:
-    url: jdbc:mysql://127.0.0.1:3306/csereal?useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul
+    url: jdbc:mysql://127.0.0.1:3307/csereal?useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul
     username: root
     password: password
   jpa:

--- a/src/test/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeServiceTest.kt
@@ -1,0 +1,136 @@
+package com.wafflestudio.csereal.core.notice.service
+
+import com.wafflestudio.csereal.core.notice.database.NoticeEntity
+import com.wafflestudio.csereal.core.notice.database.NoticeRepository
+import com.wafflestudio.csereal.core.notice.dto.NoticeDto
+import com.wafflestudio.csereal.core.user.database.Role
+import com.wafflestudio.csereal.core.user.database.UserEntity
+import com.wafflestudio.csereal.core.user.database.UserRepository
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.web.context.request.RequestAttributes
+import org.springframework.web.context.request.RequestContextHolder
+
+@SpringBootTest
+class NoticeServiceTest(
+        private val noticeService: NoticeService,
+        private val userRepository: UserRepository,
+        private val noticeRepository: NoticeRepository,
+) : BehaviorSpec() {
+    init {
+        beforeSpec {
+            userRepository.save(
+                    UserEntity(
+                            "username",
+                            "name",
+                            "email",
+                            "studentId",
+                            Role.ROLE_STAFF
+                    )
+            )
+        }
+
+        afterSpec {
+            noticeRepository.deleteAll()
+            userRepository.deleteAll()
+        }
+
+        Given("간단한 공지사항을 생성하려고 할 때") {
+            val userEntity = userRepository.findByUsername("username")!!
+
+            mockkStatic(RequestContextHolder::class)
+            val mockRequestAttributes = mockk<RequestAttributes>()
+            every {
+                RequestContextHolder.getRequestAttributes()
+            } returns mockRequestAttributes
+            every {
+                mockRequestAttributes.getAttribute(
+                        "loggedInUser",
+                        RequestAttributes.SCOPE_REQUEST
+                )
+            } returns userEntity
+
+            val noticeDto = NoticeDto(
+                    id = -1,
+                    title = "title",
+                    description = """
+                            <h1>Hello, World!</h1>
+                            <p>This is a test notice.</p>
+                            <h3>Goodbye, World!</h3>
+                        """.trimIndent(),
+                    author = "username",
+                    tags = emptyList(),
+                    createdAt = null,
+                    modifiedAt = null,
+                    isPublic = false,
+                    isPinned = false,
+                    isImportant = false,
+                    prevId = null,
+                    prevTitle = null,
+                    nextId = null,
+                    nextTitle = null,
+                    attachments = null,
+            )
+
+            When("공지사항을 생성하면") {
+                val createdNoticeDto = noticeService.createNotice(noticeDto, null)
+
+                Then("새 공지사항이 잘 생성되어야 한다.") {
+                    noticeRepository.count() shouldBe 1
+                    noticeRepository.findByIdOrNull(createdNoticeDto.id) shouldNotBe null
+                }
+                Then("plainTextDescription이 잘 생성되어야 한다.") {
+                    val noticeEntity = noticeRepository.findByIdOrNull(createdNoticeDto.id)
+                    noticeEntity?.plainTextDescription shouldBe "Hello, World! This is a test notice. Goodbye, World!"
+                }
+            }
+        }
+
+        Given("기존 간단한 공지사항의 Description을 수정하려고 할 때") {
+            val noticeEntity = noticeRepository.save (
+                    NoticeEntity(
+                            title = "title",
+                            description = """
+                                    <h1>Hello, World!</h1>
+                                    <p>This is a test notice.</p>
+                                    <h3>Goodbye, World!</h3>
+                                """.trimIndent(),
+                            plainTextDescription = "Hello, World! This is a test notice. Goodbye, World!",
+                            isPublic = false,
+                            isPinned = false,
+                            isImportant = false,
+                            author = userRepository.findByUsername("username")!!,
+                    )
+            )
+            val modifiedRequest = NoticeDto.of(
+                    noticeEntity, emptyList(), null
+            ).copy(
+                    description = """
+                            <h1>Hello, World!</h1>
+                            <p>This is a modified test notice.</p>
+                            <h3>Goodbye, World!</h3>
+                            <p>And this is a new line.</p>
+                        """.trimIndent()
+            )
+
+            When("수정된 DTO를 이용하여 수정하면") {
+                val modifiedNoticeDto = noticeService.updateNotice(
+                        modifiedRequest.id,
+                        modifiedRequest,
+                        null
+                )
+
+                Then("plainTextDescription이 잘 수정되어야 한다.") {
+                    val noticeEntity = noticeRepository.findByIdOrNull(modifiedNoticeDto.id)
+                    noticeEntity?.plainTextDescription shouldBe "Hello, World! This is a modified test notice. Goodbye, World! And this is a new line."
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeServiceTest.kt
@@ -24,7 +24,7 @@ class NoticeServiceTest(
         private val noticeRepository: NoticeRepository,
 ) : BehaviorSpec() {
     init {
-        beforeSpec {
+        beforeContainer {
             userRepository.save(
                     UserEntity(
                             "username",
@@ -36,7 +36,7 @@ class NoticeServiceTest(
             )
         }
 
-        afterSpec {
+        afterContainer {
             noticeRepository.deleteAll()
             userRepository.deleteAll()
         }


### PR DESCRIPTION
## [Test] Notice create, update 시 plainTextDescription 동작 테스트

### 상세 설명

[b7491c5](https://github.com/wafflestudio/csereal-server/pull/78/commits/b7491c515bac095586027b95195661d606cd7957): Test: Add Tests for Create, Update Notice, in perspective of plainTextDescription

[51b84d6](https://github.com/wafflestudio/csereal-server/pull/78/commits/51b84d648c1b5010518002e5001b4fe6271a0ce0): [Fix: Change life cycle hook resolution to container.](https://github.com/wafflestudio/csereal-server/pull/78/commits/51b84d648c1b5010518002e5001b4fe6271a0ce0)
