### PR TITLE
fix: 기존 objectMapper 설정 오버라이드

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/common/config/JacksonConfig.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/config/JacksonConfig.kt
@@ -5,22 +5,22 @@ import com.fasterxml.jackson.databind.JsonSerializer
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.databind.module.SimpleModule
+import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.event.EventListener
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 
 @Configuration
-class JacksonConfig {
+class JacksonConfig(private val objectMapper: ObjectMapper) {
 
-    @Bean
-    fun objectMapper(): ObjectMapper {
-        val objectMapper = ObjectMapper()
+    @EventListener(ApplicationReadyEvent::class)
+    fun setUp() {
         val module = SimpleModule()
         module.addSerializer(LocalDateTime::class.java, LocalDateTimeSerializer())
         objectMapper.registerModule(module)
-        return objectMapper
     }
 }
 


### PR DESCRIPTION
## JacksonConfig 파일 수정

### 한줄 요약

LocalDateTime 응답 수정하면서 objectMapper를 새로 만든것 때문에 기존에 스프링부트가 autoConfigure하던 세팅들이 바뀌어서 response가 의도치 않게 바뀌는 부분을 복구하였습니다.

### 상세 설명

[889b499d951b6ad18138ee4f877c0512e63438d4]: LocalDateTime 이외 기존 설정 유지
