### PR TITLE
fix: total 더미 값 + pageNum null일때만 더미 값 주기

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/api/NewsController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/api/NewsController.kt
@@ -20,11 +20,12 @@ class NewsController(
     fun searchNews(
         @RequestParam(required = false) tag: List<String>?,
         @RequestParam(required = false) keyword: String?,
-        @RequestParam(required = false, defaultValue = "1") pageNum: Int
+        @RequestParam(required = false) pageNum: Int?
     ): ResponseEntity<NewsSearchResponse> {
         val pageSize = 10
-        val pageRequest = PageRequest.of(pageNum - 1, pageSize)
-        val usePageBtn = pageNum != 1
+        val usePageBtn = pageNum != null
+        val page = pageNum ?: 1
+        val pageRequest = PageRequest.of(page - 1, pageSize)
         return ResponseEntity.ok(newsService.searchNews(tag, keyword, pageRequest, usePageBtn))
     }
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsRepository.kt
@@ -71,7 +71,7 @@ class NewsRepositoryImpl(
             total = countQuery.select(newsEntity.countDistinct()).fetchOne()!!
             pageRequest = FixedPageRequest(pageable, total)
         } else {
-            total = (10 * pageable.pageSize).toLong() // 10개 페이지 고정
+            total = (10 * pageable.pageSize).toLong() + 1 // 10개 페이지 고정
         }
 
         val newsEntityList = jpaQuery

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
@@ -24,20 +24,19 @@ class NoticeController(
     fun searchNotice(
         @RequestParam(required = false) tag: List<String>?,
         @RequestParam(required = false) keyword: String?,
-        @RequestParam(required = false, defaultValue = "1") pageNum: Int,
+        @RequestParam(required = false) pageNum: Int?,
         @AuthenticationPrincipal oidcUser: OidcUser?
     ): ResponseEntity<NoticeSearchResponse> {
-        var isStaff = false
-        if (oidcUser != null) {
-            val username = oidcUser.idToken.getClaim<String>("username")
+        val isStaff = oidcUser?.let {
+            val username = it.idToken.getClaim<String>("username")
             val user = userRepository.findByUsername(username)
-            if (user?.role == Role.ROLE_STAFF) {
-                isStaff = true
-            }
-        }
+            user?.role == Role.ROLE_STAFF
+        } ?: false
+
+        val usePageBtn = pageNum != null
+        val page = pageNum ?: 1
         val pageSize = 20
-        val pageRequest = PageRequest.of(pageNum - 1, pageSize)
-        val usePageBtn = pageNum != 1
+        val pageRequest = PageRequest.of(page - 1, pageSize)
         return ResponseEntity.ok(noticeService.searchNotice(tag, keyword, pageRequest, usePageBtn, isStaff))
     }
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
@@ -93,7 +93,7 @@ class NoticeRepositoryImpl(
             total = countQuery.select(noticeEntity.countDistinct()).fetchOne()!!
             pageRequest = FixedPageRequest(pageable, total)
         } else {
-            total = (10 * pageable.pageSize).toLong() // 10개 페이지 고정
+            total = (10 * pageable.pageSize).toLong() + 1 // 10개 페이지 고정
         }
 
         val noticeSearchDtoList = jpaQuery

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/api/SeminarController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/api/SeminarController.kt
@@ -19,11 +19,12 @@ class SeminarController(
     @GetMapping
     fun searchSeminar(
         @RequestParam(required = false) keyword: String?,
-        @RequestParam(required = false, defaultValue = "1") pageNum: Int
+        @RequestParam(required = false) pageNum: Int?
     ): ResponseEntity<SeminarSearchResponse> {
         val pageSize = 10
-        val pageRequest = PageRequest.of(pageNum - 1, pageSize)
-        val usePageBtn = pageNum != 1
+        val usePageBtn = pageNum != null
+        val page = pageNum ?: 1
+        val pageRequest = PageRequest.of(page - 1, pageSize)
         return ResponseEntity.ok(seminarService.searchSeminar(keyword, pageRequest, usePageBtn))
     }
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarRepository.kt
@@ -35,14 +35,14 @@ class SeminarRepositoryImpl(
 
         if (!keyword.isNullOrEmpty()) {
             val booleanTemplate = commonRepository.searchFullSeptupleTextTemplate(
-                    keyword,
-                    seminarEntity.title,
-                    seminarEntity.name,
-                    seminarEntity.affiliation,
-                    seminarEntity.location,
-                    seminarEntity.plainTextDescription,
-                    seminarEntity.plainTextIntroduction,
-                    seminarEntity.plainTextAdditionalNote,
+                keyword,
+                seminarEntity.title,
+                seminarEntity.name,
+                seminarEntity.affiliation,
+                seminarEntity.location,
+                seminarEntity.plainTextDescription,
+                seminarEntity.plainTextIntroduction,
+                seminarEntity.plainTextAdditionalNote,
             )
             keywordBooleanBuilder.and(booleanTemplate.gt(0.0))
         }
@@ -59,7 +59,7 @@ class SeminarRepositoryImpl(
             total = countQuery.select(seminarEntity.count()).fetchOne()!!
             pageRequest = FixedPageRequest(pageable, total)
         } else {
-            total = (10 * pageable.pageSize).toLong() // 10개 페이지 고정
+            total = (10 * pageable.pageSize).toLong() + 1 // 10개 페이지 고정
         }
 
         val seminarEntityList = jpaQuery


### PR DESCRIPTION
## total 관련 수정

### 한줄 요약

프론트에서 다음 페이지 버튼을 위해 total 더미 값 수정하고 pageNum null 일때만 더미 값 주도록 변경하였습니다 (1페이지 버튼 눌러도 total값 제대로 주게끔)

### 상세 설명

[cad8cade214ad4d8ffb6f5db2bdb54cd46a1229e]: total 값 관련 수정
