### PR TITLE
fix: 공지 새소식 PATCH 로직 수정

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/api/NewsController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/api/NewsController.kt
@@ -50,10 +50,11 @@ class NewsController(
     fun updateNews(
         @PathVariable newsId: Long,
         @Valid @RequestPart("request") request: NewsDto,
-        @RequestPart("mainImage") mainImage: MultipartFile?,
-        @RequestPart("attachments") attachments: List<MultipartFile>?
+        @RequestPart("newMainImage") newMainImage: MultipartFile?,
+        @RequestPart("newAttachments") newAttachments: List<MultipartFile>?,
+        @RequestPart("deleteIds") deleteIds: List<Long>,
     ): ResponseEntity<NewsDto> {
-        return ResponseEntity.ok(newsService.updateNews(newsId, request, mainImage, attachments))
+        return ResponseEntity.ok(newsService.updateNews(newsId, request, newMainImage, newAttachments, deleteIds))
     }
 
     @AuthenticatedStaff

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
@@ -62,9 +62,10 @@ class NoticeController(
     fun updateNotice(
         @PathVariable noticeId: Long,
         @Valid @RequestPart("request") request: NoticeDto,
-        @RequestPart("attachments") attachments: List<MultipartFile>?,
+        @RequestPart("newAttachments") newAttachments: List<MultipartFile>?,
+        @RequestPart("deleteIds") deleteIds: List<Long>,
     ): ResponseEntity<NoticeDto> {
-        return ResponseEntity.ok(noticeService.updateNotice(noticeId, request, attachments))
+        return ResponseEntity.ok(noticeService.updateNotice(noticeId, request, newAttachments, deleteIds))
     }
 
     @AuthenticatedStaff

--- a/src/test/kotlin/com/wafflestudio/csereal/core/notice/news/NewsServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/notice/news/NewsServiceTest.kt
@@ -12,8 +12,8 @@ import org.springframework.data.repository.findByIdOrNull
 
 @SpringBootTest
 class NewsServiceTest(
-        private val newsService: NewsService,
-        private val newsRepository: NewsRepository,
+    private val newsService: NewsService,
+    private val newsRepository: NewsRepository,
 ) : BehaviorSpec() {
     init {
 
@@ -23,25 +23,25 @@ class NewsServiceTest(
 
         Given("뉴스를 생성하려고 할 때 간단한 뉴스가 주어지면") {
             val newsDTO = NewsDto(
-                    id = -1,
-                    title = "title",
-                    description = """
+                id = -1,
+                title = "title",
+                description = """
                         <h1>Hello, World!</h1>
                         <p>This is news description.</p>
                         <h3>Goodbye, World!</h3>
                     """.trimIndent(),
-                    tags = emptyList(),
-                    createdAt = null,
-                    modifiedAt = null,
-                    isPrivate = false,
-                    isSlide = false,
-                    isImportant = false,
-                    prevId = null,
-                    prevTitle = null,
-                    nextId = null,
-                    nextTitle = null,
-                    imageURL = null,
-                    attachments = null,
+                tags = emptyList(),
+                createdAt = null,
+                modifiedAt = null,
+                isPrivate = false,
+                isSlide = false,
+                isImportant = false,
+                prevId = null,
+                prevTitle = null,
+                nextId = null,
+                nextTitle = null,
+                imageURL = null,
+                attachments = null,
             )
 
             When("DTO를 이용하여 뉴스를 생성하면") {
@@ -61,33 +61,35 @@ class NewsServiceTest(
 
         Given("간단한 뉴스가 저장되어 있을 때") {
             val newsEntity = newsRepository.save(
-                    NewsEntity(
-                            title = "title",
-                            description = """
+                NewsEntity(
+                    title = "title",
+                    description = """
                             <h1>Hello, World!</h1>
                             <p>This is news description.</p>
                             <h3>Goodbye, World!</h3>
                             """.trimIndent(),
-                            plainTextDescription = "Hello, World! This is news description. Goodbye, World!",
-                            isPrivate = false,
-                            isSlide = false,
-                            isImportant = false,
-                    )
+                    plainTextDescription = "Hello, World! This is news description. Goodbye, World!",
+                    isPrivate = false,
+                    isSlide = false,
+                    isImportant = false,
+                )
             )
 
             When("저장된 뉴스의 Description을 수정하면") {
                 newsService.updateNews(
-                        newsEntity.id,
-                        NewsDto.of(newsEntity, null, emptyList(), null)
-                                .copy(description = """
+                    newsEntity.id,
+                    NewsDto.of(newsEntity, null, emptyList(), null)
+                        .copy(
+                            description = """
                             <h1>Hello, World!</h1>
                             <p>This is modified news description.</p>
                             <h3>Goodbye, World!</h3>
                             <p>This is additional description.</p>
                             """.trimIndent()
-                                ),
-                        null,
-                        null
+                        ),
+                    null,
+                    null,
+                    emptyList()
                 )
 
                 Then("description, plainTextDescription이 수정되어야 한다.") {

--- a/src/test/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeServiceTest.kt
@@ -19,20 +19,20 @@ import org.springframework.web.context.request.RequestContextHolder
 
 @SpringBootTest
 class NoticeServiceTest(
-        private val noticeService: NoticeService,
-        private val userRepository: UserRepository,
-        private val noticeRepository: NoticeRepository,
+    private val noticeService: NoticeService,
+    private val userRepository: UserRepository,
+    private val noticeRepository: NoticeRepository,
 ) : BehaviorSpec() {
     init {
         beforeContainer {
             userRepository.save(
-                    UserEntity(
-                            "username",
-                            "name",
-                            "email",
-                            "studentId",
-                            Role.ROLE_STAFF
-                    )
+                UserEntity(
+                    "username",
+                    "name",
+                    "email",
+                    "studentId",
+                    Role.ROLE_STAFF
+                )
             )
         }
 
@@ -51,31 +51,31 @@ class NoticeServiceTest(
             } returns mockRequestAttributes
             every {
                 mockRequestAttributes.getAttribute(
-                        "loggedInUser",
-                        RequestAttributes.SCOPE_REQUEST
+                    "loggedInUser",
+                    RequestAttributes.SCOPE_REQUEST
                 )
             } returns userEntity
 
             val noticeDto = NoticeDto(
-                    id = -1,
-                    title = "title",
-                    description = """
+                id = -1,
+                title = "title",
+                description = """
                             <h1>Hello, World!</h1>
                             <p>This is a test notice.</p>
                             <h3>Goodbye, World!</h3>
                         """.trimIndent(),
-                    author = "username",
-                    tags = emptyList(),
-                    createdAt = null,
-                    modifiedAt = null,
-                    isPrivate = false,
-                    isPinned = false,
-                    isImportant = false,
-                    prevId = null,
-                    prevTitle = null,
-                    nextId = null,
-                    nextTitle = null,
-                    attachments = null,
+                author = "username",
+                tags = emptyList(),
+                createdAt = null,
+                modifiedAt = null,
+                isPrivate = false,
+                isPinned = false,
+                isImportant = false,
+                prevId = null,
+                prevTitle = null,
+                nextId = null,
+                nextTitle = null,
+                attachments = null,
             )
 
             When("공지사항을 생성하면") {
@@ -93,25 +93,25 @@ class NoticeServiceTest(
         }
 
         Given("기존 간단한 공지사항의 Description을 수정하려고 할 때") {
-            val noticeEntity = noticeRepository.save (
-                    NoticeEntity(
-                            title = "title",
-                            description = """
+            val noticeEntity = noticeRepository.save(
+                NoticeEntity(
+                    title = "title",
+                    description = """
                                     <h1>Hello, World!</h1>
                                     <p>This is a test notice.</p>
                                     <h3>Goodbye, World!</h3>
                                 """.trimIndent(),
-                            plainTextDescription = "Hello, World! This is a test notice. Goodbye, World!",
-                            isPrivate = false,
-                            isPinned = false,
-                            isImportant = false,
-                            author = userRepository.findByUsername("username")!!,
-                    )
+                    plainTextDescription = "Hello, World! This is a test notice. Goodbye, World!",
+                    isPrivate = false,
+                    isPinned = false,
+                    isImportant = false,
+                    author = userRepository.findByUsername("username")!!,
+                )
             )
             val modifiedRequest = NoticeDto.of(
-                    noticeEntity, emptyList(), null
+                noticeEntity, emptyList(), null
             ).copy(
-                    description = """
+                description = """
                             <h1>Hello, World!</h1>
                             <p>This is a modified test notice.</p>
                             <h3>Goodbye, World!</h3>
@@ -121,9 +121,10 @@ class NoticeServiceTest(
 
             When("수정된 DTO를 이용하여 수정하면") {
                 val modifiedNoticeDto = noticeService.updateNotice(
-                        modifiedRequest.id,
-                        modifiedRequest,
-                        null
+                    modifiedRequest.id,
+                    modifiedRequest,
+                    null,
+                    emptyList()
                 )
 
                 Then("plainTextDescription이 잘 수정되어야 한다.") {


### PR DESCRIPTION
## 공지 새소식 PATCH API 수정

### 한줄 요약

세미나에 적용했던 로직 동일하게 공지 새소식에도 적용하였습니다 

### 상세 설명

[e47cf8a81901ff003d404e9f359180e194dc431d]: fix PATCH api

### TODO

예약 쪽 권한 수정