### PR TITLE
refactor: 공지 태그 응답 한국어로 변경 및 리팩토링

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsRepository.kt
@@ -88,10 +88,10 @@ class NewsRepositoryImpl(
                 title = it.title,
                 description = it.plainTextDescription,
                 createdAt = it.createdAt,
-                tags = it.newsTags.map { newsTagEntity -> TagInNewsEnum.getTagString(newsTagEntity.tag.name) },
+                tags = it.newsTags.map { newsTagEntity -> newsTagEntity.tag.name.krName },
                 imageURL = imageURL
             )
         }
-        return NewsSearchResponse(total!!, newsSearchDtoList)
+        return NewsSearchResponse(total, newsSearchDtoList)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/database/TagInNewsEnum.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/database/TagInNewsEnum.kt
@@ -2,39 +2,15 @@ package com.wafflestudio.csereal.core.news.database
 
 import com.wafflestudio.csereal.common.CserealException
 
-enum class TagInNewsEnum {
-    EVENT, RESEARCH, AWARDS, RECRUIT, COLUMN, LECTURE, EDUCATION, INTERVIEW, CAREER, UNCLASSIFIED;
+enum class TagInNewsEnum(val krName: String) {
+    EVENT("행사"), RESEARCH("연구"), AWARDS("수상"), RECRUIT("채용"), COLUMN("칼럼"),
+    LECTURE("강연"), EDUCATION("교육"), INTERVIEW("인터뷰"), CAREER("진로"), UNCLASSIFIED("과거 미분류");
 
     companion object {
-        fun getTagEnum(t: String) : TagInNewsEnum {
-            return when (t) {
-                "행사" -> EVENT
-                "연구" -> RESEARCH
-                "수상" -> AWARDS
-                "채용" -> RECRUIT
-                "칼럼" -> COLUMN
-                "강연" -> LECTURE
-                "교육" -> EDUCATION
-                "인터뷰" -> INTERVIEW
-                "진로" -> CAREER
-                "과거 미분류" -> UNCLASSIFIED
-                else -> throw CserealException.Csereal404("태그를 찾을 수 없습니다")
-            }
-        }
+        private val lookupMap: Map<String, TagInNewsEnum> = TagInNewsEnum.values().associateBy(TagInNewsEnum::krName)
 
-        fun getTagString(t: TagInNewsEnum): String {
-            return when (t) {
-                EVENT -> "행사"
-                RESEARCH -> "연구"
-                AWARDS -> "수상"
-                RECRUIT -> "채용"
-                COLUMN -> "칼럼"
-                LECTURE -> "강연"
-                EDUCATION -> "교육"
-                INTERVIEW -> "인터뷰"
-                CAREER -> "진로"
-                UNCLASSIFIED -> "과거 미분류"
-            }
+        fun getTagEnum(t: String): TagInNewsEnum {
+            return lookupMap[t] ?: throw CserealException.Csereal404("태그를 찾을 수 없습니다: $t")
         }
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/dto/NewsDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/dto/NewsDto.kt
@@ -1,7 +1,6 @@
 package com.wafflestudio.csereal.core.news.dto
 
 import com.wafflestudio.csereal.core.news.database.NewsEntity
-import com.wafflestudio.csereal.core.news.database.TagInNewsEnum
 import com.wafflestudio.csereal.core.resource.attachment.dto.AttachmentResponse
 import java.time.LocalDateTime
 
@@ -34,7 +33,7 @@ data class NewsDto(
                 id = this.id,
                 title = this.title,
                 description = this.description,
-                tags = this.newsTags.map { TagInNewsEnum.getTagString(it.tag.name) },
+                tags = this.newsTags.map { it.tag.name.krName },
                 createdAt = this.createdAt,
                 modifiedAt = this.modifiedAt,
                 isPrivate = this.isPrivate,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/TagInNoticeEnum.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/TagInNoticeEnum.kt
@@ -2,28 +2,17 @@ package com.wafflestudio.csereal.core.notice.database
 
 import com.wafflestudio.csereal.common.CserealException
 
-enum class TagInNoticeEnum {
-    CLASS, SCHOLARSHIP, UNDERGRADUATE, GRADUATE, MINOR, REGISTRATIONS, ADMISSIONS, GRADUATIONS,
-    RECRUIT, STUDENT_EXCHANGE, INNER_EVENTS_PROGRAMS, OUTER_EVENTS_PROGRAMS, FOREIGN;
+enum class TagInNoticeEnum(val krName: String) {
+    CLASS("수업"), SCHOLARSHIP("장학"), UNDERGRADUATE("학사(학부)"), GRADUATE("학사(대학원)"),
+    MINOR("다전공/전과"), REGISTRATIONS("등록/복학/휴학/재입학"), ADMISSIONS("입학"), GRADUATIONS("졸업"),
+    RECRUIT("채용정보"), STUDENT_EXCHANGE("교환학생/유학"), INNER_EVENTS_PROGRAMS("내부행사/프로그램"),
+    OUTER_EVENTS_PROGRAMS("외부행사/프로그램"), FOREIGN("foreign");
 
     companion object {
+        private val lookupMap: Map<String, TagInNoticeEnum> = values().associateBy(TagInNoticeEnum::krName)
+
         fun getTagEnum(t: String): TagInNoticeEnum {
-            return when (t) {
-                "수업" -> CLASS
-                "장학" -> SCHOLARSHIP
-                "학사(학부)" -> UNDERGRADUATE
-                "학사(대학원)" -> GRADUATE
-                "다전공/전과" -> MINOR
-                "등록/복학/휴학/재입학" -> REGISTRATIONS
-                "입학" -> ADMISSIONS
-                "졸업" -> GRADUATIONS
-                "채용정보" -> RECRUIT
-                "교환학생/유학" -> STUDENT_EXCHANGE
-                "내부행사/프로그램" -> INNER_EVENTS_PROGRAMS
-                "외부행사/프로그램" -> OUTER_EVENTS_PROGRAMS
-                "foreign" -> FOREIGN
-                else -> throw CserealException.Csereal404("태그를 찾을 수 없습니다")
-            }
+            return lookupMap[t] ?: throw CserealException.Csereal404("태그를 찾을 수 없습니다: $t")
         }
     }
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/NoticeDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/NoticeDto.kt
@@ -35,7 +35,7 @@ data class NoticeDto(
                 title = this.title,
                 description = this.description,
                 author = this.author.name,
-                tags = this.noticeTags.map { it.tag.name.name },
+                tags = this.noticeTags.map { it.tag.name.krName },
                 createdAt = this.createdAt,
                 modifiedAt = this.modifiedAt,
                 isPrivate = this.isPrivate,


### PR DESCRIPTION
## 태그 리팩토링

### 한줄 요약

공지 태그 응답을 한국어로 수정 및 공지,새소식 태그를 리팩토링하였습니다.

### 상세 설명

[796966d8e4001183f721a4ee5a252b77725a859e]: 공지 태그

[4d56af023a030e7cb050269e63b3c7bd8c3bff5d]: 새소식 태그
