### PR TITLE
refactor: 실제 스누씨 서버 연동

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,30 +22,25 @@ jobs:
             contents: read
 
         steps:
-            -
-                name: Checkout
+            -   name: Checkout
                 uses: actions/checkout@v3
 
-            - 
-                name: Setup Java JDK
+            -   name: Setup Java JDK
                 uses: actions/setup-java@v3.12.0
                 with:
                     java-version: '17'
                     distribution: 'adopt'
 
-            -
-                run: ./gradlew clean bootJar -x test
+            -   run: ./gradlew clean bootJar -x test
 
-            -
-                name: Log in to the Container Registry
+            -   name: Log in to the Container Registry
                 uses: docker/login-action@v2.2.0
                 with:
                     registry: ghcr.io
                     username: ${{github.actor}}
                     password: ${{secrets.GITHUB_TOKEN}}
 
-            -
-                name: Build and push Docker image
+            -   name: Build and push Docker image
                 uses: docker/build-push-action@v4.1.1
                 with:
                     context: .
@@ -56,19 +51,17 @@ jobs:
                         ghcr.io/wafflestudio/csereal-server/server_image:latest
                         ghcr.io/wafflestudio/csereal-server/server_image:${{github.sha}}
 
-            -
-                name: Create .env file
+            -   name: Create .env file
                 run: |
                     echo "MYSQL_ROOT_PASSWORD=${{secrets.MYSQL_ROOT_PASSWORD}}" > .env
                     echo "MYSQL_USER=${{secrets.MYSQL_USER}}" >> .env
                     echo "MYSQL_PASSWORD=${{secrets.MYSQL_PASSWORD}}" >> .env
                     echo "MYSQL_DATABASE=${{secrets.MYSQL_DATABASE}}" >> .env
                     echo "PROFILE=prod" >> .env
-                    echo "OIDC_CLIENT_SECRET_DEV=${{secrets.OIDC_CLIENT_SECRET_DEV}}" >> .env
+                    echo "OIDC_CLIENT_SECRET=${{secrets.OIDC_CLIENT_SECRET}}" >> .env
                     echo "URL=${{secrets.URL}}" >> .env
 
-            -
-                name: SCP Command to Transfer Files
+            -   name: SCP Command to Transfer Files
                 uses: appleboy/scp-action@v0.1.4
                 with:
                     host: ${{secrets.SSH_HOST}}
@@ -77,8 +70,7 @@ jobs:
                     source: "docker-compose-backend.yml, .env"
                     target: "~/app"
                     overwrite: true
-            -
-                name: SSH Remote Commands
+            -   name: SSH Remote Commands
                 uses: appleboy/ssh-action@v1.0.0
                 with:
                     host: ${{secrets.SSH_HOST}}

--- a/docker-compose-backend.yml
+++ b/docker-compose-backend.yml
@@ -1,27 +1,27 @@
 services:
-  green:
-    container_name: csereal_server_green
-    build:
-      context: ./
-      args:
-        PROFILE: ${PROFILE}
-    ports:
-      - 8080:8080
-    volumes:
-      - ./cse-files:/app/cse-files
-      - ./files:/app/files
+    green:
+        container_name: csereal_server_green
+        build:
+            context: ./
+            args:
+                PROFILE: ${PROFILE}
+        ports:
+            - 8080:8080
+        volumes:
+            - ./cse-files:/app/cse-files
+            - ./files:/app/files
 
