### PR TITLE
Feat: 뉴스 날짜로 정렬

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsEntity.kt
@@ -25,7 +25,7 @@ class NewsEntity(
     @Column(columnDefinition = "mediumtext")
     var plainTextDescription: String,
 
-    var date: LocalDateTime?,
+    var date: LocalDateTime,
     var isPrivate: Boolean,
     var isSlide: Boolean,
     var isImportant: Boolean,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsRepository.kt
@@ -95,7 +95,7 @@ class NewsRepositoryImpl(
         }
 
         val newsEntityList = jpaQuery
-            .orderBy(newsEntity.createdAt.desc())
+            .orderBy(newsEntity.date.desc())
             .offset(pageRequest.offset)
             .limit(pageRequest.pageSize.toLong())
             .distinct()

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/dto/NewsDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/dto/NewsDto.kt
@@ -12,7 +12,7 @@ data class NewsDto(
     val tags: List<String>,
     val createdAt: LocalDateTime?,
     val modifiedAt: LocalDateTime?,
-    val date: LocalDateTime?,
+    val date: LocalDateTime,
     val isPrivate: Boolean,
     val isSlide: Boolean,
     val isImportant: Boolean,

--- a/src/test/kotlin/com/wafflestudio/csereal/core/news/NewsServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/news/NewsServiceTest.kt
@@ -1,4 +1,4 @@
-package com.wafflestudio.csereal.core.notice.news
+package com.wafflestudio.csereal.core.news
 
 import com.wafflestudio.csereal.core.news.database.NewsEntity
 import com.wafflestudio.csereal.core.news.database.NewsRepository
@@ -104,7 +104,8 @@ class NewsServiceTest(
                             <h3>Goodbye, World!</h3>
                             <p>This is additional description.</p>
                             """.trimIndent()
-                    updatedNewsEntity.plainTextDescription shouldBe "Hello, World! This is modified news description. Goodbye, World! This is additional description."
+                    updatedNewsEntity.plainTextDescription shouldBe "Hello, World! This is modified news description." +
+                            " Goodbye, World! This is additional description."
                 }
             }
         }

--- a/src/test/kotlin/com/wafflestudio/csereal/core/notice/news/NewsServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/notice/news/NewsServiceTest.kt
@@ -9,6 +9,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.data.repository.findByIdOrNull
+import java.time.LocalDateTime
 
 @SpringBootTest
 class NewsServiceTest(
@@ -34,7 +35,7 @@ class NewsServiceTest(
                 tags = emptyList(),
                 createdAt = null,
                 modifiedAt = null,
-                date = null,
+                date = LocalDateTime.now(),
                 isPrivate = false,
                 isSlide = false,
                 isImportant = false,
@@ -72,7 +73,7 @@ class NewsServiceTest(
                             <h3>Goodbye, World!</h3>
                             """.trimIndent(),
                     plainTextDescription = "Hello, World! This is news description. Goodbye, World!",
-                    date = null,
+                    date = LocalDateTime.now(),
                     isPrivate = false,
                     isSlide = false,
                     isImportant = false,


### PR DESCRIPTION
## Feat: 뉴스 날짜로 정렬

### 한줄 요약

뉴스를 createdAt 대신 date로 정렬하도록 하였고, date를 non null하게 바꾸었습니다.

### 상세 설명

46dd7b7 Feat: Change date field to NOT NULLABLE.
a4d2e31 Feat: Change to sort by date, not createdat.
cb7ce9f Test: Fix test.

