### PR TITLE
feat: migrateAbout, migrateFutureCareers 추가

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/api/AboutController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/api/AboutController.kt
@@ -63,4 +63,11 @@ class AboutController(
     ): ResponseEntity<List<AboutDto>> {
         return ResponseEntity.ok(aboutService.migrateAbout(requestList))
     }
+
+    @PostMapping("/future-careers/migrate")
+    fun migrateFutureCareers(
+        @RequestBody request: FutureCareersRequest
+    ): ResponseEntity<FutureCareersResponse> {
+        return ResponseEntity.ok(aboutService.migrateFutureCareers(request))
+    }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/api/AboutController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/api/AboutController.kt
@@ -2,6 +2,8 @@ package com.wafflestudio.csereal.core.about.api
 
 import com.wafflestudio.csereal.common.aop.AuthenticatedStaff
 import com.wafflestudio.csereal.core.about.dto.*
+import com.wafflestudio.csereal.core.about.dto.request.AboutRequest
+import com.wafflestudio.csereal.core.about.dto.request.FutureCareersRequest
 import com.wafflestudio.csereal.core.about.service.AboutService
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/api/AboutController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/api/AboutController.kt
@@ -1,9 +1,7 @@
 package com.wafflestudio.csereal.core.about.api
 
 import com.wafflestudio.csereal.common.aop.AuthenticatedStaff
-import com.wafflestudio.csereal.core.about.dto.AboutDto
-import com.wafflestudio.csereal.core.about.dto.CompanyDto
-import com.wafflestudio.csereal.core.about.dto.FutureCareersPage
+import com.wafflestudio.csereal.core.about.dto.*
 import com.wafflestudio.csereal.core.about.service.AboutService
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
@@ -59,4 +57,10 @@ class AboutController(
         return ResponseEntity.ok(aboutService.readFutureCareers())
     }
 
