### PR TITLE
fix: noticeSearchDto에도 private 추가

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsRepository.kt
@@ -69,7 +69,7 @@ class NewsRepositoryImpl(
 
         if (!isStaff) {
             isPrivateBooleanBuilder.or(
-                QNoticeEntity.noticeEntity.isPrivate.eq(false)
+                newsEntity.isPrivate.eq(false)
             )
         }
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
@@ -77,7 +77,8 @@ class NoticeRepositoryImpl(
                 noticeEntity.title,
                 noticeEntity.createdAt,
                 noticeEntity.isPinned,
-                noticeEntity.attachments.isNotEmpty
+                noticeEntity.attachments.isNotEmpty,
+                noticeEntity.isPrivate
             )
         )
             .from(noticeEntity)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/NoticeSearchDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/NoticeSearchDto.kt
@@ -10,12 +10,14 @@ data class NoticeSearchDto @QueryProjection constructor(
     val createdAt: LocalDateTime?,
     val isPinned: Boolean,
     val hasAttachment: Boolean,
+    val isPrivate: Boolean,
 ) {
     constructor(entity: NoticeEntity, hasAttachment: Boolean) : this(
         entity.id,
         entity.title,
         entity.createdAt,
         entity.isPinned,
-        hasAttachment
+        hasAttachment,
+        entity.isPrivate
     )
 }


### PR DESCRIPTION
## 제목
fix: noticeSearchDto에도 private 추가

### 한줄 요약
noticeSearchDto에 private을 추가하고, newsEntity에서 notice의 isPrivate을 찾고 있어서 수정하였습니다.

### 상세 설명

[e1179c81e2d9f1f65034edd54e7c5255abea2a0a]: noticeSearchDto에 private을 추가하고, newsEntity에서 notice의 isPrivate을 찾고 있어서 수정하였습니다.


제가 맞게 수정한 건지 확인해주세요


