### PR TITLE
fix: news, notice에 titleForMain 추가

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/database/MainRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/database/MainRepository.kt
@@ -86,7 +86,8 @@ class MainRepositoryImpl(
             mainImportantResponses.add(
                 MainImportantResponse(
                     id = it.id,
-                    title = it.title,
+                    title = it.titleForMain!!,
+                    description = it.description,
                     createdAt = it.createdAt,
                     category = "notice"
                 )
@@ -97,7 +98,8 @@ class MainRepositoryImpl(
             mainImportantResponses.add(
                 MainImportantResponse(
                     id = it.id,
-                    title = it.title,
+                    title = it.titleForMain!!,
+                    description = it.description,
                     createdAt = it.createdAt,
                     category = "news"
                 )
@@ -109,6 +111,7 @@ class MainRepositoryImpl(
                 MainImportantResponse(
                     id = it.id,
                     title = it.title,
+                    description = it.description,
                     createdAt = it.createdAt,
                     category = "seminar"
                 )

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/database/MainRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/database/MainRepository.kt
@@ -110,7 +110,7 @@ class MainRepositoryImpl(
             mainImportantResponses.add(
                 MainImportantResponse(
                     id = it.id,
-                    title = it.title,
+                    title = it.titleForMain!!,
                     description = it.description,
                     createdAt = it.createdAt,
                     category = "seminar"

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/dto/MainImportantResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/dto/MainImportantResponse.kt
@@ -5,6 +5,7 @@ import java.time.LocalDateTime
 data class MainImportantResponse(
     val id: Long,
     val title: String,
+    val description: String,
     val createdAt: LocalDateTime?,
     val category: String,
 ) {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsEntity.kt
@@ -63,6 +63,7 @@ class NewsEntity(
             this.plainTextDescription = cleanTextFromHtml(updateNewsRequest.description)
         }
         this.title = updateNewsRequest.title
+        this.titleForMain = updateNewsRequest.titleForMain
         this.date = updateNewsRequest.date
         this.isPrivate = updateNewsRequest.isPrivate
         this.isSlide = updateNewsRequest.isSlide

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsEntity.kt
@@ -16,6 +16,8 @@ class NewsEntity(
     var isDeleted: Boolean = false,
     var title: String,
 
+    var titleForMain: String?,
+
     @Column(columnDefinition = "mediumtext")
     var description: String,
 
@@ -44,6 +46,7 @@ class NewsEntity(
         fun of(newsDto: NewsDto): NewsEntity {
             return NewsEntity(
                 title = newsDto.title,
+                titleForMain = newsDto.titleForMain,
                 description = newsDto.description,
                 plainTextDescription = cleanTextFromHtml(newsDto.description),
                 date = newsDto.date,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/dto/NewsDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/dto/NewsDto.kt
@@ -7,6 +7,7 @@ import java.time.LocalDateTime
 data class NewsDto(
     val id: Long,
     val title: String,
+    val titleForMain: String?,
     val description: String,
     val tags: List<String>,
     val createdAt: LocalDateTime?,
@@ -33,6 +34,7 @@ data class NewsDto(
             NewsDto(
                 id = this.id,
                 title = this.title,
+                titleForMain = this.titleForMain,
                 description = this.description,
                 tags = this.newsTags.map { it.tag.name.krName },
                 createdAt = this.createdAt,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/service/NewsService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/service/NewsService.kt
@@ -80,6 +80,10 @@ class NewsServiceImpl(
             attachmentService.uploadAllAttachments(newNews, attachments)
         }
 
+        if (request.isImportant && request.titleForMain.isNullOrEmpty()) {
+            throw CserealException.Csereal400("중요 제목이 입력되어야 합니다")
+        }
+
         newsRepository.save(newNews)
 
         val imageURL = mainImageService.createImageURL(newNews.mainImage)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeEntity.kt
@@ -45,6 +45,7 @@ class NoticeEntity(
         }
 
         this.title = updateNoticeRequest.title
+        this.titleForMain = updateNoticeRequest.titleForMain
         this.description = updateNoticeRequest.description
         this.isPrivate = updateNoticeRequest.isPrivate
         this.isPinned = updateNoticeRequest.isPinned

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeEntity.kt
@@ -13,6 +13,8 @@ import jakarta.persistence.*
 class NoticeEntity(
     var isDeleted: Boolean = false,
     var title: String,
+    var titleForMain: String?,
+
     @Column(columnDefinition = "mediumtext")
     var description: String,
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/NoticeDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/NoticeDto.kt
@@ -8,6 +8,7 @@ import java.time.LocalDateTime
 data class NoticeDto(
     val id: Long,
     val title: String,
+    val titleForMain: String?,
     val description: String,
     val author: String?,
     val tags: List<String>,
@@ -33,6 +34,7 @@ data class NoticeDto(
             NoticeDto(
                 id = this.id,
                 title = this.title,
+                titleForMain = this.titleForMain,
                 description = this.description,
                 author = this.author.name,
                 tags = this.noticeTags.map { it.tag.name.krName },

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
@@ -85,6 +85,7 @@ class NoticeServiceImpl(
 
         val newNotice = NoticeEntity(
             title = request.title,
+            titleForMain = request.titleForMain,
             description = request.description,
             plainTextDescription = cleanTextFromHtml(request.description),
             isPrivate = request.isPrivate,
@@ -101,6 +102,10 @@ class NoticeServiceImpl(
 
         if (attachments != null) {
             attachmentService.uploadAllAttachments(newNotice, attachments)
+        }
+
+        if (request.isImportant && request.titleForMain.isNullOrEmpty()) {
+            throw CserealException.Csereal400("중요 제목이 입력되어야 합니다")
         }
 
         noticeRepository.save(newNotice)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarEntity.kt
@@ -17,6 +17,8 @@ class SeminarEntity(
 
     var title: String,
 
+    var titleForMain: String?,
+
     @Column(columnDefinition = "mediumtext")
     var description: String,
 
@@ -70,6 +72,7 @@ class SeminarEntity(
 
             return SeminarEntity(
                 title = seminarDto.title,
+                titleForMain = seminarDto.titleForMain,
                 description = seminarDto.description,
                 plainTextDescription = plainTextDescription,
                 introduction = seminarDto.introduction,
@@ -108,6 +111,7 @@ class SeminarEntity(
         }
 
         title = updateSeminarRequest.title
+        titleForMain = updateSeminarRequest.titleForMain
         introduction = updateSeminarRequest.introduction
         name = updateSeminarRequest.name
         speakerURL = updateSeminarRequest.speakerURL

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/dto/SeminarDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/dto/SeminarDto.kt
@@ -8,6 +8,7 @@ import java.time.LocalDateTime
 data class SeminarDto(
     val id: Long,
     val title: String,
+    val titleForMain: String?,
     val description: String,
     val introduction: String,
     val name: String,
@@ -43,6 +44,7 @@ data class SeminarDto(
             SeminarDto(
                 id = this.id,
                 title = this.title,
+                titleForMain = this.titleForMain,
                 description = this.description,
                 introduction = this.introduction,
                 name = this.name,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/service/SeminarService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/service/SeminarService.kt
@@ -106,7 +106,7 @@ class SeminarServiceImpl(
         if (request.isImportant && request.titleForMain.isNullOrEmpty()) {
             throw CserealException.Csereal400("중요 제목이 입력되어야 합니다")
         }
-        
+
         val attachmentResponses = attachmentService.createAttachmentResponses(seminar.attachments)
 
         val imageURL = mainImageService.createImageURL(seminar.mainImage)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/service/SeminarService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/service/SeminarService.kt
@@ -103,6 +103,10 @@ class SeminarServiceImpl(
             attachmentService.uploadAllAttachments(seminar, newAttachments)
         }
 
+        if (request.isImportant && request.titleForMain.isNullOrEmpty()) {
+            throw CserealException.Csereal400("중요 제목이 입력되어야 합니다")
+        }
+        
         val attachmentResponses = attachmentService.createAttachmentResponses(seminar.attachments)
 
         val imageURL = mainImageService.createImageURL(seminar.mainImage)

--- a/src/test/kotlin/com/wafflestudio/csereal/core/notice/news/NewsServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/notice/news/NewsServiceTest.kt
@@ -25,24 +25,25 @@ class NewsServiceTest(
             val newsDTO = NewsDto(
                 id = -1,
                 title = "title",
+                titleForMain = null,
                 description = """
                         <h1>Hello, World!</h1>
                         <p>This is news description.</p>
                         <h3>Goodbye, World!</h3>
                     """.trimIndent(),
-                    tags = emptyList(),
-                    createdAt = null,
-                    modifiedAt = null,
-                    date = null,
-                    isPrivate = false,
-                    isSlide = false,
-                    isImportant = false,
-                    prevId = null,
-                    prevTitle = null,
-                    nextId = null,
-                    nextTitle = null,
-                    imageURL = null,
-                    attachments = null,
+                tags = emptyList(),
+                createdAt = null,
+                modifiedAt = null,
+                date = null,
+                isPrivate = false,
+                isSlide = false,
+                isImportant = false,
+                prevId = null,
+                prevTitle = null,
+                nextId = null,
+                nextTitle = null,
+                imageURL = null,
+                attachments = null,
             )
 
             When("DTO를 이용하여 뉴스를 생성하면") {
@@ -64,17 +65,18 @@ class NewsServiceTest(
             val newsEntity = newsRepository.save(
                 NewsEntity(
                     title = "title",
+                    titleForMain = null,
                     description = """
                             <h1>Hello, World!</h1>
                             <p>This is news description.</p>
                             <h3>Goodbye, World!</h3>
                             """.trimIndent(),
-                            plainTextDescription = "Hello, World! This is news description. Goodbye, World!",
-                            date = null,
-                            isPrivate = false,
-                            isSlide = false,
-                            isImportant = false,
-                    )
+                    plainTextDescription = "Hello, World! This is news description. Goodbye, World!",
+                    date = null,
+                    isPrivate = false,
+                    isSlide = false,
+                    isImportant = false,
+                )
             )
 
             When("저장된 뉴스의 Description을 수정하면") {

--- a/src/test/kotlin/com/wafflestudio/csereal/core/notice/news/NewsServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/notice/news/NewsServiceTest.kt
@@ -25,25 +25,24 @@ class NewsServiceTest(
             val newsDTO = NewsDto(
                 id = -1,
                 title = "title",
-                titleForMain = null,
                 description = """
                         <h1>Hello, World!</h1>
                         <p>This is news description.</p>
                         <h3>Goodbye, World!</h3>
                     """.trimIndent(),
-                tags = emptyList(),
-                createdAt = null,
-                modifiedAt = null,
-                date = null,
-                isPrivate = false,
-                isSlide = false,
-                isImportant = false,
-                prevId = null,
-                prevTitle = null,
-                nextId = null,
-                nextTitle = null,
-                imageURL = null,
-                attachments = null,
+                    tags = emptyList(),
+                    createdAt = null,
+                    modifiedAt = null,
+                    date = null,
+                    isPrivate = false,
+                    isSlide = false,
+                    isImportant = false,
+                    prevId = null,
+                    prevTitle = null,
+                    nextId = null,
+                    nextTitle = null,
+                    imageURL = null,
+                    attachments = null,
             )
 
             When("DTO를 이용하여 뉴스를 생성하면") {
@@ -65,18 +64,17 @@ class NewsServiceTest(
             val newsEntity = newsRepository.save(
                 NewsEntity(
                     title = "title",
-                    titleForMain = null,
                     description = """
                             <h1>Hello, World!</h1>
                             <p>This is news description.</p>
                             <h3>Goodbye, World!</h3>
                             """.trimIndent(),
-                    plainTextDescription = "Hello, World! This is news description. Goodbye, World!",
-                    date = null,
-                    isPrivate = false,
-                    isSlide = false,
-                    isImportant = false,
-                )
+                            plainTextDescription = "Hello, World! This is news description. Goodbye, World!",
+                            date = null,
+                            isPrivate = false,
+                            isSlide = false,
+                            isImportant = false,
+                    )
             )
 
             When("저장된 뉴스의 Description을 수정하면") {

--- a/src/test/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeServiceTest.kt
@@ -59,7 +59,6 @@ class NoticeServiceTest(
             val noticeDto = NoticeDto(
                 id = -1,
                 title = "title",
-                titleForMain = null,
                 description = """
                             <h1>Hello, World!</h1>
                             <p>This is a test notice.</p>
@@ -97,7 +96,6 @@ class NoticeServiceTest(
             val noticeEntity = noticeRepository.save(
                 NoticeEntity(
                     title = "title",
-                    titleForMain = null,
                     description = """
                                     <h1>Hello, World!</h1>
                                     <p>This is a test notice.</p>

--- a/src/test/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeServiceTest.kt
@@ -59,6 +59,7 @@ class NoticeServiceTest(
             val noticeDto = NoticeDto(
                 id = -1,
                 title = "title",
+                titleForMain = null,
                 description = """
                             <h1>Hello, World!</h1>
                             <p>This is a test notice.</p>
@@ -96,6 +97,7 @@ class NoticeServiceTest(
             val noticeEntity = noticeRepository.save(
                 NoticeEntity(
                     title = "title",
+                    titleForMain = null,
                     description = """
                                     <h1>Hello, World!</h1>
                                     <p>This is a test notice.</p>

--- a/src/test/kotlin/com/wafflestudio/csereal/core/seminar/service/SeminarServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/seminar/service/SeminarServiceTest.kt
@@ -30,6 +30,7 @@ class SeminarServiceTest(
             val seminarDTO = SeminarDto(
                 id = -1,
                 title = "title",
+                titleForMain = null,
                 description = """
                         <h1>Hello, World!</h1>
                         <p>This is seminar description.</p>
@@ -86,6 +87,7 @@ class SeminarServiceTest(
             val originalSeminar = seminarRepository.save(
                 SeminarEntity(
                     title = "title",
+                    titleForMain = null,
                     description = """
                                 <h1>Hello, World!</h1>
                                 <p>This is seminar description.</p>


### PR DESCRIPTION
## 제목
fix: news, notice에 titleForMain 추가

### 설명
news와 notice에 titleForMain을 추가하였고, 메인 중요안내에서 이들이 제목으로 나오게 했으며, description을 추가하였습니다.

main에서 title은 그쪽에서 title로 받고 있었으니까 굳이 titleForMain으로 안 바꿨고,

커밋에서는 삼총사라도 적어놨는데 실제로는 새소식과 공지사항만 titleForMain을 받기를 원하셔서 두개만 고쳤습니다
