### PR TITLE
fix: 중요 안내

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/admin/service/AdminService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admin/service/AdminService.kt
@@ -44,7 +44,7 @@ class AdminServiceImpl(
     @Transactional
     override fun readAllImportants(pageNum: Long): List<ImportantResponse> {
         val importantResponses: MutableList<ImportantResponse> = mutableListOf()
-        noticeRepository.findAllByIsImportant(true).forEach {
+        noticeRepository.findAllByIsImportantTrueAndIsDeletedFalse().forEach {
             importantResponses.add(
                 ImportantResponse(
                     id = it.id,
@@ -55,7 +55,7 @@ class AdminServiceImpl(
             )
         }
 
-        newsRepository.findAllByIsImportant(true).forEach {
+        newsRepository.findAllByIsImportantTrueAndIsDeletedFalse().forEach {
             importantResponses.add(
                 ImportantResponse(
                     id = it.id,
@@ -66,7 +66,7 @@ class AdminServiceImpl(
             )
         }
 
-        seminarRepository.findAllByIsImportant(true).forEach {
+        seminarRepository.findAllByIsImportantTrueAndIsDeletedFalse().forEach {
             importantResponses.add(
                 ImportantResponse(
                     id = it.id,
@@ -90,11 +90,13 @@ class AdminServiceImpl(
                         ?: throw CserealException.Csereal404("해당하는 공지사항을 찾을 수 없습니다.(noticeId=${important.id})")
                     notice.isImportant = false
                 }
+
                 "news" -> {
                     val news = newsRepository.findByIdOrNull(important.id)
                         ?: throw CserealException.Csereal404("해당하는 새소식을 찾을 수 없습니다.(noticeId=${important.id})")
                     news.isImportant = false
                 }
+
                 "seminar" -> {
                     val seminar = seminarRepository.findByIdOrNull(important.id)
                         ?: throw CserealException.Csereal404("해당하는 세미나를 찾을 수 없습니다.(noticeId=${important.id})")

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/database/MainRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/database/MainRepository.kt
@@ -88,7 +88,7 @@ class MainRepositoryImpl(
 
     override fun readMainImportant(): List<MainImportantResponse> {
         val mainImportantResponses: MutableList<MainImportantResponse> = mutableListOf()
-        noticeRepository.findAllByIsImportant(true).forEach {
+        noticeRepository.findAllByIsPrivateFalseAndIsImportantTrueAndIsDeletedFalse().forEach {
             mainImportantResponses.add(
                 MainImportantResponse(
                     id = it.id,
@@ -100,7 +100,7 @@ class MainRepositoryImpl(
             )
         }
 
-        newsRepository.findAllByIsImportant(true).forEach {
+        newsRepository.findAllByIsPrivateFalseAndIsImportantTrueAndIsDeletedFalse().forEach {
             mainImportantResponses.add(
                 MainImportantResponse(
                     id = it.id,
@@ -112,7 +112,7 @@ class MainRepositoryImpl(
             )
         }
 
-        seminarRepository.findAllByIsImportant(true).forEach {
+        seminarRepository.findAllByIsPrivateFalseAndIsImportantTrueAndIsDeletedFalse().forEach {
             mainImportantResponses.add(
                 MainImportantResponse(
                     id = it.id,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/database/MainRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/database/MainRepository.kt
@@ -93,7 +93,7 @@ class MainRepositoryImpl(
                 MainImportantResponse(
                     id = it.id,
                     title = it.titleForMain ?: it.title,
-                    description = it.description,
+                    description = it.plainTextDescription,
                     createdAt = it.createdAt,
                     category = "notice"
                 )
@@ -105,7 +105,7 @@ class MainRepositoryImpl(
                 MainImportantResponse(
                     id = it.id,
                     title = it.titleForMain ?: it.title,
-                    description = it.description,
+                    description = it.plainTextDescription,
                     createdAt = it.createdAt,
                     category = "news"
                 )
@@ -117,7 +117,7 @@ class MainRepositoryImpl(
                 MainImportantResponse(
                     id = it.id,
                     title = it.titleForMain ?: it.title,
-                    description = it.description,
+                    description = it.plainTextDescription,
                     createdAt = it.createdAt,
                     category = "seminar"
                 )
@@ -125,6 +125,6 @@ class MainRepositoryImpl(
         }
         mainImportantResponses.sortByDescending { it.createdAt }
 
-        return mainImportantResponses
+        return mainImportantResponses.take(2)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsRepository.kt
@@ -20,7 +20,8 @@ import org.springframework.stereotype.Component
 import java.time.LocalDateTime
 
 interface NewsRepository : JpaRepository<NewsEntity, Long>, CustomNewsRepository {
-    fun findAllByIsImportant(isImportant: Boolean): List<NewsEntity>
+    fun findAllByIsPrivateFalseAndIsImportantTrueAndIsDeletedFalse(): List<NewsEntity>
+    fun findAllByIsImportantTrueAndIsDeletedFalse(): List<NewsEntity>
     fun findFirstByCreatedAtLessThanOrderByCreatedAtDesc(timestamp: LocalDateTime): NewsEntity?
     fun findFirstByCreatedAtGreaterThanOrderByCreatedAtAsc(timestamp: LocalDateTime): NewsEntity?
 }
@@ -33,6 +34,7 @@ interface CustomNewsRepository {
         usePageBtn: Boolean,
         isStaff: Boolean
     ): NewsSearchResponse
+
     fun searchTotalNews(
         keyword: String,
         number: Int,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
@@ -17,7 +17,8 @@ import org.springframework.stereotype.Component
 import java.time.LocalDateTime
 
 interface NoticeRepository : JpaRepository<NoticeEntity, Long>, CustomNoticeRepository {
-    fun findAllByIsImportant(isImportant: Boolean): List<NoticeEntity>
+    fun findAllByIsPrivateFalseAndIsImportantTrueAndIsDeletedFalse(): List<NoticeEntity>
+    fun findAllByIsImportantTrueAndIsDeletedFalse(): List<NoticeEntity>
     fun findFirstByCreatedAtLessThanOrderByCreatedAtDesc(timestamp: LocalDateTime): NoticeEntity?
     fun findFirstByCreatedAtGreaterThanOrderByCreatedAtAsc(timestamp: LocalDateTime): NoticeEntity?
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarRepository.kt
@@ -14,7 +14,8 @@ import org.springframework.stereotype.Component
 import java.time.LocalDateTime
 
 interface SeminarRepository : JpaRepository<SeminarEntity, Long>, CustomSeminarRepository {
-    fun findAllByIsImportant(isImportant: Boolean): List<SeminarEntity>
+    fun findAllByIsPrivateFalseAndIsImportantTrueAndIsDeletedFalse(): List<SeminarEntity>
+    fun findAllByIsImportantTrueAndIsDeletedFalse(): List<SeminarEntity>
     fun findFirstByCreatedAtLessThanAndIsPrivateFalseOrderByCreatedAtDesc(timestamp: LocalDateTime): SeminarEntity?
     fun findFirstByCreatedAtGreaterThanAndIsPrivateFalseOrderByCreatedAtAsc(timestamp: LocalDateTime): SeminarEntity?
 }


### PR DESCRIPTION
## 중요 안내

### 한줄 요약

삭제된 글이 중요 안내에서 보이지 않게 하고 관리자 페이지에서는 비공개 중요 안내는 볼 수 있도록 하였습니다. 
메인 페이지에서는 최대 2개까지 중요 안내를 보내주고, plainTextDescription을 보내도록 수정하였습니다.