-    environment:
-      SPRING_DATASOURCE_URL: "jdbc:mysql://host.docker.internal:3306/${MYSQL_DATABASE}?serverTimezone=Asia/Seoul&useSSL=false&allowPublicKeyRetrieval=true"
-      SPRING_DATASOURCE_USERNAME: ${MYSQL_USER}
-      SPRING_DATASOURCE_PASSWORD: ${MYSQL_PASSWORD}
-      OIDC_CLIENT_SECRET_DEV: ${OIDC_CLIENT_SECRET_DEV}
-      URL: ${URL}
-    extra_hosts:
-      - host.docker.internal:host-gateway
-    restart: always
-    image: ghcr.io/wafflestudio/csereal-server/server_image:latest
-  # TODO: Activate after implementing health check
+        environment:
+            SPRING_DATASOURCE_URL: "jdbc:mysql://host.docker.internal:3306/${MYSQL_DATABASE}?serverTimezone=Asia/Seoul&useSSL=false&allowPublicKeyRetrieval=true"
+            SPRING_DATASOURCE_USERNAME: ${MYSQL_USER}
+            SPRING_DATASOURCE_PASSWORD: ${MYSQL_PASSWORD}
+            OIDC_CLIENT_SECRET: ${OIDC_CLIENT_SECRET}
+            URL: ${URL}
+        extra_hosts:
+            - host.docker.internal:host-gateway
+        restart: always
+        image: ghcr.io/wafflestudio/csereal-server/server_image:latest
+    # TODO: Activate after implementing health check
 #  blue:
 #    container_name: csereal_server_blue
 #    build:

