### PR TITLE
fix: main 프론트에 맞게 협의, notice 태그 enum 추가

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/api/MainController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/api/MainController.kt
@@ -6,8 +6,8 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
-@RequestMapping
-@RestController("/api/v1")
+@RequestMapping("/api/v1")
+@RestController
 class MainController(
     private val mainService: MainService,
 ) {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/database/MainRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/database/MainRepository.kt
@@ -2,17 +2,16 @@ package com.wafflestudio.csereal.core.main.database
 
 import com.querydsl.core.types.Projections
 import com.querydsl.jpa.impl.JPAQueryFactory
-import com.wafflestudio.csereal.core.admin.dto.ImportantResponse
 import com.wafflestudio.csereal.core.main.dto.MainImportantResponse
 import com.wafflestudio.csereal.core.main.dto.MainNoticeResponse
 import com.wafflestudio.csereal.core.main.dto.MainSlideResponse
-import com.wafflestudio.csereal.core.main.dto.NoticesResponse
 import com.wafflestudio.csereal.core.news.database.NewsRepository
 import com.wafflestudio.csereal.core.news.database.QNewsEntity.newsEntity
 import com.wafflestudio.csereal.core.notice.database.NoticeRepository
 import com.wafflestudio.csereal.core.notice.database.QNoticeEntity.noticeEntity
 import com.wafflestudio.csereal.core.notice.database.QNoticeTagEntity.noticeTagEntity
 import com.wafflestudio.csereal.core.notice.database.QTagInNoticeEntity.tagInNoticeEntity
+import com.wafflestudio.csereal.core.notice.database.TagInNoticeEnum
 import com.wafflestudio.csereal.core.resource.mainImage.service.MainImageService
 import com.wafflestudio.csereal.core.seminar.database.SeminarRepository
 
@@ -21,7 +20,7 @@ import org.springframework.stereotype.Component
 interface MainRepository {
     fun readMainSlide(): List<MainSlideResponse>
     fun readMainNoticeTotal(): List<MainNoticeResponse>
-    fun readMainNoticeTag(tag: String): List<MainNoticeResponse>
+    fun readMainNoticeTag(tagEnum: TagInNoticeEnum): List<MainNoticeResponse>
     fun readMainImportant(): List<MainImportantResponse>
 }
 
@@ -64,7 +63,7 @@ class MainRepositoryImpl(
             .limit(6).fetch()
     }
 
-    override fun readMainNoticeTag(tag: String): List<MainNoticeResponse> {
+    override fun readMainNoticeTag(tagEnum: TagInNoticeEnum): List<MainNoticeResponse> {
         return queryFactory.select(
             Projections.constructor(
                 MainNoticeResponse::class.java,
@@ -75,7 +74,7 @@ class MainRepositoryImpl(
         ).from(noticeTagEntity)
             .rightJoin(noticeEntity).on(noticeTagEntity.notice.eq(noticeEntity))
             .rightJoin(tagInNoticeEntity).on(noticeTagEntity.tag.eq(tagInNoticeEntity))
-            .where(noticeTagEntity.tag.name.eq(tag))
+            .where(noticeTagEntity.tag.name.eq(tagEnum))
             .where(noticeEntity.isDeleted.eq(false), noticeEntity.isPublic.eq(true))
             .orderBy(noticeEntity.isPinned.desc()).orderBy(noticeEntity.createdAt.desc())
             .limit(6).distinct().fetch()

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/database/MainRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/database/MainRepository.kt
@@ -1,47 +1,59 @@
 package com.wafflestudio.csereal.core.main.database
 
-import com.querydsl.core.QueryFactory
 import com.querydsl.core.types.Projections
 import com.querydsl.jpa.impl.JPAQueryFactory
-import com.sun.tools.javac.Main
-import com.wafflestudio.csereal.core.main.dto.MainResponse
-import com.wafflestudio.csereal.core.main.dto.NewsResponse
-import com.wafflestudio.csereal.core.main.dto.NoticeResponse
+import com.wafflestudio.csereal.core.admin.dto.ImportantResponse
+import com.wafflestudio.csereal.core.main.dto.MainImportantResponse
+import com.wafflestudio.csereal.core.main.dto.MainNoticeResponse
+import com.wafflestudio.csereal.core.main.dto.MainSlideResponse
+import com.wafflestudio.csereal.core.main.dto.NoticesResponse
+import com.wafflestudio.csereal.core.news.database.NewsRepository
 import com.wafflestudio.csereal.core.news.database.QNewsEntity.newsEntity
+import com.wafflestudio.csereal.core.notice.database.NoticeRepository
 import com.wafflestudio.csereal.core.notice.database.QNoticeEntity.noticeEntity
 import com.wafflestudio.csereal.core.notice.database.QNoticeTagEntity.noticeTagEntity
 import com.wafflestudio.csereal.core.notice.database.QTagInNoticeEntity.tagInNoticeEntity
+import com.wafflestudio.csereal.core.resource.mainImage.service.MainImageService
+import com.wafflestudio.csereal.core.seminar.database.SeminarRepository
 
 import org.springframework.stereotype.Component
 
 interface MainRepository {
-    fun readMainSlide(): List<NewsResponse>
-    fun readMainNoticeTotal(): List<NoticeResponse>
-    fun readMainNoticeTag(tag: String): List<NoticeResponse>
+    fun readMainSlide(): List<MainSlideResponse>
+    fun readMainNoticeTotal(): List<MainNoticeResponse>
+    fun readMainNoticeTag(tag: String): List<MainNoticeResponse>
+    fun readMainImportant(): List<MainImportantResponse>
 }
 
 @Component
 class MainRepositoryImpl(
     private val queryFactory: JPAQueryFactory,
+    private val mainImageService: MainImageService,
+    private val noticeRepository: NoticeRepository,
+    private val newsRepository: NewsRepository,
+    private val seminarRepository: SeminarRepository,
 ) : MainRepository {
-    override fun readMainSlide(): List<NewsResponse> {
-        return queryFactory.select(
-            Projections.constructor(
-                NewsResponse::class.java,
-                newsEntity.id,
-                newsEntity.title,
-                newsEntity.createdAt
-            )
-        ).from(newsEntity)
+    override fun readMainSlide(): List<MainSlideResponse> {
+        val newsEntityList = queryFactory.select(newsEntity).from(newsEntity)
             .where(newsEntity.isDeleted.eq(false), newsEntity.isPublic.eq(true), newsEntity.isSlide.eq(true))
             .orderBy(newsEntity.createdAt.desc())
             .limit(20).fetch()
+
+        return newsEntityList.map {
+            val imageURL = mainImageService.createImageURL(it.mainImage)
+            MainSlideResponse(
+                id = it.id,
+                title = it.title,
+                imageURL = imageURL,
+                createdAt = it.createdAt
+            )
+        }
     }
 
-    override fun readMainNoticeTotal(): List<NoticeResponse> {
+    override fun readMainNoticeTotal(): List<MainNoticeResponse> {
         return queryFactory.select(
             Projections.constructor(
-                NoticeResponse::class.java,
+                MainNoticeResponse::class.java,
                 noticeEntity.id,
                 noticeEntity.title,
                 noticeEntity.createdAt
@@ -51,10 +63,11 @@ class MainRepositoryImpl(
             .orderBy(noticeEntity.isPinned.desc()).orderBy(noticeEntity.createdAt.desc())
             .limit(6).fetch()
     }
-    override fun readMainNoticeTag(tag: String): List<NoticeResponse> {
+
+    override fun readMainNoticeTag(tag: String): List<MainNoticeResponse> {
         return queryFactory.select(
             Projections.constructor(
-                NoticeResponse::class.java,
+                MainNoticeResponse::class.java,
                 noticeTagEntity.notice.id,
                 noticeTagEntity.notice.title,
                 noticeTagEntity.notice.createdAt,
@@ -66,5 +79,44 @@ class MainRepositoryImpl(
             .where(noticeEntity.isDeleted.eq(false), noticeEntity.isPublic.eq(true))
             .orderBy(noticeEntity.isPinned.desc()).orderBy(noticeEntity.createdAt.desc())
             .limit(6).distinct().fetch()
+    }
+
+    override fun readMainImportant(): List<MainImportantResponse> {
+        val mainImportantResponses: MutableList<MainImportantResponse> = mutableListOf()
+        noticeRepository.findAllByIsImportant(true).forEach {
+            mainImportantResponses.add(
+                MainImportantResponse(
+                    id = it.id,
+                    title = it.title,
+                    createdAt = it.createdAt,
+                    category = "notice"
+                )
+            )
+        }
+
+        newsRepository.findAllByIsImportant(true).forEach {
+            mainImportantResponses.add(
+                MainImportantResponse(
+                    id = it.id,
+                    title = it.title,
+                    createdAt = it.createdAt,
+                    category = "news"
+                )
+            )
+        }
+
+        seminarRepository.findAllByIsImportant(true).forEach {
+            mainImportantResponses.add(
+                MainImportantResponse(
+                    id = it.id,
+                    title = it.title,
+                    createdAt = it.createdAt,
+                    category = "seminar"
+                )
+            )
+        }
+        mainImportantResponses.sortByDescending { it.createdAt }
+
+        return mainImportantResponses
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/dto/MainImportantResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/dto/MainImportantResponse.kt
@@ -1,11 +1,11 @@
 package com.wafflestudio.csereal.core.main.dto
 
-import com.querydsl.core.annotations.QueryProjection
 import java.time.LocalDateTime
 
-data class NoticeResponse @QueryProjection constructor(
+data class MainImportantResponse(
     val id: Long,
     val title: String,
     val createdAt: LocalDateTime?,
-){
+    val category: String,
+) {
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/dto/MainNoticeResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/dto/MainNoticeResponse.kt
@@ -1,0 +1,10 @@
+package com.wafflestudio.csereal.core.main.dto
+
+import java.time.LocalDateTime
+
+data class MainNoticeResponse(
+    val id: Long,
+    val title: String,
+    val createdAt: LocalDateTime?
+) {
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/dto/MainResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/dto/MainResponse.kt
@@ -1,11 +1,10 @@
 package com.wafflestudio.csereal.core.main.dto
 
+
 data class MainResponse(
-    val slide: List<NewsResponse>,
-    val noticeTotal: List<NoticeResponse>,
-    val noticeAdmissions: List<NoticeResponse>,
-    val noticeUndergraduate: List<NoticeResponse>,
-    val noticeGraduate: List<NoticeResponse>
+    val slides: List<MainSlideResponse>,
+    val notices: NoticesResponse,
+    val importants: List<MainImportantResponse>
 ) {
 
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/dto/MainSlideResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/dto/MainSlideResponse.kt
@@ -3,9 +3,10 @@ package com.wafflestudio.csereal.core.main.dto
 import com.querydsl.core.annotations.QueryProjection
 import java.time.LocalDateTime
 
-data class NewsResponse @QueryProjection constructor(
+data class MainSlideResponse @QueryProjection constructor(
     val id: Long,
     val title: String,
+    val imageURL: String?,
     val createdAt: LocalDateTime?
 ) {
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/dto/NoticesResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/dto/NoticesResponse.kt
@@ -1,0 +1,11 @@
+package com.wafflestudio.csereal.core.main.dto
+
+import com.querydsl.core.annotations.QueryProjection
+
+data class NoticesResponse @QueryProjection constructor(
+    val all: List<MainNoticeResponse>,
+    val scholarship: List<MainNoticeResponse>,
+    val undergraduate: List<MainNoticeResponse>,
+    val graduate: List<MainNoticeResponse>
+){
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/service/MainService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/service/MainService.kt
@@ -3,8 +3,10 @@ package com.wafflestudio.csereal.core.main.service
 import com.wafflestudio.csereal.core.main.database.MainRepository
 import com.wafflestudio.csereal.core.main.dto.MainResponse
 import com.wafflestudio.csereal.core.main.dto.NoticesResponse
+import com.wafflestudio.csereal.core.notice.database.TagInNoticeEnum
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import javax.swing.text.html.HTML.Tag
 
 interface MainService {
     fun readMain() : MainResponse
@@ -19,9 +21,9 @@ class MainServiceImpl(
         val slides = mainRepository.readMainSlide()
 
         val noticeTotal = mainRepository.readMainNoticeTotal()
-        val noticeScholarship = mainRepository.readMainNoticeTag("scholarship")
-        val noticeUndergraduate = mainRepository.readMainNoticeTag("undergraduate")
-        val noticeGraduate = mainRepository.readMainNoticeTag("graduate")
+        val noticeScholarship = mainRepository.readMainNoticeTag(TagInNoticeEnum.SCHOLARSHIP)
+        val noticeUndergraduate = mainRepository.readMainNoticeTag(TagInNoticeEnum.UNDERGRADUATE)
+        val noticeGraduate = mainRepository.readMainNoticeTag(TagInNoticeEnum.GRADUATE)
         val notices = NoticesResponse(noticeTotal, noticeScholarship, noticeUndergraduate, noticeGraduate)
 
         val importants = mainRepository.readMainImportant()

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/service/MainService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/service/MainService.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.csereal.core.main.service
 
 import com.wafflestudio.csereal.core.main.database.MainRepository
 import com.wafflestudio.csereal.core.main.dto.MainResponse
+import com.wafflestudio.csereal.core.main.dto.NoticesResponse
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -15,11 +16,16 @@ class MainServiceImpl(
 ) : MainService {
     @Transactional(readOnly = true)
     override fun readMain(): MainResponse {
-        val slide = mainRepository.readMainSlide()
+        val slides = mainRepository.readMainSlide()
+
         val noticeTotal = mainRepository.readMainNoticeTotal()
-        val noticeAdmissions = mainRepository.readMainNoticeTag("admissions")
+        val noticeScholarship = mainRepository.readMainNoticeTag("scholarship")
         val noticeUndergraduate = mainRepository.readMainNoticeTag("undergraduate")
         val noticeGraduate = mainRepository.readMainNoticeTag("graduate")
-        return MainResponse(slide, noticeTotal, noticeAdmissions, noticeUndergraduate, noticeGraduate)
+        val notices = NoticesResponse(noticeTotal, noticeScholarship, noticeUndergraduate, noticeGraduate)
+
+        val importants = mainRepository.readMainImportant()
+
+        return MainResponse(slides, notices, importants)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
@@ -43,6 +43,7 @@ class NoticeController(
         return ResponseEntity.ok(noticeService.createNotice(request, attachments))
     }
 
+    /*
     @PatchMapping("/{noticeId}")
     fun updateNotice(
         @PathVariable noticeId: Long,
@@ -80,4 +81,6 @@ class NoticeController(
         noticeService.enrollTag(tagName["name"]!!)
         return ResponseEntity<String>("등록되었습니다. (tagName: ${tagName["name"]})", HttpStatus.OK)
     }
+
+    */
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
@@ -43,7 +43,6 @@ class NoticeController(
         return ResponseEntity.ok(noticeService.createNotice(request, attachments))
     }
 
-    /*
     @PatchMapping("/{noticeId}")
     fun updateNotice(
         @PathVariable noticeId: Long,
@@ -81,6 +80,4 @@ class NoticeController(
         noticeService.enrollTag(tagName["name"]!!)
         return ResponseEntity<String>("등록되었습니다. (tagName: ${tagName["name"]})", HttpStatus.OK)
     }
-
-    */
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
@@ -58,8 +58,9 @@ class NoticeRepositoryImpl(
         }
         if (!tag.isNullOrEmpty()) {
             tag.forEach {
+                val tagEnum = TagInNoticeEnum.getTagEnum(it)
                 tagsBooleanBuilder.or(
-                    noticeTagEntity.tag.name.eq(it)
+                    noticeTagEntity.tag.name.eq(tagEnum)
                 )
             }
         }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/TagInNoticeEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/TagInNoticeEntity.kt
@@ -2,11 +2,14 @@ package com.wafflestudio.csereal.core.notice.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.OneToMany
 
 @Entity(name = "tag_in_notice")
 class TagInNoticeEntity(
-    var name: String,
+    @Enumerated(EnumType.STRING)
+    var name: TagInNoticeEnum,
 
     @OneToMany(mappedBy = "tag")
     val noticeTags: MutableSet<NoticeTagEntity> = mutableSetOf()

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/TagInNoticeEnum.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/TagInNoticeEnum.kt
@@ -1,0 +1,33 @@
+package com.wafflestudio.csereal.core.notice.database
+
+import com.wafflestudio.csereal.common.CserealException
+
+enum class TagInNoticeEnum {
+    CLASS, SCHOLARSHIP, UNDERGRADUATE, GRADUATE, MINOR, REGISTRATIONS, ADMISSIONS, GRADUATIONS,
+    RECRUIT, STUDENT_EXCHANGE, EVENTS_PROGRAMS, FOREIGN;
+
+    companion object {
+        fun getTagEnum(t: String) : TagInNoticeEnum{
+            return when(t) {
+                "수업" -> CLASS
+                "장학" -> SCHOLARSHIP
+                "학사(학부)" -> UNDERGRADUATE
+                "학사(대학원)" -> GRADUATE
+                "다전공/전과" -> MINOR
+                "등록/복학/휴학/재입학" -> REGISTRATIONS
+                "입학" -> ADMISSIONS
+                "졸업" -> GRADUATIONS
+                "채용정보" -> RECRUIT
+                "교환학생/유학" -> STUDENT_EXCHANGE
+                "행사/프로그램" -> EVENTS_PROGRAMS
+                "foreign" -> FOREIGN
+                else -> throw CserealException.Csereal404("태그를 찾을 수 없습니다")
+            }
+        }
+    }
+
+
+}
+
+
+

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/TagInNoticeRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/TagInNoticeRepository.kt
@@ -3,5 +3,5 @@ package com.wafflestudio.csereal.core.notice.database
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface TagInNoticeRepository : JpaRepository<TagInNoticeEntity, Long> {
-    fun findByName(tagName: TagInNoticeEnum): TagInNoticeEntity?
+    fun findByName(tagName: TagInNoticeEnum): TagInNoticeEntity
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/TagInNoticeRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/TagInNoticeRepository.kt
@@ -3,5 +3,5 @@ package com.wafflestudio.csereal.core.notice.database
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface TagInNoticeRepository : JpaRepository<TagInNoticeEntity, Long> {
-    fun findByName(tagName: String): TagInNoticeEntity?
+    fun findByName(tagName: TagInNoticeEnum): TagInNoticeEntity?
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/NoticeDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/NoticeDto.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.csereal.core.notice.dto
 
 import com.wafflestudio.csereal.core.notice.database.NoticeEntity
+import com.wafflestudio.csereal.core.notice.database.TagInNoticeEnum
 import com.wafflestudio.csereal.core.resource.attachment.dto.AttachmentResponse
 import java.time.LocalDateTime
 
@@ -34,7 +35,7 @@ data class NoticeDto(
                 title = this.title,
                 description = this.description,
                 author = this.author.name,
-                tags = this.noticeTags.map { it.tag.name },
+                tags = this.noticeTags.map { it.tag.name.name },
                 createdAt = this.createdAt,
                 modifiedAt = this.modifiedAt,
                 isPublic = this.isPublic,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
@@ -94,7 +94,7 @@ class NoticeServiceImpl(
 
         for (tag in request.tags) {
             val tagEnum = TagInNoticeEnum.getTagEnum(tag)
-            val tagEntity = tagInNoticeRepository.findByName(tagEnum) ?: tagInNoticeRepository.save(TagInNoticeEntity(name = tagEnum))
+            val tagEntity = tagInNoticeRepository.findByName(tagEnum)
             NoticeTagEntity.createNoticeTag(newNotice, tagEntity)
         }
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
@@ -27,14 +27,11 @@ interface NoticeService {
 
     fun readNotice(noticeId: Long): NoticeDto
     fun createNotice(request: NoticeDto, attachments: List<MultipartFile>?): NoticeDto
-    /*
     fun updateNotice(noticeId: Long, request: NoticeDto, attachments: List<MultipartFile>?): NoticeDto
     fun deleteNotice(noticeId: Long)
     fun unpinManyNotices(idList: List<Long>)
     fun deleteManyNotices(idList: List<Long>)
     fun enrollTag(tagName: String)
-
-     */
 }
 
 @Service
@@ -112,7 +109,6 @@ class NoticeServiceImpl(
         return NoticeDto.of(newNotice, attachmentResponses)
 
     }
-    /*
 
     @Transactional
     override fun updateNotice(noticeId: Long, request: NoticeDto, attachments: List<MultipartFile>?): NoticeDto {
@@ -131,18 +127,17 @@ class NoticeServiceImpl(
 
         val oldTags = notice.noticeTags.map { it.tag.name }
 
-        val tagsToRemove = oldTags - request.tags
-        val tagsToAdd = request.tags - oldTags
+        val tagsToRemove = oldTags - request.tags.map { TagInNoticeEnum.getTagEnum(it) }
+        val tagsToAdd = request.tags.map { TagInNoticeEnum.getTagEnum(it) } - oldTags
 
-        for (tagRequest in tagsToRemove) {
-            val tagName = TagInNotice.valueOf(tagRequest)
-            val tagId = tagInNoticeRepository.findByName(tagName)!!.id
-            notice.noticeTags.removeIf { it.tag.name == tagName }
+        for (tagEnum in tagsToRemove) {
+            val tagId = tagInNoticeRepository.findByName(tagEnum)!!.id
+            notice.noticeTags.removeIf { it.tag.name == tagEnum }
             noticeTagRepository.deleteByNoticeIdAndTagId(noticeId, tagId)
         }
 
-        for (tagName in tagsToAdd) {
-            val tag = tagInNoticeRepository.findByName(tagName) ?: throw CserealException.Csereal404("해당하는 태그가 없습니다")
+        for (tagEnum in tagsToAdd) {
+            val tag = tagInNoticeRepository.findByName(tagEnum) ?: throw CserealException.Csereal404("해당하는 태그가 없습니다")
             NoticeTagEntity.createNoticeTag(notice, tag)
         }
 
@@ -178,15 +173,12 @@ class NoticeServiceImpl(
         }
     }
 
-
-
     override fun enrollTag(tagName: String) {
         val newTag = TagInNoticeEntity(
-            name = tagName
+            name = TagInNoticeEnum.getTagEnum(tagName)
         )
         tagInNoticeRepository.save(newTag)
     }
 
-     */
 
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
@@ -27,11 +27,14 @@ interface NoticeService {
 
     fun readNotice(noticeId: Long): NoticeDto
     fun createNotice(request: NoticeDto, attachments: List<MultipartFile>?): NoticeDto
+    /*
     fun updateNotice(noticeId: Long, request: NoticeDto, attachments: List<MultipartFile>?): NoticeDto
     fun deleteNotice(noticeId: Long)
     fun unpinManyNotices(idList: List<Long>)
     fun deleteManyNotices(idList: List<Long>)
     fun enrollTag(tagName: String)
+
+     */
 }
 
 @Service
@@ -92,9 +95,10 @@ class NoticeServiceImpl(
             author = user
         )
 
-        for (tagName in request.tags) {
-            val tag = tagInNoticeRepository.findByName(tagName) ?: throw CserealException.Csereal404("해당하는 태그가 없습니다")
-            NoticeTagEntity.createNoticeTag(newNotice, tag)
+        for (tag in request.tags) {
+            val tagEnum = TagInNoticeEnum.getTagEnum(tag)
+            val tagEntity = tagInNoticeRepository.findByName(tagEnum) ?: tagInNoticeRepository.save(TagInNoticeEntity(name = tagEnum))
+            NoticeTagEntity.createNoticeTag(newNotice, tagEntity)
         }
 
         if (attachments != null) {
@@ -108,6 +112,7 @@ class NoticeServiceImpl(
         return NoticeDto.of(newNotice, attachmentResponses)
 
     }
+    /*
 
     @Transactional
     override fun updateNotice(noticeId: Long, request: NoticeDto, attachments: List<MultipartFile>?): NoticeDto {
@@ -129,7 +134,8 @@ class NoticeServiceImpl(
         val tagsToRemove = oldTags - request.tags
         val tagsToAdd = request.tags - oldTags
 
-        for (tagName in tagsToRemove) {
+        for (tagRequest in tagsToRemove) {
+            val tagName = TagInNotice.valueOf(tagRequest)
             val tagId = tagInNoticeRepository.findByName(tagName)!!.id
             notice.noticeTags.removeIf { it.tag.name == tagName }
             noticeTagRepository.deleteByNoticeIdAndTagId(noticeId, tagId)
@@ -172,6 +178,8 @@ class NoticeServiceImpl(
         }
     }
 
+
+
     override fun enrollTag(tagName: String) {
         val newTag = TagInNoticeEntity(
             name = tagName
@@ -179,5 +187,6 @@ class NoticeServiceImpl(
         tagInNoticeRepository.save(newTag)
     }
 
-    //TODO: 이미지 등록, 글쓴이 함께 조회
+     */
+
 }


### PR DESCRIPTION
## 제목
fix: main 프론트에 맞게 협의, notice 태그 enum 추가

### 한줄 요약
mainResponse을 프론트가 원하는 바에 따라 고쳤고, notice에서 태그들을 enum으로 추가시켰습니다.

### 상세 설명

[73b195a248fadce79bfd4a85d3b38010afd61bbf]: 프론트에서 메인을 slides, notices, importants로 주기를 원해서 맞게 고쳤습니다.

[c2ddb16540295d6d5c55bcb0b7504c6f6bd2370f]: notice Tag들을 프론트에서 제공하는 목록 그대로 가져왔습니다.

[015353473c50c22500d1db96a1678f58fb18d9a3]: tagEnum을 update, main 등에서도 잘 쓸 수 있도록 들고왔습니다.

### TODO
News 태그를 손봐야 하고, 소개에서 차트도 봐야 합니다
질문이 있는데, 저희 검색을 위해 pageName 넣기로 한거 아직 그대로죠?
