### PR TITLE
fix: 예약 조회 권한 분리 및 응답 단순화

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/conference/service/ConferenceService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/conference/service/ConferenceService.kt
@@ -30,10 +30,10 @@ interface ConferenceService {
 @Service
 @Transactional
 class ConferenceServiceImpl(
-        private val conferencePageRepository: ConferencePageRepository,
-        private val conferenceRepository: ConferenceRepository,
-        private val userRepository: UserRepository,
-        private val researchSearchService: ResearchSearchService,
+    private val conferencePageRepository: ConferencePageRepository,
+    private val conferenceRepository: ConferenceRepository,
+    private val userRepository: UserRepository,
+    private val researchSearchService: ResearchSearchService,
 ) : ConferenceService {
 
     @Transactional(readOnly = true)
@@ -44,17 +44,10 @@ class ConferenceServiceImpl(
 
     @Transactional
     override fun modifyConferences(conferenceModifyRequest: ConferenceModifyRequest): ConferencePage {
-        var user = RequestContextHolder.getRequestAttributes()?.getAttribute(
-                "loggedInUser",
-                RequestAttributes.SCOPE_REQUEST
-        ) as UserEntity?
-
-        if (user == null) {
-            val oidcUser = SecurityContextHolder.getContext().authentication.principal as OidcUser
-            val username = oidcUser.idToken.getClaim<String>("username")
-
-            user = userRepository.findByUsername(username) ?: throw CserealException.Csereal404("재로그인이 필요합니다.")
-        }
+        val user = RequestContextHolder.getRequestAttributes()?.getAttribute(
+            "loggedInUser",
+            RequestAttributes.SCOPE_REQUEST
+        ) as UserEntity
 
         val conferencePage = conferencePageRepository.findAll()[0]
 
@@ -77,12 +70,12 @@ class ConferenceServiceImpl(
 
     @Transactional
     fun createConferenceWithoutSave(
-            conferenceCreateDto: ConferenceCreateDto,
-            conferencePage: ConferencePageEntity,
+        conferenceCreateDto: ConferenceCreateDto,
+        conferencePage: ConferencePageEntity,
     ): ConferenceEntity {
         val newConference = ConferenceEntity.of(
-                conferenceCreateDto,
-                conferencePage
+            conferenceCreateDto,
+            conferencePage
         )
         conferencePage.conferences.add(newConference)
 
@@ -93,33 +86,33 @@ class ConferenceServiceImpl(
 
     @Transactional
     fun modifyConferenceWithoutSave(
-            conferenceDto: ConferenceDto,
+        conferenceDto: ConferenceDto,
     ): ConferenceEntity {
         val conferenceEntity = conferenceRepository.findByIdOrNull(conferenceDto.id)
-                ?: throw CserealException.Csereal404("Conference id:${conferenceDto.id} 가 존재하지 않습니다.")
+            ?: throw CserealException.Csereal404("Conference id:${conferenceDto.id} 가 존재하지 않습니다.")
 
         conferenceEntity.update(conferenceDto)
 
         conferenceEntity.researchSearch?.update(conferenceEntity)
-                ?: let {
-                    conferenceEntity.researchSearch = ResearchSearchEntity.create(conferenceEntity)
-                }
+            ?: let {
+                conferenceEntity.researchSearch = ResearchSearchEntity.create(conferenceEntity)
+            }
 
         return conferenceEntity
     }
 
     @Transactional
     fun deleteConference(
-            id: Long,
-            conferencePage: ConferencePageEntity,
+        id: Long,
+        conferencePage: ConferencePageEntity,
     ) = conferenceRepository.findByIdOrNull(id)
-            ?. let {
-                it.isDeleted = true
-                conferencePage.conferences.remove(it)
+        ?.let {
+            it.isDeleted = true
+            conferencePage.conferences.remove(it)
 
-                it.researchSearch?.let {
-                    researchSearchService.deleteResearchSearch(it)
-                }
-                it.researchSearch = null
+            it.researchSearch?.let {
+                researchSearchService.deleteResearchSearch(it)
             }
+            it.researchSearch = null
+        }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
@@ -78,17 +78,10 @@ class NoticeServiceImpl(
 
     @Transactional
     override fun createNotice(request: NoticeDto, attachments: List<MultipartFile>?): NoticeDto {
-        var user = RequestContextHolder.getRequestAttributes()?.getAttribute(
+        val user = RequestContextHolder.getRequestAttributes()?.getAttribute(
             "loggedInUser",
             RequestAttributes.SCOPE_REQUEST
-        ) as UserEntity?
-
-        if (user == null) {
-            val oidcUser = SecurityContextHolder.getContext().authentication.principal as OidcUser
-            val username = oidcUser.idToken.getClaim<String>("username")
-
-            user = userRepository.findByUsername(username) ?: throw CserealException.Csereal404("재로그인이 필요합니다.")
-        }
+        ) as UserEntity
 
         val newNotice = NoticeEntity(
             title = request.title,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/reservation/api/ReservceController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/reservation/api/ReservceController.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.csereal.core.reservation.api
 import com.wafflestudio.csereal.common.aop.AuthenticatedForReservation
 import com.wafflestudio.csereal.core.reservation.dto.ReservationDto
 import com.wafflestudio.csereal.core.reservation.dto.ReserveRequest
+import com.wafflestudio.csereal.core.reservation.dto.SimpleReservationDto
 import com.wafflestudio.csereal.core.reservation.service.ReservationService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -28,7 +29,7 @@ class ReservationController(
         @RequestParam roomId: Long,
         @RequestParam year: Int,
         @RequestParam month: Int
-    ): ResponseEntity<List<ReservationDto>> {
+    ): ResponseEntity<List<SimpleReservationDto>> {
         val start = LocalDateTime.of(year, month, 1, 0, 0)
         val end = start.plusMonths(1)
         return ResponseEntity.ok(reservationService.getRoomReservationsBetween(roomId, start, end))
@@ -41,7 +42,7 @@ class ReservationController(
         @RequestParam year: Int,
         @RequestParam month: Int,
         @RequestParam day: Int,
-    ): ResponseEntity<List<ReservationDto>> {
+    ): ResponseEntity<List<SimpleReservationDto>> {
         val start = LocalDateTime.of(year, month, day, 0, 0)
         val end = start.plusDays(7)
         return ResponseEntity.ok(reservationService.getRoomReservationsBetween(roomId, start, end))

--- a/src/main/kotlin/com/wafflestudio/csereal/core/reservation/api/ReservceController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/reservation/api/ReservceController.kt
@@ -1,11 +1,9 @@
 package com.wafflestudio.csereal.core.reservation.api
 
 import com.wafflestudio.csereal.common.aop.AuthenticatedForReservation
-import com.wafflestudio.csereal.common.aop.AuthenticatedStaff
 import com.wafflestudio.csereal.core.reservation.dto.ReservationDto
 import com.wafflestudio.csereal.core.reservation.dto.ReserveRequest
 import com.wafflestudio.csereal.core.reservation.service.ReservationService
-import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -15,7 +13,6 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -51,7 +48,7 @@ class ReservationController(
     }
 
     @GetMapping("/{reservationId}")
-    @AuthenticatedStaff
+    @AuthenticatedForReservation
     fun getReservation(@PathVariable reservationId: Long): ResponseEntity<ReservationDto> {
         return ResponseEntity.ok(reservationService.getReservation(reservationId))
     }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/reservation/dto/ReservationDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/reservation/dto/ReservationDto.kt
@@ -6,7 +6,7 @@ import java.util.UUID
 
 data class ReservationDto(
     val id: Long,
-    val recurrenceId: UUID?,
+    val recurrenceId: UUID? = null,
     val title: String,
     val purpose: String,
     val startTime: LocalDateTime,
@@ -14,9 +14,9 @@ data class ReservationDto(
     val recurringWeeks: Int = 1,
     val roomName: String?,
     val roomLocation: String,
-    val userName: String,
-    val contactEmail: String,
-    val contactPhone: String,
+    val userName: String? = null,
+    val contactEmail: String? = null,
+    val contactPhone: String? = null,
     val professor: String
 ) {
     companion object {
@@ -37,5 +37,20 @@ data class ReservationDto(
                 professor = reservationEntity.professor
             )
         }
+
+        fun forNormalUser(reservationEntity: ReservationEntity): ReservationDto {
+            return ReservationDto(
+                id = reservationEntity.id,
+                title = reservationEntity.title,
+                purpose = reservationEntity.purpose,
+                startTime = reservationEntity.startTime,
+                endTime = reservationEntity.endTime,
+                recurringWeeks = reservationEntity.recurringWeeks,
+                roomName = reservationEntity.room.name,
+                roomLocation = reservationEntity.room.location,
+                professor = reservationEntity.professor
+            )
+        }
+
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/reservation/dto/SimpleReservationDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/reservation/dto/SimpleReservationDto.kt
@@ -1,0 +1,22 @@
+package com.wafflestudio.csereal.core.reservation.dto
+
+import com.wafflestudio.csereal.core.reservation.database.ReservationEntity
+import java.time.LocalDateTime
+
+data class SimpleReservationDto(
+    val id: Long,
+    val title: String,
+    val startTime: LocalDateTime,
+    val endTime: LocalDateTime
+) {
+    companion object {
+        fun of(reservationEntity: ReservationEntity): SimpleReservationDto {
+            return SimpleReservationDto(
+                id = reservationEntity.id,
+                title = reservationEntity.title,
+                startTime = reservationEntity.startTime,
+                endTime = reservationEntity.endTime
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/reservation/service/ReservationService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/reservation/service/ReservationService.kt
@@ -4,11 +4,9 @@ import com.wafflestudio.csereal.common.CserealException
 import com.wafflestudio.csereal.core.reservation.database.*
 import com.wafflestudio.csereal.core.reservation.dto.ReservationDto
 import com.wafflestudio.csereal.core.reservation.dto.ReserveRequest
+import com.wafflestudio.csereal.core.user.database.Role
 import com.wafflestudio.csereal.core.user.database.UserEntity
-import com.wafflestudio.csereal.core.user.database.UserRepository
 import org.springframework.data.repository.findByIdOrNull
-import org.springframework.security.core.context.SecurityContextHolder
-import org.springframework.security.oauth2.core.oidc.user.OidcUser
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.context.request.RequestAttributes
@@ -28,22 +26,14 @@ interface ReservationService {
 @Transactional
 class ReservationServiceImpl(
     private val reservationRepository: ReservationRepository,
-    private val userRepository: UserRepository,
     private val roomRepository: RoomRepository
 ) : ReservationService {
 
     override fun reserveRoom(reserveRequest: ReserveRequest): List<ReservationDto> {
-        var user = RequestContextHolder.getRequestAttributes()?.getAttribute(
+        val user = RequestContextHolder.getRequestAttributes()?.getAttribute(
             "loggedInUser",
             RequestAttributes.SCOPE_REQUEST
-        ) as UserEntity?
-
-        if (user == null) {
-            val oidcUser = SecurityContextHolder.getContext().authentication.principal as OidcUser
-            val username = oidcUser.idToken.getClaim<String>("username")
-
-            user = userRepository.findByUsername(username) ?: throw CserealException.Csereal404("재로그인이 필요합니다.")
-        }
+        ) as UserEntity
 
         val room =
             roomRepository.findByIdOrNull(reserveRequest.roomId) ?: throw CserealException.Csereal404("Room Not Found")
@@ -91,7 +81,17 @@ class ReservationServiceImpl(
     override fun getReservation(reservationId: Long): ReservationDto {
         val reservationEntity =
             reservationRepository.findByIdOrNull(reservationId) ?: throw CserealException.Csereal404("예약을 찾을 수 없습니다.")
-        return ReservationDto.of(reservationEntity)
+
+        val user = RequestContextHolder.getRequestAttributes()?.getAttribute(
+            "loggedInUser",
+            RequestAttributes.SCOPE_REQUEST
+        ) as UserEntity
+
+        if (user.role == Role.ROLE_STAFF) {
+            return ReservationDto.of(reservationEntity)
+        } else {
+            return ReservationDto.forNormalUser(reservationEntity)
+        }
     }
 
     override fun cancelSpecific(reservationId: Long) {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/reservation/service/ReservationService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/reservation/service/ReservationService.kt
@@ -4,6 +4,7 @@ import com.wafflestudio.csereal.common.CserealException
 import com.wafflestudio.csereal.core.reservation.database.*
 import com.wafflestudio.csereal.core.reservation.dto.ReservationDto
 import com.wafflestudio.csereal.core.reservation.dto.ReserveRequest
+import com.wafflestudio.csereal.core.reservation.dto.SimpleReservationDto
 import com.wafflestudio.csereal.core.user.database.Role
 import com.wafflestudio.csereal.core.user.database.UserEntity
 import org.springframework.data.repository.findByIdOrNull
@@ -16,7 +17,7 @@ import java.util.*
 
 interface ReservationService {
     fun reserveRoom(reserveRequest: ReserveRequest): List<ReservationDto>
-    fun getRoomReservationsBetween(roomId: Long, start: LocalDateTime, end: LocalDateTime): List<ReservationDto>
+    fun getRoomReservationsBetween(roomId: Long, start: LocalDateTime, end: LocalDateTime): List<SimpleReservationDto>
     fun getReservation(reservationId: Long): ReservationDto
     fun cancelSpecific(reservationId: Long)
     fun cancelRecurring(recurrenceId: UUID)
@@ -72,9 +73,9 @@ class ReservationServiceImpl(
         roomId: Long,
         start: LocalDateTime,
         end: LocalDateTime
-    ): List<ReservationDto> {
+    ): List<SimpleReservationDto> {
         return reservationRepository.findByRoomIdAndStartTimeBetweenOrderByStartTimeAsc(roomId, start, end)
-            .map { ReservationDto.of(it) }
+            .map { SimpleReservationDto.of(it) }
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 예약 조회

### 한줄 요약

관리자가 아닌 예약 권한이 있는 다른 사용자들도 유저 정보를 제외한 응답을 볼 수 있게 수정하였습니다.
월별,주별 조회 응답용 SimpleReservationDto 클래스를 별도로 생성하였습니다.

### 상세 설명

[16c312810335f8cfa87ea85a6042f62d57674061]: 예약 단건 조회 권한 분리

[edcf673c868113ba706d4a7d9925e8e80c08d558]: SimpleReservationDto