### PR TITLE
refactor: deleteIds request 내부로 이동

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/api/NewsController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/api/NewsController.kt
@@ -53,9 +53,8 @@ class NewsController(
         @Valid @RequestPart("request") request: NewsDto,
         @RequestPart("newMainImage") newMainImage: MultipartFile?,
         @RequestPart("newAttachments") newAttachments: List<MultipartFile>?,
-        @RequestPart("deleteIds") deleteIds: List<Long>,
     ): ResponseEntity<NewsDto> {
-        return ResponseEntity.ok(newsService.updateNews(newsId, request, newMainImage, newAttachments, deleteIds))
+        return ResponseEntity.ok(newsService.updateNews(newsId, request, newMainImage, newAttachments))
     }
 
     @AuthenticatedStaff

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/dto/NewsDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/dto/NewsDto.kt
@@ -21,6 +21,7 @@ data class NewsDto(
     val nextTitle: String?,
     val imageURL: String?,
     val attachments: List<AttachmentResponse>?,
+    val deleteIds: List<Long>? = null
 ) {
     companion object {
         fun of(

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/service/NewsService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/service/NewsService.kt
@@ -21,7 +21,6 @@ interface NewsService {
         request: NewsDto,
         newMainImage: MultipartFile?,
         newAttachments: List<MultipartFile>?,
-        deleteIds: List<Long>,
     ): NewsDto
 
     fun deleteNews(newsId: Long)
@@ -94,7 +93,6 @@ class NewsServiceImpl(
         request: NewsDto,
         newMainImage: MultipartFile?,
         newAttachments: List<MultipartFile>?,
-        deleteIds: List<Long>,
     ): NewsDto {
         val news: NewsEntity = newsRepository.findByIdOrNull(newsId)
             ?: throw CserealException.Csereal404("존재하지 않는 새소식입니다. (newsId: $newsId)")
@@ -107,7 +105,7 @@ class NewsServiceImpl(
             mainImageService.uploadMainImage(news, newMainImage)
         }
 
-        attachmentService.deleteAttachments(deleteIds)
+        attachmentService.deleteAttachments(request.deleteIds)
 
         if (newAttachments != null) {
             attachmentService.uploadAllAttachments(news, newAttachments)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
@@ -61,10 +61,9 @@ class NoticeController(
     fun updateNotice(
         @PathVariable noticeId: Long,
         @Valid @RequestPart("request") request: NoticeDto,
-        @RequestPart("newAttachments") newAttachments: List<MultipartFile>?,
-        @RequestPart("deleteIds") deleteIds: List<Long>,
+        @RequestPart("newAttachments") newAttachments: List<MultipartFile>?
     ): ResponseEntity<NoticeDto> {
-        return ResponseEntity.ok(noticeService.updateNotice(noticeId, request, newAttachments, deleteIds))
+        return ResponseEntity.ok(noticeService.updateNotice(noticeId, request, newAttachments))
     }
 
     @AuthenticatedStaff

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/NoticeDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/NoticeDto.kt
@@ -21,6 +21,7 @@ data class NoticeDto(
     val nextId: Long?,
     val nextTitle: String?,
     val attachments: List<AttachmentResponse>?,
+    val deleteIds: List<Long>? = null
 ) {
 
     companion object {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
@@ -32,7 +32,6 @@ interface NoticeService {
         noticeId: Long,
         request: NoticeDto,
         newAttachments: List<MultipartFile>?,
-        deleteIds: List<Long>
     ): NoticeDto
 
     fun deleteNotice(noticeId: Long)
@@ -46,7 +45,6 @@ class NoticeServiceImpl(
     private val noticeRepository: NoticeRepository,
     private val tagInNoticeRepository: TagInNoticeRepository,
     private val noticeTagRepository: NoticeTagRepository,
-    private val userRepository: UserRepository,
     private val attachmentService: AttachmentService,
 ) : NoticeService {
 
@@ -115,8 +113,7 @@ class NoticeServiceImpl(
     override fun updateNotice(
         noticeId: Long,
         request: NoticeDto,
-        newAttachments: List<MultipartFile>?,
-        deleteIds: List<Long>
+        newAttachments: List<MultipartFile>?
     ): NoticeDto {
         val notice: NoticeEntity = noticeRepository.findByIdOrNull(noticeId)
             ?: throw CserealException.Csereal404("존재하지 않는 공지사항입니다.(noticeId: $noticeId)")
@@ -124,7 +121,7 @@ class NoticeServiceImpl(
 
         notice.update(request)
 
-        attachmentService.deleteAttachments(deleteIds)
+        attachmentService.deleteAttachments(request.deleteIds)
 
         if (newAttachments != null) {
             attachmentService.uploadAllAttachments(notice, newAttachments)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/service/AttachmentService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/service/AttachmentService.kt
@@ -41,7 +41,7 @@ interface AttachmentService {
 //        attachmentsList: List<AttachmentResponse>
 //    )
 
-    fun deleteAttachments(ids: List<Long>)
+    fun deleteAttachments(ids: List<Long>?)
     fun deleteAttachment(attachment: AttachmentEntity)
 }
 
@@ -141,32 +141,15 @@ class AttachmentServiceImpl(
         return list
     }
 
-//    @Transactional
-//    override fun updateAttachmentResponses(
-//        contentEntity: AttachmentContentEntityType,
-//        attachmentsList: List<AttachmentResponse>
-//    ) {
-//        val oldAttachments = contentEntity.bringAttachments().map { it.filename }
-//
-//        val attachmentsToRemove = oldAttachments - attachmentsList.map { it.name }
-//
-//        when (contentEntity) {
-//            is SeminarEntity -> {
-//                for (attachmentFilename in attachmentsToRemove) {
-//                    val attachmentEntity = attachmentRepository.findByFilename(attachmentFilename)
-//                    attachmentEntity.isDeleted = true
-//                    attachmentEntity.seminar = null
-//                }
-//            }
-//        }
-//    }
 
     @Transactional
-    override fun deleteAttachments(ids: List<Long>) {
-        for (id in ids) {
-            val attachment = attachmentRepository.findByIdOrNull(id)
-                ?: throw CserealException.Csereal404("id:${id}인 첨부파일을 찾을 수 없습니다.")
-            attachment.isDeleted = true
+    override fun deleteAttachments(ids: List<Long>?) {
+        if (ids != null) {
+            for (id in ids) {
+                val attachment = attachmentRepository.findByIdOrNull(id)
+                    ?: throw CserealException.Csereal404("id:${id}인 첨부파일을 찾을 수 없습니다.")
+                attachment.isDeleted = true
+            }
         }
     }
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/api/SeminarController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/api/SeminarController.kt
@@ -52,7 +52,6 @@ class SeminarController(
         @Valid @RequestPart("request") request: SeminarDto,
         @RequestPart("newMainImage") newMainImage: MultipartFile?,
         @RequestPart("newAttachments") newAttachments: List<MultipartFile>?,
-        @RequestPart("deleteIds") deleteIds: List<Long>,
     ): ResponseEntity<SeminarDto> {
         return ResponseEntity.ok(
             seminarService.updateSeminar(
@@ -60,7 +59,6 @@ class SeminarController(
                 request,
                 newMainImage,
                 newAttachments,
-                deleteIds
             )
         )
     }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/dto/SeminarDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/dto/SeminarDto.kt
@@ -30,6 +30,7 @@ data class SeminarDto(
     val nextTitle: String?,
     val imageURL: String?,
     val attachments: List<AttachmentResponse>?,
+    val deleteIds: List<Long>? = null
 ) {
 
     companion object {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/service/SeminarService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/service/SeminarService.kt
@@ -22,7 +22,6 @@ interface SeminarService {
         request: SeminarDto,
         newMainImage: MultipartFile?,
         newAttachments: List<MultipartFile>?,
-        deleteIds: List<Long>,
     ): SeminarDto
 
     fun deleteSeminar(seminarId: Long)
@@ -84,7 +83,6 @@ class SeminarServiceImpl(
         request: SeminarDto,
         newMainImage: MultipartFile?,
         newAttachments: List<MultipartFile>?,
-        deleteIds: List<Long>,
     ): SeminarDto {
         val seminar: SeminarEntity = seminarRepository.findByIdOrNull(seminarId)
             ?: throw CserealException.Csereal404("존재하지 않는 세미나입니다")
@@ -97,7 +95,7 @@ class SeminarServiceImpl(
             mainImageService.uploadMainImage(seminar, newMainImage)
         }
 
-        attachmentService.deleteAttachments(deleteIds)
+        attachmentService.deleteAttachments(request.deleteIds)
 
         if (newAttachments != null) {
             attachmentService.uploadAllAttachments(seminar, newAttachments)

--- a/src/test/kotlin/com/wafflestudio/csereal/core/notice/news/NewsServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/notice/news/NewsServiceTest.kt
@@ -30,19 +30,19 @@ class NewsServiceTest(
                         <p>This is news description.</p>
                         <h3>Goodbye, World!</h3>
                     """.trimIndent(),
-                    tags = emptyList(),
-                    createdAt = null,
-                    modifiedAt = null,
-                    date = null,
-                    isPrivate = false,
-                    isSlide = false,
-                    isImportant = false,
-                    prevId = null,
-                    prevTitle = null,
-                    nextId = null,
-                    nextTitle = null,
-                    imageURL = null,
-                    attachments = null,
+                tags = emptyList(),
+                createdAt = null,
+                modifiedAt = null,
+                date = null,
+                isPrivate = false,
+                isSlide = false,
+                isImportant = false,
+                prevId = null,
+                prevTitle = null,
+                nextId = null,
+                nextTitle = null,
+                imageURL = null,
+                attachments = null,
             )
 
             When("DTO를 이용하여 뉴스를 생성하면") {
@@ -69,12 +69,12 @@ class NewsServiceTest(
                             <p>This is news description.</p>
                             <h3>Goodbye, World!</h3>
                             """.trimIndent(),
-                            plainTextDescription = "Hello, World! This is news description. Goodbye, World!",
-                            date = null,
-                            isPrivate = false,
-                            isSlide = false,
-                            isImportant = false,
-                    )
+                    plainTextDescription = "Hello, World! This is news description. Goodbye, World!",
+                    date = null,
+                    isPrivate = false,
+                    isSlide = false,
+                    isImportant = false,
+                )
             )
 
             When("저장된 뉴스의 Description을 수정하면") {
@@ -91,7 +91,6 @@ class NewsServiceTest(
                         ),
                     null,
                     null,
-                    emptyList()
                 )
 
                 Then("description, plainTextDescription이 수정되어야 한다.") {

--- a/src/test/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeServiceTest.kt
@@ -124,7 +124,6 @@ class NoticeServiceTest(
                     modifiedRequest.id,
                     modifiedRequest,
                     null,
-                    emptyList()
                 )
 
                 Then("plainTextDescription이 잘 수정되어야 한다.") {

--- a/src/test/kotlin/com/wafflestudio/csereal/core/seminar/service/SeminarServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/seminar/service/SeminarServiceTest.kt
@@ -148,7 +148,6 @@ class SeminarServiceTest(
                     modifiedSeminarDTO,
                     null,
                     null,
-                    emptyList()
                 )
 
                 Then("같은 Entity가 수정되어야 한다.") {


### PR DESCRIPTION
## 리팩토링

### 한줄 요약

삭제할 첨부파일 id목록을 request 내부에서 받도록 변경하였습니다.

### 상세 설명

[fce1c48fe32de8c6a5128d7ff68d0edb4ea71fb8]: 리팩토링
