### PR TITLE
fix: 첨부파일 다운로드

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/common/api/DeprecatedFileController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/common/api/DeprecatedFileController.kt
@@ -6,13 +6,16 @@ import org.springframework.core.io.Resource
 import org.springframework.core.io.UrlResource
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.util.AntPathMatcher
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import java.net.URLEncoder
 import java.nio.file.Paths
+import kotlin.text.Charsets.UTF_8
 
 @RestController
 @RequestMapping("/sites/default/files")
@@ -34,17 +37,15 @@ class DeprecatedFileController(
         val resource = UrlResource(file.toUri())
 
         return if (resource.exists() || resource.isReadable) {
-            var contentType: String? = request.servletContext.getMimeType(resource.file.absolutePath)
+            val contentType: String? = request.servletContext.getMimeType(resource.file.absolutePath)
             val headers = HttpHeaders()
 
-            contentType = contentType ?: "application/octet-stream"
+            headers.contentType = MediaType.parseMediaType(contentType ?: "application/octet-stream")
 
-            if (contentType.startsWith("text")) {
-                contentType += ";charset=UTF-8"
-            }
+            val originalFilename = fileSubDir.substringAfterLast("/")
+            val encodedFilename = URLEncoder.encode(originalFilename, UTF_8.toString()).replace("+", "%20")
 
-            headers.contentType =
-                org.springframework.http.MediaType.parseMediaType(contentType)
+            headers.add(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename*=UTF-8''$encodedFilename")
 
             ResponseEntity.ok()
                 .headers(headers)


### PR DESCRIPTION
## 첨부파일

### 한줄 요약

첨부파일 다운로드 시 파일 이름이 이상하게 받아지는 문제가 있었는데 content-dispositon 헤더로 filename을 직접 주어서 해결하였습니다.
