### PR TITLE
fix: titleForMain이 없어도 isImportant 등록 가능

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/service/NewsService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/service/NewsService.kt
@@ -110,10 +110,6 @@ class NewsServiceImpl(
             attachmentService.uploadAllAttachments(newNews, attachments)
         }
 
-        if (request.isImportant && request.titleForMain.isNullOrEmpty()) {
-            throw CserealException.Csereal400("중요 제목이 입력되어야 합니다")
-        }
-
         newsRepository.save(newNews)
 
         val imageURL = mainImageService.createImageURL(newNews.mainImage)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
@@ -114,10 +114,6 @@ class NoticeServiceImpl(
             attachmentService.uploadAllAttachments(newNotice, attachments)
         }
 
-        if (request.isImportant && request.titleForMain.isNullOrEmpty()) {
-            throw CserealException.Csereal400("중요 제목이 입력되어야 합니다")
-        }
-
         noticeRepository.save(newNotice)
 
         val attachmentResponses = attachmentService.createAttachmentResponses(newNotice.attachments)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/service/SeminarService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/service/SeminarService.kt
@@ -118,10 +118,6 @@ class SeminarServiceImpl(
             attachmentService.uploadAllAttachments(seminar, newAttachments)
         }
 
-        if (request.isImportant && request.titleForMain.isNullOrEmpty()) {
-            throw CserealException.Csereal400("중요 제목이 입력되어야 합니다")
-        }
-
         val attachmentResponses = attachmentService.createAttachmentResponses(seminar.attachments)
 
         val imageURL = mainImageService.createImageURL(seminar.mainImage)


### PR DESCRIPTION
## 제목
fix: titleForMain이 없어도 isImportant 등록 가능

### 한줄 요약
titleForMain = null 이어도 isImportant = true일 수 있습니다

### 상세 설명

[33c8ac4](https://github.com/wafflestudio/csereal-server/pull/160/commits/33c8ac4e8eb5a9b9b4138c9e6ea4fe677139c4f8): 지금 새소식 3총사 create할 때 isImportant = true라면 titleForMain을 작성해야 한다고 서비스 단에서 막고 있는데, 메인에 나와있는 것처럼 titleForMain이 없으면 title이 나올 수 있도록 서비스단에서의 예외조치 삭제했습니다.

### TODO

TODO가 있다면 작성해주시고, 없다면 생략해주세요.
