### PR TITLE
Feat: 구성원 검색 위한 table 추가.

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/database/MemberSearchEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/database/MemberSearchEntity.kt
@@ -1,0 +1,101 @@
+package com.wafflestudio.csereal.core.member.database
+
+import com.wafflestudio.csereal.common.CserealException
+import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import jakarta.persistence.*
+
+@Entity(name = "member_search")
+class MemberSearchEntity (
+        @Column(columnDefinition = "TEXT")
+        var content: String,
+
+        @OneToOne
+        @JoinColumn(name = "professor_id")
+        val professor: ProfessorEntity? = null,
+
+        @OneToOne
+        @JoinColumn(name = "staff_id")
+        val staff: StaffEntity? = null,
+): BaseTimeEntity() {
+    companion object {
+        fun create(professor: ProfessorEntity): MemberSearchEntity {
+            return MemberSearchEntity(
+                    content = createContent(professor),
+                    professor = professor
+            )
+        }
+
+        fun create(staff: StaffEntity): MemberSearchEntity {
+            return MemberSearchEntity(
+                    content = createContent(staff),
+                    staff = staff
+            )
+        }
+
+        fun createContent(professor: ProfessorEntity): String {
+            val stringBuilder = StringBuilder()
+            stringBuilder.appendLine(professor.name)
+            stringBuilder.appendLine(professor.status.krValue)
+            stringBuilder.appendLine(professor.academicRank)
+            professor.lab?.let { stringBuilder.appendLine(it.name) }
+            professor.startDate?.let { stringBuilder.appendLine(it) }
+            professor.endDate?.let { stringBuilder.appendLine(it) }
+            professor.office?.let { stringBuilder.appendLine(it) }
+            professor.phone?.let { stringBuilder.appendLine(it) }
+            professor.fax?.let { stringBuilder.appendLine(it) }
+            professor.email?.let { stringBuilder.appendLine(it) }
+            professor.website?.let { stringBuilder.appendLine(it) }
+            professor.educations.forEach { stringBuilder.appendLine(it.name) }
+            professor.researchAreas.forEach { stringBuilder.appendLine(it.name) }
+            professor.careers.forEach { stringBuilder.appendLine(it.name) }
+
+                    return stringBuilder.toString()
+        }
+
+        fun createContent(staff: StaffEntity): String {
+            val stringBuilder = StringBuilder()
+            stringBuilder.appendLine(staff.name)
+            stringBuilder.appendLine(staff.role)
+            stringBuilder.appendLine(staff.office)
+            stringBuilder.appendLine(staff.phone)
+            stringBuilder.appendLine(staff.email)
+            staff.tasks.forEach { stringBuilder.appendLine(it.name) }
+
+            return stringBuilder.toString()
+        }
+    }
+
+    @PrePersist
+    @PreUpdate
+    fun checkType() {
+        if (
+                (professor != null && staff != null)
+                || (professor == null && staff == null)
+        ) {
+            throw RuntimeException("MemberSearchEntity must have either professor or staff")
+        }
+    }
+
+    fun ofType(): MemberSearchType {
+        return if (professor != null) {
+            MemberSearchType.PROFESSOR
+        } else if (staff != null) {
+            MemberSearchType.STAFF
+        } else {
+            throw RuntimeException("MemberSearchEntity must have either professor or staff")
+        }
+    }
+
+    fun update(professor: ProfessorEntity) {
+        this.content = createContent(professor)
+    }
+
+    fun update(staff: StaffEntity) {
+        this.content = createContent(staff)
+    }
+}
+
+enum class MemberSearchType {
+    PROFESSOR,
+    STAFF
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/database/MemberSearchRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/database/MemberSearchRepository.kt
@@ -1,0 +1,19 @@
+package com.wafflestudio.csereal.core.member.database
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+interface MemberSearchRepository
+    : JpaRepository<MemberSearchEntity, Long>, MemberSearchRepositoryCustom {
+}
+
+interface MemberSearchRepositoryCustom {
+
+}
+
+@Repository
+class MemberSearchRepositoryCustomImpl (
+        private val queryFactory: JPAQueryFactory,
+): MemberSearchRepositoryCustom {
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/database/ProfessorEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/database/ProfessorEntity.kt
@@ -87,6 +87,10 @@ class ProfessorEntity(
 
 }
 
-enum class ProfessorStatus {
-    ACTIVE, INACTIVE, VISITING
+enum class ProfessorStatus (
+    val krValue: String
+){
+    ACTIVE("교수"),
+    INACTIVE("역대 교수"),
+    VISITING("객원교수");
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/database/ProfessorEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/database/ProfessorEntity.kt
@@ -44,6 +44,8 @@ class ProfessorEntity(
     @OneToOne
     var mainImage: MainImageEntity? = null,
 
+    @OneToOne(mappedBy = "professor", cascade = [CascadeType.ALL], orphanRemoval = true)
+    var memberSearch: MemberSearchEntity? = null,
 ) : BaseTimeEntity(), MainImageContentEntityType {
     override fun bringMainImage(): MainImageEntity? = mainImage
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/database/StaffEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/database/StaffEntity.kt
@@ -24,7 +24,9 @@ class StaffEntity(
     @OneToOne
     var mainImage: MainImageEntity? = null,
 
-    ) : BaseTimeEntity(), MainImageContentEntityType {
+    @OneToOne(mappedBy = "staff", cascade = [CascadeType.ALL], orphanRemoval = true)
+    var memberSearch: MemberSearchEntity? = null,
+) : BaseTimeEntity(), MainImageContentEntityType {
     override fun bringMainImage(): MainImageEntity? = mainImage
 
     companion object {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/service/MemberSearchService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/service/MemberSearchService.kt
@@ -1,0 +1,16 @@
+package com.wafflestudio.csereal.core.member.service
+
+import com.wafflestudio.csereal.core.member.database.MemberSearchRepository
+import com.wafflestudio.csereal.core.member.database.ProfessorEntity
+import jakarta.transaction.Transactional
+import org.springframework.stereotype.Service
+
+interface MemberSearchService {
+
+}
+
+@Service
+class MemberSearchServiceImpl (
+        private val memberSearchRepository: MemberSearchRepository,
+): MemberSearchService {
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/service/ProfessorService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/service/ProfessorService.kt
@@ -52,6 +52,8 @@ class ProfessorServiceImpl(
             mainImageService.uploadMainImage(professor, mainImage)
         }
 
+        professor.memberSearch = MemberSearchEntity.create(professor)
+
         professorRepository.save(professor)
 
         val imageURL = mainImageService.createImageURL(professor.mainImage)
@@ -147,6 +149,9 @@ class ProfessorServiceImpl(
         for (career in careersToAdd) {
             CareerEntity.create(career, professor)
         }
+
+        // 검색 엔티티 업데이트
+        professor.memberSearch!!.update(professor)
 
         val imageURL = mainImageService.createImageURL(professor.mainImage)
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/service/StaffService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/service/StaffService.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.csereal.core.member.service
 
 import com.wafflestudio.csereal.common.CserealException
+import com.wafflestudio.csereal.core.member.database.MemberSearchEntity
 import com.wafflestudio.csereal.core.member.database.StaffEntity
 import com.wafflestudio.csereal.core.member.database.StaffRepository
 import com.wafflestudio.csereal.core.member.database.TaskEntity
@@ -36,6 +37,8 @@ class StaffServiceImpl(
         if(mainImage != null) {
             mainImageService.uploadMainImage(staff, mainImage)
         }
+
+        staff.memberSearch = MemberSearchEntity.create(staff)
 
         staffRepository.save(staff)
 
@@ -85,6 +88,9 @@ class StaffServiceImpl(
         for (task in tasksToAdd) {
             TaskEntity.create(task, staff)
         }
+
+        // 검색 엔티티 업데이트
+        staff.memberSearch?.update(staff)
 
         val imageURL = mainImageService.createImageURL(staff.mainImage)
 

--- a/src/test/kotlin/com/wafflestudio/csereal/core/member/service/ProfessorServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/member/service/ProfessorServiceTest.kt
@@ -1,0 +1,264 @@
+package com.wafflestudio.csereal.core.member.service
+
+import com.wafflestudio.csereal.core.member.database.MemberSearchRepository
+import com.wafflestudio.csereal.core.member.database.ProfessorRepository
+import com.wafflestudio.csereal.core.member.database.ProfessorStatus
+import com.wafflestudio.csereal.core.member.dto.ProfessorDto
+import com.wafflestudio.csereal.core.research.database.*
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.extensions.spring.SpringTestExtension
+import io.kotest.extensions.spring.SpringTestLifecycleMode
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import jakarta.transaction.Transactional
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.repository.findByIdOrNull
+import java.time.LocalDate
+
+@SpringBootTest
+@Transactional
+class ProfessorServiceTest (
+        private val professorService: ProfessorService,
+        private val professorRepository: ProfessorRepository,
+        private val labRepository: LabRepository,
+        private val memberSearchRepository: MemberSearchRepository,
+        private val researchRepository: ResearchRepository,
+): BehaviorSpec({
+    extensions(SpringTestExtension(SpringTestLifecycleMode.Root))
+
+    afterContainer {
+        professorRepository.deleteAll()
+        researchRepository.deleteAll()
+    }
+
+    Given("이미지 없는 교수를 생성하려고 할 때") {
+        val date = LocalDate.now()
+
+        val researchEntity = ResearchEntity(
+                name = "researchName",
+                description = null,
+                postType = ResearchPostType.LABS,
+        )
+        var labEntity = LabEntity(
+                name = "labName",
+                location = null,
+                tel = null,
+                acronym = null,
+                youtube = null,
+                description = null,
+                websiteURL = null,
+                research = researchEntity,
+        )
+        researchEntity.labs.add(labEntity)
+        researchRepository.save(researchEntity)
+        labEntity = labRepository.save(labEntity)
+
+        val professorDto = ProfessorDto(
+                name = "name",
+                email = "email",
+                status = ProfessorStatus.ACTIVE,
+                academicRank = "academicRank",
+                labId = labEntity.id,
+                labName = null,
+                startDate = date,
+                endDate = date,
+                office = "office",
+                phone = "phone",
+                fax = "fax",
+                website = "website",
+                educations = listOf("education1", "education2"),
+                researchAreas = listOf("researchArea1", "researchArea2"),
+                careers = listOf("career1", "career2")
+        )
+
+        When("교수를 생성한다면") {
+            val createdProfessorDto = professorService.createProfessor(professorDto, null)
+
+            Then("교수가 생성되어야 한다") {
+                professorRepository.count() shouldBe 1
+                professorRepository.findByIdOrNull(createdProfessorDto.id) shouldNotBe null
+            }
+
+
+            Then("교수의 정보가 일치해야 한다") {
+                val professorEntity = professorRepository.findByIdOrNull(createdProfessorDto.id)!!
+
+                professorEntity.name shouldBe professorDto.name
+                professorEntity.email shouldBe professorDto.email
+                professorEntity.status shouldBe professorDto.status
+                professorEntity.academicRank shouldBe professorDto.academicRank
+                professorEntity.lab shouldBe labEntity
+                professorEntity.startDate shouldBe professorDto.startDate
+                professorEntity.endDate shouldBe professorDto.endDate
+                professorEntity.office shouldBe professorDto.office
+                professorEntity.phone shouldBe professorDto.phone
+                professorEntity.fax shouldBe professorDto.fax
+                professorEntity.website shouldBe professorDto.website
+                professorEntity.educations.map { it.name } shouldBe professorDto.educations
+                professorEntity.researchAreas.map { it.name } shouldBe professorDto.researchAreas
+                professorEntity.careers.map { it.name } shouldBe professorDto.careers
+            }
+
+
+            Then("교수의 검색 정보가 생성되어야 한다") {
+                memberSearchRepository.count() shouldBe 1
+                val memberSearchEntity = memberSearchRepository.findAll()[0]
+
+                memberSearchEntity.professor?.id shouldBe createdProfessorDto.id
+
+                val contentExpected = """
+                        name
+                        교수
+                        academicRank
+                        labName
+                        ${date}
+                        ${date}
+                        office
+                        phone
+                        fax
+                        email
+                        website
+                        education1
+                        education2
+                        researchArea1
+                        researchArea2
+                        career1
+                        career2
+                        
+                    """.trimIndent()
+
+                memberSearchEntity.content shouldBe contentExpected
+            }
+        }
+    }
+
+    Given("생성되어 있는 간단한 교수에 대하여") {
+        val date = LocalDate.now()
+        val researchEntity = ResearchEntity(
+                name = "researchName",
+                description = null,
+                postType = ResearchPostType.LABS,
+        )
+        val labEntity1 = LabEntity(
+                name = "labName1",
+                location = null,
+                tel = null,
+                acronym = null,
+                youtube = null,
+                description = null,
+                websiteURL = null,
+                research = researchEntity,
+        )
+        val labEntity2 = LabEntity(
+                name = "labName2",
+                location = null,
+                tel = null,
+                acronym = null,
+                youtube = null,
+                description = null,
+                websiteURL = null,
+                research = researchEntity,
+        )
+        researchEntity.labs.addAll(listOf(labEntity1, labEntity2))
+        researchRepository.save(researchEntity)
+
+        val createdProfessorDto = professorService.createProfessor(
+                ProfessorDto(
+                        name = "name",
+                        email = "email",
+                        status = ProfessorStatus.ACTIVE,
+                        academicRank = "academicRank",
+                        labId = labEntity1.id,
+                        labName = null,
+                        startDate = date,
+                        endDate = date,
+                        office = "office",
+                        phone = "phone",
+                        fax = "fax",
+                        website = "website",
+                        educations = listOf("education1", "education2"),
+                        researchAreas = listOf("researchArea1", "researchArea2"),
+                        careers = listOf("career1", "career2")
+                ),
+                null
+        )
+
+        When("교수 정보를 수정하면") {
+            val toModifyProfessorDto = createdProfessorDto.copy(
+                    name = "modifiedName",
+                    email = "modifiedEmail",
+                    status = ProfessorStatus.INACTIVE,
+                    academicRank = "modifiedAcademicRank",
+                    labId = labEntity2.id,
+                    startDate = date.plusDays(1),
+                    endDate = date.plusDays(1),
+                    office = "modifiedOffice",
+                    phone = "modifiedPhone",
+                    fax = "modifiedFax",
+                    website = "modifiedWebsite",
+                    educations = listOf("education1", "modifiedEducation2", "modifiedEducation3"),
+                    researchAreas = listOf("researchArea1", "modifiedResearchArea2", "modifiedResearchArea3"),
+                    careers = listOf("career1", "modifiedCareer2", "modifiedCareer3")
+            )
+
+            val modifiedProfessorDto = professorService.updateProfessor(
+                    toModifyProfessorDto.id!!,
+                    toModifyProfessorDto,
+                    null
+            )
+
+            Then("교수 정보가 수정되어야 한다.") {
+                professorRepository.count() shouldBe 1
+                val professorEntity = professorRepository.findByIdOrNull(modifiedProfessorDto.id)
+                professorEntity shouldNotBe null
+
+                professorEntity!!.name shouldBe toModifyProfessorDto.name
+                professorEntity.email shouldBe toModifyProfessorDto.email
+                professorEntity.status shouldBe toModifyProfessorDto.status
+                professorEntity.academicRank shouldBe toModifyProfessorDto.academicRank
+                professorEntity.lab shouldBe labEntity2
+                professorEntity.startDate shouldBe toModifyProfessorDto.startDate
+                professorEntity.endDate shouldBe toModifyProfessorDto.endDate
+                professorEntity.office shouldBe toModifyProfessorDto.office
+                professorEntity.phone shouldBe toModifyProfessorDto.phone
+                professorEntity.fax shouldBe toModifyProfessorDto.fax
+                professorEntity.website shouldBe toModifyProfessorDto.website
+                professorEntity.educations.map { it.name } shouldBe toModifyProfessorDto.educations
+                professorEntity.researchAreas.map { it.name } shouldBe toModifyProfessorDto.researchAreas
+                professorEntity.careers.map { it.name } shouldBe toModifyProfessorDto.careers
+            }
+
+            Then("검색 정보가 수정되어야 한다.") {
+                memberSearchRepository.count() shouldBe 1
+
+                val professorEntity = professorRepository.findByIdOrNull(modifiedProfessorDto.id)!!
+                val memberSearchEntity = professorEntity.memberSearch
+                memberSearchEntity shouldNotBe null
+
+                memberSearchEntity?.content shouldBe """
+                        modifiedName
+                        역대 교수
+                        modifiedAcademicRank
+                        labName2
+                        ${date.plusDays(1)}
+                        ${date.plusDays(1)}
+                        modifiedOffice
+                        modifiedPhone
+                        modifiedFax
+                        modifiedEmail
+                        modifiedWebsite
+                        education1
+                        modifiedEducation2
+                        modifiedEducation3
+                        researchArea1
+                        modifiedResearchArea2
+                        modifiedResearchArea3
+                        career1
+                        modifiedCareer2
+                        modifiedCareer3
+                        
+                    """.trimIndent()
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/wafflestudio/csereal/core/member/service/StaffServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/member/service/StaffServiceTest.kt
@@ -1,0 +1,131 @@
+package com.wafflestudio.csereal.core.member.service
+
+import com.wafflestudio.csereal.core.member.database.MemberSearchRepository
+import com.wafflestudio.csereal.core.member.database.StaffRepository
+import com.wafflestudio.csereal.core.member.dto.StaffDto
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.extensions.spring.SpringTestExtension
+import io.kotest.extensions.spring.SpringTestLifecycleMode
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import jakarta.transaction.Transactional
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.repository.findByIdOrNull
+
+@SpringBootTest
+@Transactional
+class StaffServiceTest(
+        private val staffService: StaffService,
+        private val staffRepository: StaffRepository,
+        private val memberSearchRepository: MemberSearchRepository,
+): BehaviorSpec({
+    extensions(SpringTestExtension(SpringTestLifecycleMode.Root))
+
+    afterSpec {
+        staffRepository.deleteAll()
+    }
+
+    Given("이미지 없는 행정직원을 생성하려고 할 떄") {
+        val staffDto = StaffDto(
+                name = "name",
+                role = "role",
+                office = "office",
+                phone = "phone",
+                email = "email",
+                tasks = listOf("task1", "task2"),
+        )
+
+        When("행정직원을 생성하면") {
+            val createdStaffDto = staffService.createStaff(staffDto, null)
+
+            Then("행정직원이 생성된다") {
+                staffRepository.count() shouldBe 1
+                staffRepository.findByIdOrNull(createdStaffDto.id!!) shouldNotBe null
+            }
+
+            Then("행정직원의 정보가 일치한다") {
+                val staffEntity = staffRepository.findByIdOrNull(createdStaffDto.id!!)!!
+                staffEntity.name shouldBe staffDto.name
+                staffEntity.role shouldBe staffDto.role
+                staffEntity.office shouldBe staffDto.office
+                staffEntity.phone shouldBe staffDto.phone
+                staffEntity.email shouldBe staffDto.email
+                staffEntity.tasks.map { it.name } shouldBe staffDto.tasks
+            }
+
+            Then("검색 정보가 생성된다") {
+                memberSearchRepository.count() shouldBe 1
+
+                val staffEntity = staffRepository.findByIdOrNull(createdStaffDto.id!!)!!
+                val memberSearch = staffEntity.memberSearch!!
+
+                memberSearch.content shouldBe """
+                    name
+                    role
+                    office
+                    phone
+                    email
+                    task1
+                    task2
+                    
+                """.trimIndent()
+            }
+        }
+    }
+
+    Given("이미지 없는 행정직원을 수정할 때") {
+        val staffDto = StaffDto(
+                name = "name",
+                role = "role",
+                office = "office",
+                phone = "phone",
+                email = "email",
+                tasks = listOf("task1", "task2"),
+        )
+
+        val createdStaffDto = staffService.createStaff(staffDto, null)
+
+        When("행정직원을 수정하면") {
+            val updateStaffDto = StaffDto(
+                    name = "name2",
+                    role = "role2",
+                    office = "office2",
+                    phone = "phone2",
+                    email = "email2",
+                    tasks = listOf("task1", "task3", "task4"),
+            )
+
+            val updatedStaffDto = staffService.updateStaff(createdStaffDto.id!!, updateStaffDto, null)
+
+            Then("행정직원의 정보가 일치한다") {
+                staffRepository.count() shouldBe 1
+                val staffEntity = staffRepository.findByIdOrNull(updatedStaffDto.id!!)!!
+                staffEntity.name shouldBe updateStaffDto.name
+                staffEntity.role shouldBe updateStaffDto.role
+                staffEntity.office shouldBe updateStaffDto.office
+                staffEntity.phone shouldBe updateStaffDto.phone
+                staffEntity.email shouldBe updateStaffDto.email
+                staffEntity.tasks.map { it.name } shouldBe updateStaffDto.tasks
+            }
+
+            Then("검색 정보가 수정된다") {
+                memberSearchRepository.count() shouldBe 1
+
+                val staffEntity = staffRepository.findByIdOrNull(updatedStaffDto.id!!)!!
+                val memberSearch = staffEntity.memberSearch!!
+
+                memberSearch.content shouldBe """
+                    name2
+                    role2
+                    office2
+                    phone2
+                    email2
+                    task1
+                    task3
+                    task4
+                    
+                """.trimIndent()
+            }
+        }
+    }
+})


### PR DESCRIPTION
## Feat: 구성원 검색 위한 table 추가.

### 한줄 요약

구성원 검색을 위한 테이블을 추가하고, 교수와 행정직원의 create/update에도 해당 테이블을 같이 수정하도록 하였습니다.

### 상세 설명

2f4c97d Feat: MemberSearchEntity 추가.
e7f7686 Feat: MemberSearchRepository 추가
baa9adc Feat: MemberSearchService 추가
5ccb4f1 Feat: ProfessorEntity, StaffEntity에 MemberSearch 추가.
09248a9 Feat: ProfessorStatus에 한글 값 추가.
5c47654 Feat: professor create, update 시 memberSearch도 반영하도록 추가.
2d05ae2 Feat: seminar create, update 시 memberSearch도 반영하도록 추가.
ff1b8f1 Test: ProfessorService 테스트 추가.
b5932bb Test: StaffServiceTest 추가.


### TODO

MemberSearchEntity를 이용한 검색 구현.
