### PR TITLE
fix: 파일 관련 수정

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/dto/AttachmentResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/dto/AttachmentResponse.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.csereal.core.resource.attachment.dto
 
 data class AttachmentResponse(
+    val id: Long,
     val name: String,
     val url: String,
     val bytes: Long,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/service/AttachmentService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/service/AttachmentService.kt
@@ -124,7 +124,7 @@ class AttachmentServiceImpl(
             for (attachment in attachments) {
                 if (attachment.isDeleted == false) {
                     val attachmentDto = AttachmentResponse(
-                        name = attachment.filename,
+                        name = attachment.filename.substringAfter("_"),
                         url = "${endpointProperties.backend}/v1/file/${attachment.filename}",
                         bytes = attachment.size,
                     )

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/api/SeminarController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/api/SeminarController.kt
@@ -1,6 +1,5 @@
 package com.wafflestudio.csereal.core.seminar.api
 
-import com.wafflestudio.csereal.core.resource.attachment.dto.AttachmentResponse
 import com.wafflestudio.csereal.core.seminar.dto.SeminarDto
 import com.wafflestudio.csereal.core.seminar.dto.SeminarSearchResponse
 import com.wafflestudio.csereal.core.seminar.service.SeminarService
@@ -48,7 +47,7 @@ class SeminarController(
         @Valid @RequestPart("request") request: SeminarDto,
         @RequestPart("newMainImage") newMainImage: MultipartFile?,
         @RequestPart("newAttachments") newAttachments: List<MultipartFile>?,
-        @RequestPart("attachmentsList") attachmentsList: List<AttachmentResponse>,
+        @RequestPart("deleteIds") deleteIds: List<Long>,
     ): ResponseEntity<SeminarDto> {
         return ResponseEntity.ok(
             seminarService.updateSeminar(
@@ -56,7 +55,7 @@ class SeminarController(
                 request,
                 newMainImage,
                 newAttachments,
-                attachmentsList
+                deleteIds
             )
         )
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,6 +16,11 @@ spring:
           idsnucse:
             issuer-uri: https://id-dev.bacchus.io/o
             jwk-set-uri: https://id-dev.bacchus.io/o/jwks
+  servlet:
+    multipart:
+      enabled: true
+      max-request-size: 100MB
+      max-file-size: 10MB
 
 server:
   servlet:
@@ -29,12 +34,6 @@ springdoc:
     path: index.html
   api-docs:
     path: /api-docs/json
-
-servlet:
-  multipart:
-    enabled: true
-    max-request-size: 100MB
-    max-file-size: 10MB
 
 ---
 spring:


### PR DESCRIPTION
## 파일 관련 수정

### 한줄 요약

파일 업로드 사이즈 제한 설정 fix + 첨부파일 이름 원본으로 응답하고 id를 별도로 응답에 추가하였습니다.
세미나 업데이트 시 id 리스트로만 soft delete 수행하도록 리팩토링하였습니다.
기존 로직은 주석 처리해놓았는데 문제없으면 추후에 삭제하겠습니다.

### 상세 설명

[ab188ecf114a3da045f47c073633d23d5a7c79fe]: 파일 사이즈 제한 관련 yml 파일 수정

[2e2b53be9aeab755f7745286ae8faf2dc06b6603]: 첨부파일 응답 name 원본 이름으로 변경

[f394637775be18e1aeec9d7419aaf79447b0f1b3]: PATCH API에서 첨부파일 삭제시 id 리스트받게끔 수정

### TODO

파일, 이미지 업로드 경로 설정?