--- a/src/main/kotlin/com/wafflestudio/csereal/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/config/SecurityConfig.kt
@@ -69,7 +69,7 @@ class SecurityConfig(
     @Bean
     fun corsConfigurationSource(): CorsConfigurationSource {
         val configuration = CorsConfiguration()
-        configuration.allowedOrigins = listOf(endpointProperties.frontend, "http://localhost:3000")
+        configuration.allowedOrigins = listOf(endpointProperties.frontend)
         configuration.allowedMethods = listOf("*")
         configuration.allowedHeaders = listOf("*")
         configuration.allowCredentials = true

--- a/src/main/kotlin/com/wafflestudio/csereal/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/config/SecurityConfig.kt
@@ -4,6 +4,7 @@ import com.wafflestudio.csereal.common.properties.EndpointProperties
 import com.wafflestudio.csereal.core.user.service.CustomOidcUserService
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -22,7 +23,9 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 @EnableConfigurationProperties(EndpointProperties::class)
 class SecurityConfig(
     private val customOidcUserService: CustomOidcUserService,
-    private val endpointProperties: EndpointProperties
+    private val endpointProperties: EndpointProperties,
+    @Value("\${login-page}")
+    private val loginPage: String
 ) {
 
     @Bean
@@ -31,7 +34,7 @@ class SecurityConfig(
             .cors().and()
             .csrf().disable()
             .oauth2Login()
-            .loginPage("${endpointProperties.frontend}/oauth2/authorization/idsnucse")
+            .loginPage("$loginPage/oauth2/authorization/idsnucse")
             .redirectionEndpoint()
             .baseUri("/api/v1/login/oauth2/code/idsnucse").and()
             .userInfoEndpoint().oidcUserService(customOidcUserService).and()
@@ -66,9 +69,10 @@ class SecurityConfig(
     @Bean
     fun corsConfigurationSource(): CorsConfigurationSource {
         val configuration = CorsConfiguration()
-        configuration.allowedOrigins = listOf("*")
+        configuration.allowedOrigins = listOf(endpointProperties.frontend, "http://localhost:3000")
         configuration.allowedMethods = listOf("*")
         configuration.allowedHeaders = listOf("*")
+        configuration.allowCredentials = true
         configuration.maxAge = 3000
         val source = UrlBasedCorsConfigurationSource()
         source.registerCorsConfiguration("/**", configuration)

--- a/src/main/kotlin/com/wafflestudio/csereal/common/config/WebConfig.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/config/WebConfig.kt
@@ -1,17 +1,23 @@
 package com.wafflestudio.csereal.common.config
 
+import com.wafflestudio.csereal.common.properties.EndpointProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.servlet.config.annotation.CorsRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
-class WebConfig : WebMvcConfigurer {
+@EnableConfigurationProperties(EndpointProperties::class)
+class WebConfig(
+    private val endpointProperties: EndpointProperties
+) : WebMvcConfigurer {
 
     override fun addCorsMappings(registry: CorsRegistry) {
         registry.addMapping("/**")
-            .allowedOrigins("*")
+            .allowedOrigins(endpointProperties.frontend, "http://localhost:3000")
             .allowedMethods("*")
             .allowedHeaders("*")
+            .allowCredentials(true)
             .maxAge(3000)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/common/config/WebConfig.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/config/WebConfig.kt
@@ -14,7 +14,7 @@ class WebConfig(
 
     override fun addCorsMappings(registry: CorsRegistry) {
         registry.addMapping("/**")
-            .allowedOrigins(endpointProperties.frontend, "http://localhost:3000")
+            .allowedOrigins(endpointProperties.frontend)
             .allowedMethods("*")
             .allowedHeaders("*")
             .allowCredentials(true)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,148 +1,138 @@
 spring:
-  profiles:
-    active: local
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-  security:
-    oauth2:
-      client:
-        registration:
-          idsnucse:
-            client-id: waffle-dev-local-testing
-            client-secret: ${OIDC_CLIENT_SECRET_DEV}
-            authorization-grant-type: authorization_code
-            scope: openid, profile, email
-        provider:
-          idsnucse:
-            issuer-uri: https://id-dev.bacchus.io/o
-            jwk-set-uri: https://id-dev.bacchus.io/o/jwks
-  servlet:
-    multipart:
-      enabled: true
-      max-request-size: 100MB
-      max-file-size: 10MB
+    profiles:
+        active: local
+    datasource:
+        driver-class-name: com.mysql.cj.jdbc.Driver
+    security:
+        oauth2:
+            client:
+                registration:
+                    idsnucse:
+                        client-id: waffle-dev-local-testing
+                        client-secret: ${OIDC_CLIENT_SECRET_DEV}
+                        authorization-grant-type: authorization_code
+                        scope: openid, profile, email
+                        redirect-uri: http://localhost:8080/api/v1/login/oauth2/code/idsnucse
+                provider:
+                    idsnucse:
+                        issuer-uri: https://id-dev.bacchus.io/o
+                        jwk-set-uri: https://id-dev.bacchus.io/o/jwks
+    servlet:
+        multipart:
+            enabled: true
+            max-request-size: 100MB
+            max-file-size: 10MB
 
 server:
-  servlet:
-    session:
-      timeout: 7200 # 2시간
+    servlet:
+        session:
+            timeout: 7200 # 2시간
 
 springdoc:
-  paths-to-match:
-    - /api/**
-  swagger-ui:
-    path: index.html
-  api-docs:
-    path: /api-docs/json
+    paths-to-match:
+        - /api/**
+    swagger-ui:
+        path: index.html
+    api-docs:
+        path: /api-docs/json
+
+csereal:
+    upload:
+        path: ./files/
+
+oldFiles:
+    path: ./cse-files/
+
+endpoint:
+    backend: http://localhost:8080/api
+    frontend: http://localhost:3000
+
+login-page: http://localhost:8080
 
 ---
 spring:
-  config.activate.on-profile: local
-  datasource:
-    url: jdbc:mysql://127.0.0.1:3306/csereal?useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul
-    username: root
-    password: password
-  jpa:
-    hibernate:
-      ddl-auto: update
-    show-sql: true
-    open-in-view: false
-    properties:
-      hibernate:
-        dialect: com.wafflestudio.csereal.common.config.MySQLDialectCustom
-  security:
-    oauth2:
-      client:
-        registration:
-          idsnucse:
-            redirect-uri: http://localhost:8080/api/v1/login/oauth2/code/idsnucse
+    config.activate.on-profile: local
+    datasource:
+        url: jdbc:mysql://127.0.0.1:3306/csereal?useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul
+        username: root
+        password: password
+    jpa:
+        hibernate:
+            ddl-auto: update
+        show-sql: true
+        open-in-view: false
+        properties:
+            hibernate:
+                dialect: com.wafflestudio.csereal.common.config.MySQLDialectCustom
 
 logging.level:
-  default: INFO
-  org:
-    springframework:
-      security: DEBUG
-
-csereal:
-  upload:
-    path: ./files/
-
-oldFiles:
-  path: ./cse-files/
-
-endpoint:
-  backend: http://localhost:8080/api
-  frontend: http://localhost:3000
+    default: INFO
+    org:
+        springframework:
+            security: DEBUG
 
 ---
 spring:
-  config.activate.on-profile: prod
-  jpa:
-    hibernate:
-      ddl-auto: update # TODO: change to validate (or none) when save actual data to server
-    open-in-view: false
-    properties:
-      hibernate:
-        dialect: com.wafflestudio.csereal.common.config.MySQLDialectCustom
-  security:
-    oauth2:
-      client:
-        registration:
-          idsnucse:
-            redirect-uri: https://${URL}/api/v1/login/oauth2/code/idsnucse
+    config.activate.on-profile: prod
+    jpa:
+        hibernate:
+            ddl-auto: update # TODO: change to validate (or none) when save actual data to server
+        open-in-view: false
+        properties:
+            hibernate:
+                dialect: com.wafflestudio.csereal.common.config.MySQLDialectCustom
+    security:
+        oauth2:
+            client:
+                registration:
+                    idsnucse:
+                        client-id: cse-waffle-dev
+                        client-secret: ${OIDC_CLIENT_SECRET}
+                        authorization-grant-type: authorization_code
+                        scope: openid, profile, email
+                        redirect-uri: https://${URL}/api/v1/login/oauth2/code/idsnucse
+                provider:
+                    idsnucse:
+                        issuer-uri: https://id.snucse.org/o
+                        jwk-set-uri: https://id.snucse.org/o/jwks
 
 csereal:
-  upload:
-    path: /app/files/
+    upload:
+        path: /app/files/
 
 oldFiles:
-  path: /app/cse-files/
+    path: /app/cse-files/
 
 endpoint:
-  backend: https://${URL}/api
-  frontend: https://${URL}
+    backend: https://${URL}/api
+    frontend: https://${URL}
+
+login-page: https://${URL}
 
 ---
 spring:
-  config.activate.on-profile: test
-  datasource:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:testdb;MODE=MYSQL;DB_CLOSE_DELAY=-1;
-    username: sa
-    password:
-  jpa:
-    database: h2
-    database-platform: org.hibernate.dialect.H2Dialect
-    show-sql: true
-    open-in-view: false
-    hibernate:
-      ddl-auto: create-drop
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.H2Dialect
-  h2:
-    console:
-      enabled: true
-  security:
-    oauth2:
-      client:
-        registration:
-          idsnucse:
-            redirect-uri: http://localhost:8080/api/v1/login/oauth2/code/idsnucse
+    config.activate.on-profile: test
+    datasource:
+        driver-class-name: org.h2.Driver
+        url: jdbc:h2:mem:testdb;MODE=MYSQL;DB_CLOSE_DELAY=-1;
+        username: sa
+        password:
+    jpa:
+        database: h2
+        database-platform: org.hibernate.dialect.H2Dialect
+        show-sql: true
+        open-in-view: false
+        hibernate:
+            ddl-auto: create-drop
+        properties:
+            hibernate:
+                dialect: org.hibernate.dialect.H2Dialect
+    h2:
+        console:
+            enabled: true
 
 logging.level:
-  default: INFO
-  org:
-    springframework:
-      security: DEBUG
-
-csereal:
-  upload:
-    path: ./files/
-
-oldFiles:
-  path: ./cse-files/
-
-endpoint:
-  backend: http://localhost:8080/api
-  frontend: http://localhost:3000
+    default: INFO
+    org:
+        springframework:
+            security: DEBUG


### PR DESCRIPTION
## 스누씨 연동

### 한줄 요약

id-dev가 아닌 id.snucse.org 를 가리키도록 변경하고 OIDC_CLIENT_SECRET 환경변수를 추가하였습니다.
application.yml 파일에서 local-test간 중복되는 항목이 많아 위로 합치고 prod에서 오버라이드 하는 식으로 리팩토링하였습니다.
로컬에서 따로 수정하지 않아도 로그인 페이지가 뜨도록 하였습니다.
리버스 프록시 때문에 배포 환경에서는 CORS 걱정을 할 필요는 없어보이지만, 로컬에서 직접 프론트 백 띄워서 테스트 할 때를 위해 수정하였습니다.
