### PR TITLE
fix: 메인 공지 정렬

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/database/MainRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/database/MainRepository.kt
@@ -64,7 +64,7 @@ class MainRepositoryImpl(
             )
         ).from(noticeEntity)
             .where(noticeEntity.isDeleted.eq(false), noticeEntity.isPrivate.eq(false))
-            .orderBy(noticeEntity.isPinned.desc()).orderBy(noticeEntity.createdAt.desc())
+            .orderBy(noticeEntity.createdAt.desc())
             .limit(6).fetch()
     }
 
@@ -82,7 +82,7 @@ class MainRepositoryImpl(
             .rightJoin(tagInNoticeEntity).on(noticeTagEntity.tag.eq(tagInNoticeEntity))
             .where(noticeTagEntity.tag.name.eq(tagEnum))
             .where(noticeEntity.isDeleted.eq(false), noticeEntity.isPrivate.eq(false))
-            .orderBy(noticeEntity.isPinned.desc()).orderBy(noticeTagEntity.notice.createdAt.desc())
+            .orderBy(noticeTagEntity.notice.createdAt.desc())
             .limit(6).distinct().fetch()
     }
 


### PR DESCRIPTION
## 메인 공지

### 한줄 요약

메인에서 6개씩 보이는 공지사항에 고정 글 여부 상관없이 최신순으로 정렬하였습니다.

### 상세 설명

[837f51707492ab4b3f1ef9cac1dabe492d117935]: 메인 공지 정렬
