### PR TITLE
feat: migrateConference 추가

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/config/SecurityConfig.kt
@@ -31,7 +31,7 @@ class SecurityConfig(
             .cors().and()
             .csrf().disable()
             .oauth2Login()
-            .loginPage("${endpointProperties.frontend}/oauth2/authorization/idsnucse")
+            .loginPage("/oauth2/authorization/idsnucse")
             .redirectionEndpoint()
             .baseUri("/api/v1/login/oauth2/code/idsnucse").and()
             .userInfoEndpoint().oidcUserService(customOidcUserService).and()

--- a/src/main/kotlin/com/wafflestudio/csereal/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/config/SecurityConfig.kt
@@ -31,7 +31,7 @@ class SecurityConfig(
             .cors().and()
             .csrf().disable()
             .oauth2Login()
-            .loginPage("/oauth2/authorization/idsnucse")
+            .loginPage("${endpointProperties.frontend}/oauth2/authorization/idsnucse")
             .redirectionEndpoint()
             .baseUri("/api/v1/login/oauth2/code/idsnucse").and()
             .userInfoEndpoint().oidcUserService(customOidcUserService).and()

--- a/src/main/kotlin/com/wafflestudio/csereal/core/conference/api/ConferenceController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/conference/api/ConferenceController.kt
@@ -24,11 +24,7 @@ class ConferenceController(
     fun modifyConferencePage(
         @RequestBody conferenceModifyRequest: ConferenceModifyRequest
     ): ResponseEntity<ConferencePage> {
-        return ResponseEntity.ok(
-            conferenceService.modifyConferences(
-                conferenceModifyRequest
-            )
-        )
+        return ResponseEntity.ok(conferenceService.modifyConferences(conferenceModifyRequest))
     }
 
     @AuthenticatedStaff

--- a/src/main/kotlin/com/wafflestudio/csereal/core/conference/api/ConferenceController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/conference/api/ConferenceController.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.csereal.core.conference.api
 
 import com.wafflestudio.csereal.common.aop.AuthenticatedStaff
+import com.wafflestudio.csereal.core.conference.dto.ConferenceDto
 import com.wafflestudio.csereal.core.conference.dto.ConferenceModifyRequest
 import com.wafflestudio.csereal.core.conference.dto.ConferencePage
 import com.wafflestudio.csereal.core.conference.service.ConferenceService
@@ -28,5 +29,13 @@ class ConferenceController(
                 conferenceModifyRequest
             )
         )
+    }
+
+    @AuthenticatedStaff
+    @PostMapping("/migrate")
+    fun migrateConferences(
+        @RequestBody requestList: List<ConferenceDto>
+    ): ResponseEntity<List<ConferenceDto>> {
+        return ResponseEntity.ok(conferenceService.migrateConferences(requestList))
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/conference/database/ConferenceEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/conference/database/ConferenceEntity.kt
@@ -1,7 +1,6 @@
 package com.wafflestudio.csereal.core.conference.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
-import com.wafflestudio.csereal.core.conference.dto.ConferenceCreateDto
 import com.wafflestudio.csereal.core.conference.dto.ConferenceDto
 import com.wafflestudio.csereal.core.research.database.ResearchSearchEntity
 import jakarta.persistence.*
@@ -22,12 +21,12 @@ class ConferenceEntity(
 ) : BaseTimeEntity() {
     companion object {
         fun of(
-            conferenceCreateDto: ConferenceCreateDto,
+            conferenceDto: ConferenceDto,
             conferencePage: ConferencePageEntity
         ) = ConferenceEntity(
-            code = conferenceCreateDto.code,
-            abbreviation = conferenceCreateDto.abbreviation,
-            name = conferenceCreateDto.name,
+            code = conferenceDto.code,
+            abbreviation = conferenceDto.abbreviation,
+            name = conferenceDto.name,
             conferencePage = conferencePage
         )
     }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/conference/database/ConferencePageEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/conference/database/ConferencePageEntity.kt
@@ -15,4 +15,13 @@ class ConferencePageEntity(
     @OrderBy("code ASC")
     val conferences: MutableSet<ConferenceEntity> = mutableSetOf()
 
-) : BaseTimeEntity()
+) : BaseTimeEntity() {
+    companion object {
+        fun of(author: UserEntity): ConferencePageEntity {
+            return ConferencePageEntity(
+                author = author,
+                conferences = mutableSetOf()
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/conference/dto/ConferenceCreateDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/conference/dto/ConferenceCreateDto.kt
@@ -1,7 +1,0 @@
-package com.wafflestudio.csereal.core.conference.dto
-
-data class ConferenceCreateDto(
-    val code: String,
-    val abbreviation: String,
-    val name: String
-)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/conference/dto/ConferenceDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/conference/dto/ConferenceDto.kt
@@ -1,9 +1,11 @@
 package com.wafflestudio.csereal.core.conference.dto
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.wafflestudio.csereal.core.conference.database.ConferenceEntity
 
 data class ConferenceDto(
-    val id: Long,
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    val id: Long? = null,
     val code: String,
     val abbreviation: String,
     val name: String

--- a/src/main/kotlin/com/wafflestudio/csereal/core/conference/dto/ConferenceModifyRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/conference/dto/ConferenceModifyRequest.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.conference.dto
 
 data class ConferenceModifyRequest(
-    val newConferenceList: List<ConferenceCreateDto>,
+    val newConferenceList: List<ConferenceDto>,
     val modifiedConferenceList: List<ConferenceDto>,
-    val deleteConfereceIdList: List<Long>
+    val deleteConferenceIdList: List<Long>
 )

--- a/src/main/kotlin/com/wafflestudio/csereal/core/conference/service/ConferenceService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/conference/service/ConferenceService.kt
@@ -82,6 +82,7 @@ class ConferenceServiceImpl(
 
             conferencePage.conferences.add(conference)
 
+            conference.researchSearch = ResearchSearchEntity.create(conference)
             list.add(ConferenceDto.of(conference))
         }
 

--- a/src/test/kotlin/com/wafflestudio/csereal/core/conference/service/ConferenceServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/conference/service/ConferenceServiceTest.kt
@@ -4,7 +4,6 @@ import com.wafflestudio.csereal.core.conference.database.ConferenceEntity
 import com.wafflestudio.csereal.core.conference.database.ConferencePageEntity
 import com.wafflestudio.csereal.core.conference.database.ConferencePageRepository
 import com.wafflestudio.csereal.core.conference.database.ConferenceRepository
-import com.wafflestudio.csereal.core.conference.dto.ConferenceCreateDto
 import com.wafflestudio.csereal.core.conference.dto.ConferenceDto
 import com.wafflestudio.csereal.core.conference.dto.ConferenceModifyRequest
 import com.wafflestudio.csereal.core.user.database.Role
@@ -110,13 +109,13 @@ class ConferenceServiceTest(
                 name = "modifiedName",
                 abbreviation = "modifiedAbbreviation"
             )
-            val newConference = ConferenceCreateDto(
+            val newConference = ConferenceDto(
                 code = "code9",
                 name = "newName",
                 abbreviation = "newAbbreviation"
             )
             val conferenceModifyRequest = ConferenceModifyRequest(
-                deleteConfereceIdList = listOf(deleteConferenceId),
+                deleteConferenceIdList = listOf(deleteConferenceId),
                 modifiedConferenceList = listOf(modifiedConference),
                 newConferenceList = listOf(newConference)
             )


### PR DESCRIPTION
## 제목
feat: migrateConference 추가

### 한줄 요약
migrateConference를 추가하고, createConferenceDto를 삭제하였습니다.

### 상세 설명

[bcb0ec84e0e81fc1532fb24925ec571f3e455812]: migrateConference를 추가하고, createConferenceDto가 없어도 되도록 코드를 정리했습니다.

[8874eae3b54737d2177b0589cf865893934bea40]: 소소한 수정 1
[6b0b5f308c36514145ca6fa32e271fbb461c4ffa]: 소소한 수정 2
[12bef49d0a88f8114b59bf825beb72ce2f45b5b7]: 소소한 수정 3

[0ef562e2b6e8ff379251c0df80fc21498dd0758b]: createConferenceDto를 삭제하였습니다.

