### PR TITLE
Hotfix: Fix search total notice stringLength default value.

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
@@ -47,7 +47,7 @@ class NoticeController(
     fun totalSearchNotice(
             @RequestParam(required = true) @Length(min = 2) @NotBlank keyword: String,
             @RequestParam(required = true) @Positive number: Int,
-            @RequestParam(required = false) @Positive stringLength: Int = 200,
+            @RequestParam(required = false, defaultValue = "200") @Positive stringLength: Int,
     ) = ResponseEntity.ok(
             noticeService.searchTotalNotice(keyword, number, stringLength)
     )


### PR DESCRIPTION
## Hotfix: Fix search total notice stringLength default value.

### Notice total search에 default value 설정이 잘못되어 수정하였습니다.
