### PR TITLE
fix: GET notice 권한 관련 로직 수정

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
@@ -3,10 +3,14 @@ package com.wafflestudio.csereal.core.notice.api
 import com.wafflestudio.csereal.common.aop.AuthenticatedStaff
 import com.wafflestudio.csereal.core.notice.dto.*
 import com.wafflestudio.csereal.core.notice.service.NoticeService
+import com.wafflestudio.csereal.core.user.database.Role
+import com.wafflestudio.csereal.core.user.database.UserRepository
 import jakarta.validation.Valid
 import org.springframework.data.domain.PageRequest
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.oauth2.core.oidc.user.OidcUser
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 
@@ -14,17 +18,27 @@ import org.springframework.web.multipart.MultipartFile
 @RestController
 class NoticeController(
     private val noticeService: NoticeService,
+    private val userRepository: UserRepository
 ) {
     @GetMapping
     fun searchNotice(
         @RequestParam(required = false) tag: List<String>?,
         @RequestParam(required = false) keyword: String?,
-        @RequestParam(required = false, defaultValue = "1") pageNum: Int
+        @RequestParam(required = false, defaultValue = "1") pageNum: Int,
+        @AuthenticationPrincipal oidcUser: OidcUser?
     ): ResponseEntity<NoticeSearchResponse> {
+        var isStaff = false
+        if (oidcUser != null) {
+            val username = oidcUser.idToken.getClaim<String>("username")
+            val user = userRepository.findByUsername(username)
+            if (user?.role == Role.ROLE_STAFF) {
+                isStaff = true
+            }
+        }
         val pageSize = 20
         val pageRequest = PageRequest.of(pageNum - 1, pageSize)
         val usePageBtn = pageNum != 1
-        return ResponseEntity.ok(noticeService.searchNotice(tag, keyword, pageRequest, usePageBtn))
+        return ResponseEntity.ok(noticeService.searchNotice(tag, keyword, pageRequest, usePageBtn, isStaff))
     }
 
     @GetMapping("/{noticeId}")

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
@@ -33,7 +33,8 @@ interface CustomNoticeRepository {
         tag: List<String>?,
         keyword: String?,
         pageable: Pageable,
-        usePageBtn: Boolean
+        usePageBtn: Boolean,
+        isStaff: Boolean
     ): NoticeSearchResponse
 }
 
@@ -46,24 +47,9 @@ class NoticeRepositoryImpl(
         tag: List<String>?,
         keyword: String?,
         pageable: Pageable,
-        usePageBtn: Boolean
+        usePageBtn: Boolean,
+        isStaff: Boolean
     ): NoticeSearchResponse {
-        var user = RequestContextHolder.getRequestAttributes()?.getAttribute(
-            "loggedInUser",
-            RequestAttributes.SCOPE_REQUEST
-        ) as UserEntity?
-
-        if (user == null) {
-            val oidcUser = SecurityContextHolder.getContext().authentication.principal as OidcUser
-            val username = oidcUser.idToken.getClaim<String>("username")
-
-            if(userRepository.findByUsername(username) == null)  {
-                user = null
-            } else {
-                user = userRepository.findByUsername(username)
-            }
-        }
-
         val keywordBooleanBuilder = BooleanBuilder()
         val tagsBooleanBuilder = BooleanBuilder()
         val isPrivateBooleanBuilder = BooleanBuilder()
@@ -91,7 +77,7 @@ class NoticeRepositoryImpl(
             }
         }
 
-        if(user?.role != Role.ROLE_STAFF) {
+        if (!isStaff) {
             isPrivateBooleanBuilder.or(
                 noticeEntity.isPrivate.eq(false)
             )

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
@@ -22,7 +22,8 @@ interface NoticeService {
         tag: List<String>?,
         keyword: String?,
         pageable: Pageable,
-        usePageBtn: Boolean
+        usePageBtn: Boolean,
+        isStaff: Boolean
     ): NoticeSearchResponse
 
     fun readNotice(noticeId: Long): NoticeDto
@@ -48,9 +49,10 @@ class NoticeServiceImpl(
         tag: List<String>?,
         keyword: String?,
         pageable: Pageable,
-        usePageBtn: Boolean
+        usePageBtn: Boolean,
+        isStaff: Boolean
     ): NoticeSearchResponse {
-        return noticeRepository.searchNotice(tag, keyword, pageable, usePageBtn)
+        return noticeRepository.searchNotice(tag, keyword, pageable, usePageBtn, isStaff)
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## GET notice 수정

### 한줄 요약

로그인 없이 GET /notice 하면 500이 떠서 관련 로직을 수정하였습니다.

### 상세 설명

[1233bb30967d86d2cb528547ec27aa415a9f9e11]: 컨트롤러 단에서 권한 체크
