### PR TITLE
feat: 관리자는 새소식, 세미나 목록에서 비공개 글 확인 가능

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/dto/NewsSearchDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/dto/NewsSearchDto.kt
@@ -11,4 +11,5 @@ data class NewsSearchDto @QueryProjection constructor(
     val date: LocalDateTime?,
     var tags: List<String>?,
     var imageURL: String?,
+    val isPrivate: Boolean
 )

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/service/NewsService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/service/NewsService.kt
@@ -13,7 +13,14 @@ import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
 
 interface NewsService {
-    fun searchNews(tag: List<String>?, keyword: String?, pageable: Pageable, usePageBtn: Boolean): NewsSearchResponse
+    fun searchNews(
+        tag: List<String>?,
+        keyword: String?,
+        pageable: Pageable,
+        usePageBtn: Boolean,
+        isStaff: Boolean
+    ): NewsSearchResponse
+
     fun readNews(newsId: Long): NewsDto
     fun createNews(request: NewsDto, mainImage: MultipartFile?, attachments: List<MultipartFile>?): NewsDto
     fun updateNews(
@@ -41,9 +48,10 @@ class NewsServiceImpl(
         tag: List<String>?,
         keyword: String?,
         pageable: Pageable,
-        usePageBtn: Boolean
+        usePageBtn: Boolean,
+        isStaff: Boolean
     ): NewsSearchResponse {
-        return newsRepository.searchNews(tag, keyword, pageable, usePageBtn)
+        return newsRepository.searchNews(tag, keyword, pageable, usePageBtn, isStaff)
     }
 
     @Transactional(readOnly = true)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/dto/SeminarSearchDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/dto/SeminarSearchDto.kt
@@ -13,5 +13,6 @@ data class SeminarSearchDto @QueryProjection constructor(
     val location: String,
     val imageURL: String?,
     val isYearLast: Boolean,
+    val isPrivate: Boolean
 ) {
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/service/SeminarService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/service/SeminarService.kt
@@ -14,7 +14,13 @@ import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
 
 interface SeminarService {
-    fun searchSeminar(keyword: String?, pageable: Pageable, usePageBtn: Boolean): SeminarSearchResponse
+    fun searchSeminar(
+        keyword: String?,
+        pageable: Pageable,
+        usePageBtn: Boolean,
+        isStaff: Boolean
+    ): SeminarSearchResponse
+
     fun createSeminar(request: SeminarDto, mainImage: MultipartFile?, attachments: List<MultipartFile>?): SeminarDto
     fun readSeminar(seminarId: Long): SeminarDto
     fun updateSeminar(
@@ -35,8 +41,13 @@ class SeminarServiceImpl(
     private val attachmentService: AttachmentService,
 ) : SeminarService {
     @Transactional(readOnly = true)
-    override fun searchSeminar(keyword: String?, pageable: Pageable, usePageBtn: Boolean): SeminarSearchResponse {
-        return seminarRepository.searchSeminar(keyword, pageable, usePageBtn)
+    override fun searchSeminar(
+        keyword: String?,
+        pageable: Pageable,
+        usePageBtn: Boolean,
+        isStaff: Boolean
+    ): SeminarSearchResponse {
+        return seminarRepository.searchSeminar(keyword, pageable, usePageBtn, isStaff)
     }
 
     @Transactional


### PR DESCRIPTION
## 새소식, 세미나 비공개 글

### 한줄 요약

관리자만 목록에서 비공개 글 확인 가능하도록 하였습니다.

### 상세 설명

[88d5f13a8386f973b682cd002389b933216700ad]: 커스텀 레포에 isPrivateBooleanBuilder 추가 + 응답에 isPrivate 추가