### PR TITLE
fix: em.close() 추가

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/admin/database/AdminRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admin/database/AdminRepository.kt
@@ -41,6 +41,7 @@ class AdminRepository(
                 category = it[3] as String
             )
         }
+        em.close()
         return formattedResult
     }
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/admin/database/AdminRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admin/database/AdminRepository.kt
@@ -64,6 +64,8 @@ class AdminRepository(
             ) as nn
             """.trimIndent()
         )
-        return query.resultList.first() as Long
+        val total = query.resultList.first() as Long
+        em.close()
+        return total
     }
 }


### PR DESCRIPTION
## 제목
fix: em.close() 추가

### 한줄 요약
getImportant에서 em.close()를 추가했습니다

### 상세 설명

[ff323e323548874689303efa668486fb1677934f]: 로그를 찾아보니, HikariPool에서 쓸 수 있는 pool들이 꽉 차서 안된다더라고요. 규모가 큰 거에는 pool에 대해 손을 봐야할지도 모르겠지만, 준형님 의견대로 em을 close하니 active pool 개수 바로 줄었습니다

notice 1500개 이주시키고 important get해보았을 때 아래 캡쳐 화면처럼 차이납니다

![image](https://github.com/wafflestudio/csereal-server/assets/86216809/02898281-98bd-471f-b1dd-b057aeb88369)

![image](https://github.com/wafflestudio/csereal-server/assets/86216809/db5bf91d-3da2-4313-b289-b7df6d359e2e)