+    @PostMapping("/migrate")
+    fun migrateAbout(
+        @RequestBody requestList: List<AboutRequest>
+    ): ResponseEntity<List<AboutDto>> {
+        return ResponseEntity.ok(aboutService.migrateAbout(requestList))
+    }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/database/CompanyEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/database/CompanyEntity.kt
@@ -1,12 +1,22 @@
 package com.wafflestudio.csereal.core.about.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.core.about.dto.FutureCareersCompanyDto
 import jakarta.persistence.Entity
 
 @Entity(name = "company")
 class CompanyEntity(
     var name: String,
-    var url: String,
-    var year: Int,
+    var url: String?,
+    var year: Int?,
 ) : BaseTimeEntity() {
+    companion object {
+        fun of(companyDto: FutureCareersCompanyDto): CompanyEntity {
+            return CompanyEntity(
+                name = companyDto.name,
+                url = companyDto.url,
+                year = companyDto.year,
+            )
+        }
+    }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/database/StatEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/database/StatEntity.kt
@@ -1,6 +1,8 @@
 package com.wafflestudio.csereal.core.about.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.core.about.dto.FutureCareersStatDegreeDto
+import com.wafflestudio.csereal.core.about.dto.FutureCareersStatDto
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
@@ -14,6 +16,16 @@ class StatEntity(
     var name: String,
     var count: Int,
 ): BaseTimeEntity() {
+    companion object {
+        fun of(year: Int, degree: Degree, statDto: FutureCareersStatDegreeDto): StatEntity {
+            return StatEntity(
+                year = year,
+                degree = degree,
+                name = statDto.name,
+                count = statDto.count,
+            )
+        }
+    }
 }
 
 enum class Degree {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/AboutDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/AboutDto.kt
@@ -1,12 +1,14 @@
 package com.wafflestudio.csereal.core.about.dto
 
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.wafflestudio.csereal.core.about.database.AboutEntity
 import com.wafflestudio.csereal.core.resource.attachment.dto.AttachmentResponse
 import java.time.LocalDateTime
 
 data class AboutDto(
-    val id: Long,
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    val id: Long? = null,
     val name: String?,
     val engName: String?,
     val description: String,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/AboutRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/AboutRequest.kt
@@ -1,0 +1,16 @@
+package com.wafflestudio.csereal.core.about.dto
+
+import java.time.LocalDateTime
+
+data class AboutRequest(
+    val postType: String,
+    val id: Long,
+    val name: String?,
+    val engName: String?,
+    val description: String,
+    val year: Int?,
+    val createdAt: LocalDateTime?,
+    val modifiedAt: LocalDateTime?,
+    val locations: List<String>?,
+) {
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/FutureCareersCompanyDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/FutureCareersCompanyDto.kt
@@ -1,8 +1,8 @@
 package com.wafflestudio.csereal.core.about.dto
 
-data class CompanyDto(
+data class FutureCareersCompanyDto(
     val name: String,
     val url: String?,
-    val year: Int?,
+    val year: Int?
 ) {
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/FutureCareersRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/FutureCareersRequest.kt
@@ -1,0 +1,8 @@
+package com.wafflestudio.csereal.core.about.dto
+
+data class FutureCareersRequest(
+    val description: String,
+    val stat: List<FutureCareersStatDto>,
+    val companies: List<FutureCareersCompanyDto>
+) {
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/FutureCareersRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/FutureCareersRequest.kt
@@ -1,8 +1,0 @@
-package com.wafflestudio.csereal.core.about.dto
-
-data class FutureCareersRequest(
-    val description: String,
-    val stat: List<FutureCareersStatDto>,
-    val companies: List<FutureCareersCompanyDto>
-) {
-}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/FutureCareersResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/FutureCareersResponse.kt
@@ -1,0 +1,8 @@
+package com.wafflestudio.csereal.core.about.dto
+
+data class FutureCareersResponse(
+    val description: String,
+    val stat: List<FutureCareersStatDto>,
+    val companies: List<FutureCareersCompanyDto>
+) {
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/FutureCareersStatDegreeDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/FutureCareersStatDegreeDto.kt
@@ -1,8 +1,7 @@
 package com.wafflestudio.csereal.core.about.dto
 
-data class CompanyDto(
+data class FutureCareersStatDegreeDto(
     val name: String,
-    val url: String?,
-    val year: Int?,
+    val count: Int,
 ) {
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/FutureCareersStatDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/FutureCareersStatDto.kt
@@ -1,0 +1,9 @@
+package com.wafflestudio.csereal.core.about.dto
+
+data class FutureCareersStatDto(
+    val year: Int,
+    val bachelor: List<FutureCareersStatDegreeDto>,
+    val master: List<FutureCareersStatDegreeDto>,
+    val doctor: List<FutureCareersStatDegreeDto>
+) {
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/request/AboutRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/request/AboutRequest.kt
@@ -1,4 +1,4 @@
-package com.wafflestudio.csereal.core.about.dto
+package com.wafflestudio.csereal.core.about.dto.request
 
 import java.time.LocalDateTime
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/request/AboutRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/request/AboutRequest.kt
@@ -4,13 +4,6 @@ import java.time.LocalDateTime
 
 data class AboutRequest(
     val postType: String,
-    val id: Long,
-    val name: String?,
-    val engName: String?,
     val description: String,
-    val year: Int?,
-    val createdAt: LocalDateTime?,
-    val modifiedAt: LocalDateTime?,
-    val locations: List<String>?,
 ) {
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/request/FutureCareersRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/request/FutureCareersRequest.kt
@@ -1,0 +1,11 @@
+package com.wafflestudio.csereal.core.about.dto.request
+
+import com.wafflestudio.csereal.core.about.dto.FutureCareersCompanyDto
+import com.wafflestudio.csereal.core.about.dto.FutureCareersStatDto
+
+data class FutureCareersRequest(
+    val description: String,
+    val stat: List<FutureCareersStatDto>,
+    val companies: List<FutureCareersCompanyDto>
+) {
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/service/AboutService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/service/AboutService.kt
@@ -16,6 +16,7 @@ interface AboutService {
     fun readAllFacilities() : List<AboutDto>
     fun readAllDirections(): List<AboutDto>
     fun readFutureCareers(): FutureCareersPage
+    fun migrateAbout(requestList: List<AboutRequest>): List<AboutDto>
 
 }
 
@@ -150,6 +151,40 @@ class AboutServiceImpl(
             )
         }
         return FutureCareersPage(description, statList, companyList)
+    }
+
+    override fun migrateAbout(requestList: List<AboutRequest>): List<AboutDto> {
+        val list = mutableListOf<AboutDto>()
+
+        for (request in requestList) {
+            val enumPostType = makeStringToEnum(request.postType)
+
+            val aboutDto = AboutDto(
+                id = request.id,
+                name = request.name,
+                engName = request.engName,
+                description = request.description,
+                year = request.year,
+                createdAt = request.createdAt,
+                modifiedAt = request.modifiedAt,
+                locations = request.locations,
+                imageURL = null,
+                attachments = listOf()
+            )
+            val newAbout = AboutEntity.of(enumPostType, aboutDto)
+
+            if(request.locations != null) {
+                for (location in request.locations) {
+                    LocationEntity.create(location, newAbout)
+                }
+            }
+
+            aboutRepository.save(newAbout)
+
+            list.add(AboutDto.of(newAbout, null, listOf()))
+
+        }
+        return list
     }
 
     private fun makeStringToEnum(postType: String) : AboutPostType {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/service/AboutService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/service/AboutService.kt
@@ -175,24 +175,18 @@ class AboutServiceImpl(
             val enumPostType = makeStringToEnum(request.postType)
 
             val aboutDto = AboutDto(
-                id = request.id,
-                name = request.name,
-                engName = request.engName,
+                id = null,
+                name = null,
+                engName = null,
                 description = request.description,
-                year = request.year,
-                createdAt = request.createdAt,
-                modifiedAt = request.modifiedAt,
-                locations = request.locations,
+                year = null,
+                createdAt = null,
+                modifiedAt = null,
+                locations = null,
                 imageURL = null,
                 attachments = listOf()
             )
             val newAbout = AboutEntity.of(enumPostType, aboutDto)
-
-            if (request.locations != null) {
-                for (location in request.locations) {
-                    LocationEntity.create(location, newAbout)
-                }
-            }
 
             aboutRepository.save(newAbout)
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/service/AboutService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/service/AboutService.kt
@@ -202,6 +202,21 @@ class AboutServiceImpl(
         val statList = mutableListOf<FutureCareersStatDto>()
         val companyList = mutableListOf<FutureCareersCompanyDto>()
 
+        val aboutDto = AboutDto(
+            id = null,
+            name = null,
+            engName = null,
+            description = description,
+            year = null,
+            createdAt = null,
+            modifiedAt = null,
+            locations = null,
+            imageURL = null,
+            attachments = listOf()
+        )
+        val newAbout = AboutEntity.of(AboutPostType.FUTURE_CAREERS, aboutDto)
+        aboutRepository.save(newAbout)
+        
         for (stat in request.stat) {
             val year = stat.year
             val bachelorList = mutableListOf<FutureCareersStatDegreeDto>()

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/service/AboutService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/service/AboutService.kt
@@ -10,13 +10,20 @@ import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
 
 interface AboutService {
-    fun createAbout(postType: String, request: AboutDto, mainImage: MultipartFile?, attachments: List<MultipartFile>?): AboutDto
+    fun createAbout(
+        postType: String,
+        request: AboutDto,
+        mainImage: MultipartFile?,
+        attachments: List<MultipartFile>?
+    ): AboutDto
+
     fun readAbout(postType: String): AboutDto
-    fun readAllClubs() : List<AboutDto>
-    fun readAllFacilities() : List<AboutDto>
+    fun readAllClubs(): List<AboutDto>
+    fun readAllFacilities(): List<AboutDto>
     fun readAllDirections(): List<AboutDto>
     fun readFutureCareers(): FutureCareersPage
     fun migrateAbout(requestList: List<AboutRequest>): List<AboutDto>
+    fun migrateFutureCareers(request: FutureCareersRequest): FutureCareersResponse
 
 }
 
@@ -29,21 +36,26 @@ class AboutServiceImpl(
     private val attachmentService: AttachmentService,
 ) : AboutService {
     @Transactional
-    override fun createAbout(postType: String, request: AboutDto, mainImage: MultipartFile?, attachments: List<MultipartFile>?): AboutDto {
+    override fun createAbout(
+        postType: String,
+        request: AboutDto,
+        mainImage: MultipartFile?,
+        attachments: List<MultipartFile>?
+    ): AboutDto {
         val enumPostType = makeStringToEnum(postType)
         val newAbout = AboutEntity.of(enumPostType, request)
 
-        if(request.locations != null) {
+        if (request.locations != null) {
             for (location in request.locations) {
                 LocationEntity.create(location, newAbout)
             }
         }
 
-        if(mainImage != null) {
+        if (mainImage != null) {
             mainImageService.uploadMainImage(newAbout, mainImage)
         }
 
-        if(attachments != null) {
+        if (attachments != null) {
             attachmentService.uploadAllAttachments(newAbout, attachments)
         }
         aboutRepository.save(newAbout)
@@ -112,7 +124,7 @@ class AboutServiceImpl(
                 "그 이후로는 국내외 관련 산업계, 학계에 주로 진출하고 있고, 새로운 아이디어로 벤처기업을 창업하기도 한다."
 
         val statList = mutableListOf<StatDto>()
-        for(i: Int in 2021 downTo 2011) {
+        for (i: Int in 2021 downTo 2011) {
             val bachelor = statRepository.findAllByYearAndDegree(i, Degree.BACHELOR).map {
                 CompanyNameAndCountDto(
                     id = it.id,
@@ -173,7 +185,7 @@ class AboutServiceImpl(
             )
             val newAbout = AboutEntity.of(enumPostType, aboutDto)
 
-            if(request.locations != null) {
+            if (request.locations != null) {
                 for (location in request.locations) {
                     LocationEntity.create(location, newAbout)
                 }
@@ -187,9 +199,51 @@ class AboutServiceImpl(
         return list
     }
 
-    private fun makeStringToEnum(postType: String) : AboutPostType {
+    override fun migrateFutureCareers(request: FutureCareersRequest): FutureCareersResponse {
+        val description = request.description
+        val statList = mutableListOf<FutureCareersStatDto>()
+        val companyList = mutableListOf<FutureCareersCompanyDto>()
+
+        for (stat in request.stat) {
+            val year = stat.year
+            val bachelorList = mutableListOf<FutureCareersStatDegreeDto>()
+            val masterList = mutableListOf<FutureCareersStatDegreeDto>()
+            val doctorList = mutableListOf<FutureCareersStatDegreeDto>()
+
+            for (bachelor in stat.bachelor) {
+                val newBachelor = StatEntity.of(year, Degree.BACHELOR, bachelor)
+                statRepository.save(newBachelor)
+
+                bachelorList.add(bachelor)
+            }
+            for (master in stat.master) {
+                val newMaster = StatEntity.of(year, Degree.MASTER, master)
+                statRepository.save(newMaster)
+
+                masterList.add(master)
+            }
+            for (doctor in stat.doctor) {
+                val newDoctor = StatEntity.of(year, Degree.DOCTOR, doctor)
+                statRepository.save(newDoctor)
+
+                doctorList.add(doctor)
+            }
+        }
+
+        for (company in request.companies) {
+            val newCompany = CompanyEntity.of(company)
+            companyRepository.save(newCompany)
+
+            companyList.add(company)
+        }
+
+
+        return FutureCareersResponse(description, statList.toList(), companyList.toList())
+    }
+
+    private fun makeStringToEnum(postType: String): AboutPostType {
         try {
-            val upperPostType = postType.replace("-","_").uppercase()
+            val upperPostType = postType.replace("-", "_").uppercase()
             return AboutPostType.valueOf(upperPostType)
 
         } catch (e: IllegalArgumentException) {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/service/AboutService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/service/AboutService.kt
@@ -3,6 +3,8 @@ package com.wafflestudio.csereal.core.about.service
 import com.wafflestudio.csereal.common.CserealException
 import com.wafflestudio.csereal.core.about.database.*
 import com.wafflestudio.csereal.core.about.dto.*
+import com.wafflestudio.csereal.core.about.dto.request.AboutRequest
+import com.wafflestudio.csereal.core.about.dto.request.FutureCareersRequest
 import com.wafflestudio.csereal.core.resource.attachment.service.AttachmentService
 import com.wafflestudio.csereal.core.resource.mainImage.service.MainImageService
 import org.springframework.stereotype.Service
@@ -165,6 +167,7 @@ class AboutServiceImpl(
         return FutureCareersPage(description, statList, companyList)
     }
 
+    @Transactional
     override fun migrateAbout(requestList: List<AboutRequest>): List<AboutDto> {
         val list = mutableListOf<AboutDto>()
 
@@ -199,6 +202,7 @@ class AboutServiceImpl(
         return list
     }
 
+    @Transactional
     override fun migrateFutureCareers(request: FutureCareersRequest): FutureCareersResponse {
         val description = request.description
         val statList = mutableListOf<FutureCareersStatDto>()


### PR DESCRIPTION
## 제목
feat: migrateAbout, migrateFutureCareers 추가

### 한줄 요약
about 패키지에서 migrateAbout, migrateFutureCareers를 추가했고, 관련 request을 추가했습니다.

### 상세 설명

[2f2bba73d50b83bd4dbdb795bbbe2a1df41af06d]: migrateAbout 메서드를 만들었고, 패키지에 대해서 request를 따로 만들었으면 좋겠다고 해서 AboutRequest을 따로 만들었습니다. 나중에는 createAbout의 AboutDto도 AboutRequest로 만들 수 있게끔 만들었습니다.

[f2dc552c2b24ebdd6900780256e2a99def7e4b61]: migrateFutureCareers 메서드를 만들었고, request와 dto를 만들었습니다.
CompanyDto, CompanyNameAndCountDto가 FutureCareersCompanyDto와 FutureCareersStatDegreeDto와 거의 유사한데, 만약 이번 pr이 통과되면 CompanyDto, CompanyNameAndCountDto는 뒤의 두개로 변경할 예정입니다

[[c00821b](https://github.com/wafflestudio/csereal-server/pull/118/commits/c00821b163f539e6e13dd1fe1a2502238cb355b1)]: AboutRequest는 개요, 인사말, 연혁에만 적용되는 것들입니다. 그런데 불필요한 request들이 많아서 다른 것들은 잘랐습니다.
같은 About 패키지라고 하더라도 요청하는 값이 다르면 request을 다르게 할 예정입니다. (이렇게 되면 나중에 api도 세분화하긴 하는데.. 마이그레이션 하면서 어색한건 request 나누고, 이후 api도 쪼개려고 합니다)

[[d64b8be](https://github.com/wafflestudio/csereal-server/pull/118/commits/d64b8be55158b7f9fffa7326abb937ce17ff294c)]: future-careers description을 about 패키지에 저장하는 메서드를 추가했습니다.

### TODO

만약 이번 migrate 기획이 승인되면 다른 패키지들도 하나씩 바꿔나갈 것입니다
사실 마이그레이션을 나중에 할 건데 굳이 지금 메서드 만들기가 필요한지.. 라고 생각하실 거 같기도 한데,
이 과정에서 request를 새로 만들고 있고, request 만들기도 저희가 하기로 했던 일 중 하나니까 일단 지속해보려고 합니다 

만약 더 필요한 다른 업무가 있다면, 언제든지 요청해주세요
