### PR TITLE
feat: Research 검색

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/CserealApplication.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/CserealApplication.kt
@@ -3,9 +3,11 @@ package com.wafflestudio.csereal
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import org.springframework.scheduling.annotation.EnableAsync
 
 @EnableJpaAuditing
 @SpringBootApplication
+@EnableAsync
 class CserealApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/wafflestudio/csereal/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/config/SecurityConfig.kt
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.core.Authentication
@@ -18,6 +19,7 @@ import org.springframework.web.cors.CorsConfiguration
 import org.springframework.web.cors.CorsConfigurationSource
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 
+@Profile("!test")
 @Configuration
 @EnableWebSecurity
 @EnableConfigurationProperties(EndpointProperties::class)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/event/ProfessorCreatedEvent.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/event/ProfessorCreatedEvent.kt
@@ -1,0 +1,15 @@
+package com.wafflestudio.csereal.core.member.event
+
+import com.wafflestudio.csereal.core.member.database.ProfessorEntity
+
+data class ProfessorCreatedEvent(
+    val id: Long,
+    val labId: Long?
+) {
+    companion object {
+        fun of(professor: ProfessorEntity) = ProfessorCreatedEvent(
+            id = professor.id,
+            labId = professor.lab?.id
+        )
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/event/ProfessorDeletedEvent.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/event/ProfessorDeletedEvent.kt
@@ -1,0 +1,15 @@
+package com.wafflestudio.csereal.core.member.event
+
+import com.wafflestudio.csereal.core.member.database.ProfessorEntity
+
+data class ProfessorDeletedEvent(
+    val id: Long,
+    val labId: Long?
+) {
+    companion object {
+        fun of(professor: ProfessorEntity) = ProfessorDeletedEvent(
+            id = professor.id,
+            labId = professor.lab?.id
+        )
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/event/ProfessorModifiedEvent.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/event/ProfessorModifiedEvent.kt
@@ -1,0 +1,17 @@
+package com.wafflestudio.csereal.core.member.event
+
+import com.wafflestudio.csereal.core.member.database.ProfessorEntity
+
+data class ProfessorModifiedEvent(
+    val id: Long,
+    val beforeLabId: Long?,
+    val afterLabId: Long?
+) {
+    companion object {
+        fun of(updatedProfessor: ProfessorEntity, beforeLabId: Long?) = ProfessorModifiedEvent(
+            id = updatedProfessor.id,
+            beforeLabId,
+            afterLabId = updatedProfessor.lab?.id
+        )
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/service/ProfessorService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/service/ProfessorService.kt
@@ -184,13 +184,13 @@ class ProfessorServiceImpl(
     }
 
     override fun deleteProfessor(professorId: Long) {
-        professorRepository.findByIdOrNull(professorId)?.let {
-            applicationEventPublisher.publishEvent(
-                ProfessorDeletedEvent.of(it)
-            )
-        }
+        val professorEntity = professorRepository.findByIdOrNull(professorId) ?: return
 
         professorRepository.deleteById(professorId)
+
+        applicationEventPublisher.publishEvent(
+            ProfessorDeletedEvent.of(professorEntity)
+        )
     }
 
     @Transactional

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/api/ResearchController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/api/ResearchController.kt
@@ -1,10 +1,8 @@
 package com.wafflestudio.csereal.core.research.api
 
 import com.wafflestudio.csereal.common.aop.AuthenticatedStaff
-import com.wafflestudio.csereal.core.research.dto.LabDto
-import com.wafflestudio.csereal.core.research.dto.LabUpdateRequest
-import com.wafflestudio.csereal.core.research.dto.ResearchDto
-import com.wafflestudio.csereal.core.research.dto.ResearchGroupResponse
+import com.wafflestudio.csereal.core.research.dto.*
+import com.wafflestudio.csereal.core.research.service.ResearchSearchService
 import com.wafflestudio.csereal.core.research.service.ResearchService
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
@@ -14,7 +12,8 @@ import org.springframework.web.multipart.MultipartFile
 @RequestMapping("/api/v1/research")
 @RestController
 class ResearchController(
-    private val researchService: ResearchService
+    private val researchService: ResearchService,
+    private val researchSearchService: ResearchSearchService
 ) {
     @AuthenticatedStaff
     @PostMapping
@@ -102,4 +101,17 @@ class ResearchController(
     ): ResponseEntity<List<LabDto>> {
         return ResponseEntity.ok(researchService.migrateLabs(requestList))
     }
+
+    @GetMapping("/search/top")
+    fun searchTop(
+        @RequestParam(required = true) keyword: String,
+        @RequestParam(required = true) number: Int
+    ) = researchSearchService.searchTopResearch(keyword, number)
+
+    @GetMapping("/search")
+    fun searchPage(
+        @RequestParam(required = true) keyword: String,
+        @RequestParam(required = true) pageSize: Int,
+        @RequestParam(required = true) pageNum: Int
+    ) = researchSearchService.searchResearch(keyword, pageSize, pageNum)
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/database/ResearchSearchRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/database/ResearchSearchRepository.kt
@@ -1,14 +1,94 @@
 package com.wafflestudio.csereal.core.research.database
 
+import com.querydsl.jpa.impl.JPAQuery
 import com.querydsl.jpa.impl.JPAQueryFactory
+import com.wafflestudio.csereal.common.repository.CommonRepository
+import com.wafflestudio.csereal.core.conference.database.QConferenceEntity.conferenceEntity
+import com.wafflestudio.csereal.core.research.database.QLabEntity.labEntity
+import com.wafflestudio.csereal.core.research.database.QResearchEntity.researchEntity
+import com.wafflestudio.csereal.core.research.database.QResearchSearchEntity.researchSearchEntity
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 interface ResearchSearchRepository : JpaRepository<ResearchSearchEntity, Long>, ResearchSearchRepositoryCustom
 
-interface ResearchSearchRepositoryCustom
+interface ResearchSearchRepositoryCustom {
+    fun searchTopResearch(keyword: String, number: Int): List<ResearchSearchEntity>
+
+    fun searchResearch(keyword: String, pageSize: Int, pageNum: Int): Pair<List<ResearchSearchEntity>, Long>
+}
 
 @Repository
 class ResearchSearchRepositoryCustomImpl(
-    private val jpaQueryFactory: JPAQueryFactory
-) : ResearchSearchRepositoryCustom
+    private val queryFactory: JPAQueryFactory,
+    private val commonRepository: CommonRepository
+) : ResearchSearchRepositoryCustom {
+    override fun searchTopResearch(keyword: String, number: Int): List<ResearchSearchEntity> {
+        return searchQuery(keyword)
+            .limit(number.toLong())
+            .fetch()
+    }
+
+    override fun searchResearch(keyword: String, pageSize: Int, pageNum: Int): Pair<List<ResearchSearchEntity>, Long> {
+        val query = searchQuery(keyword)
+        val total = getSearchCount(keyword)
+
+        val validPageNum = exchangePageNum(pageSize, pageNum, total)
+        val validOffset = (if (validPageNum >= 1) validPageNum - 1 else 0) * pageSize.toLong()
+        val queryResult = query
+            .offset(validOffset)
+            .limit(pageSize.toLong())
+            .fetch()
+
+        return queryResult to total
+    }
+
+    fun searchQuery(keyword: String): JPAQuery<ResearchSearchEntity> {
+        val searchDoubleTemplate = commonRepository.searchFullSingleTextTemplate(
+            keyword,
+            researchSearchEntity.content
+        )
+
+        return queryFactory.selectFrom(
+            researchSearchEntity
+        ).leftJoin(
+            researchSearchEntity.lab,
+            labEntity
+        ).fetchJoin()
+            .leftJoin(
+                researchSearchEntity.research,
+                researchEntity
+            ).fetchJoin()
+            .leftJoin(
+                researchSearchEntity.conferenceElement,
+                conferenceEntity
+            ).fetchJoin()
+            .where(
+                searchDoubleTemplate.gt(0.0)
+            )
+    }
+
+    fun getSearchCount(keyword: String): Long {
+        val searchDoubleTemplate = commonRepository.searchFullSingleTextTemplate(
+            keyword,
+            researchSearchEntity.content
+        )
+
+        return queryFactory.select(
+            researchSearchEntity
+                .countDistinct()
+        ).from(
+            researchSearchEntity
+        ).where(
+            searchDoubleTemplate.gt(0.0)
+        ).fetchOne()!!
+    }
+
+    fun exchangePageNum(pageSize: Int, pageNum: Int, total: Long): Int {
+        return if ((pageNum - 1) * pageSize < total) {
+            pageNum
+        } else {
+            Math.ceil(total.toDouble() / pageSize).toInt()
+        }
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/dto/ResearchSearchPageResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/dto/ResearchSearchPageResponse.kt
@@ -1,0 +1,18 @@
+package com.wafflestudio.csereal.core.research.dto
+
+import com.wafflestudio.csereal.core.research.database.ResearchSearchEntity
+
+data class ResearchSearchPageResponse(
+    val researches: List<ResearchSearchResponseElement>,
+    val total: Long
+) {
+    companion object {
+        fun of(
+            researches: List<ResearchSearchEntity>,
+            total: Long
+        ) = ResearchSearchPageResponse(
+            researches = researches.map(ResearchSearchResponseElement::of),
+            total = total
+        )
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/dto/ResearchSearchResponseElement.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/dto/ResearchSearchResponseElement.kt
@@ -1,0 +1,55 @@
+package com.wafflestudio.csereal.core.research.dto
+
+import com.wafflestudio.csereal.common.CserealException
+import com.wafflestudio.csereal.core.research.database.ResearchSearchEntity
+import com.wafflestudio.csereal.core.research.database.ResearchSearchType
+
+data class ResearchSearchResponseElement(
+    val id: Long,
+    val name: String,
+    val researchType: ResearchSearchType
+) {
+    companion object {
+        fun of(
+            researchSearchEntity: ResearchSearchEntity
+        ): ResearchSearchResponseElement =
+            when {
+                researchSearchEntity.research != null &&
+                    researchSearchEntity.lab == null &&
+                    researchSearchEntity.conferenceElement == null
+                -> researchSearchEntity.research!!.let {
+                    ResearchSearchResponseElement(
+                        id = it.id,
+                        name = it.name,
+                        researchType = ResearchSearchType.RESEARCH
+                    )
+                }
+
+                researchSearchEntity.lab != null &&
+                    researchSearchEntity.research == null &&
+                    researchSearchEntity.conferenceElement == null
+                -> researchSearchEntity.lab!!.let {
+                    ResearchSearchResponseElement(
+                        id = it.id,
+                        name = it.name,
+                        researchType = ResearchSearchType.LAB
+                    )
+                }
+
+                researchSearchEntity.conferenceElement != null &&
+                    researchSearchEntity.research == null &&
+                    researchSearchEntity.lab == null
+                -> researchSearchEntity.conferenceElement!!.let {
+                    ResearchSearchResponseElement(
+                        id = it.id,
+                        name = it.name,
+                        researchType = ResearchSearchType.CONFERENCE
+                    )
+                }
+
+                else -> throw CserealException.Csereal401(
+                    "ResearchSearchEntity의 연결이 올바르지 않습니다."
+                )
+            }
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/dto/ResearchSearchTopResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/dto/ResearchSearchTopResponse.kt
@@ -1,0 +1,15 @@
+package com.wafflestudio.csereal.core.research.dto
+
+import com.wafflestudio.csereal.core.research.database.ResearchSearchEntity
+
+data class ResearchSearchTopResponse(
+    val topResearches: List<ResearchSearchResponseElement>
+) {
+    companion object {
+        fun of(
+            topResearches: List<ResearchSearchEntity>
+        ) = ResearchSearchTopResponse(
+            topResearches = topResearches.map(ResearchSearchResponseElement::of)
+        )
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/service/ResearchSearchService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/service/ResearchSearchService.kt
@@ -12,8 +12,6 @@ import org.springframework.context.event.EventListener
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import org.springframework.transaction.event.TransactionPhase
-import org.springframework.transaction.event.TransactionalEventListener
 
 interface ResearchSearchService {
     fun professorCreatedEventListener(professorCreatedEvent: ProfessorCreatedEvent)
@@ -29,7 +27,18 @@ class ResearchSearchServiceImpl(
     private val labRepository: LabRepository,
     private val researchSearchRepository: ResearchSearchRepository
 ) : ResearchSearchService {
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(readOnly = true)
+    override fun searchTopResearch(keyword: String, number: Int): ResearchSearchTopResponse =
+        ResearchSearchTopResponse.of(
+            researchSearchRepository.searchTopResearch(keyword, number)
+        )
+
+    @Transactional(readOnly = true)
+    override fun searchResearch(keyword: String, pageSize: Int, pageNum: Int): ResearchSearchPageResponse =
+        researchSearchRepository.searchResearch(keyword, pageSize, pageNum).let {
+            ResearchSearchPageResponse.of(it.first, it.second)
+        }
+
     @EventListener
     @Transactional
     override fun professorCreatedEventListener(professorCreatedEvent: ProfessorCreatedEvent) {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/service/ResearchSearchService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/service/ResearchSearchService.kt
@@ -1,18 +1,70 @@
 package com.wafflestudio.csereal.core.research.service
 
+import com.wafflestudio.csereal.core.member.event.ProfessorCreatedEvent
+import com.wafflestudio.csereal.core.member.event.ProfessorDeletedEvent
+import com.wafflestudio.csereal.core.member.event.ProfessorModifiedEvent
+import com.wafflestudio.csereal.core.research.database.LabRepository
 import com.wafflestudio.csereal.core.research.database.ResearchSearchEntity
 import com.wafflestudio.csereal.core.research.database.ResearchSearchRepository
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
 
 interface ResearchSearchService {
+    fun professorCreatedEventListener(professorCreatedEvent: ProfessorCreatedEvent)
+    fun professorDeletedEventListener(professorDeletedEvent: ProfessorDeletedEvent)
+    fun professorModifiedEventListener(professorModifiedEvent: ProfessorModifiedEvent)
     fun deleteResearchSearch(researchSearchEntity: ResearchSearchEntity)
 }
 
 @Service
 class ResearchSearchServiceImpl(
+    private val labRepository: LabRepository,
     private val researchSearchRepository: ResearchSearchRepository
 ) : ResearchSearchService {
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional
+    override fun professorCreatedEventListener(professorCreatedEvent: ProfessorCreatedEvent) {
+        val lab = professorCreatedEvent.labId?.let {
+            labRepository.findByIdOrNull(it)
+        } ?: return
+
+        lab.researchSearch?.update(lab) ?: let {
+            lab.researchSearch = ResearchSearchEntity.create(lab)
+        }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional
+    override fun professorDeletedEventListener(professorDeletedEvent: ProfessorDeletedEvent) {
+        val lab = professorDeletedEvent.labId?.let {
+            labRepository.findByIdOrNull(it)
+        } ?: return
+
+        lab.researchSearch?.update(lab)
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional
+    override fun professorModifiedEventListener(professorModifiedEvent: ProfessorModifiedEvent) {
+        val beforeLab = professorModifiedEvent.beforeLabId?.let {
+            labRepository.findByIdOrNull(it)
+        }
+
+        val afterLab = professorModifiedEvent.afterLabId?.let {
+            labRepository.findByIdOrNull(it)
+        }
+
+        beforeLab?.run {
+            researchSearch?.update(this)
+        }
+
+        afterLab?.run {
+            researchSearch?.update(this)
+        }
+    }
 
     @Transactional
     override fun deleteResearchSearch(

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,20 +3,6 @@ spring:
         active: local
     datasource:
         driver-class-name: com.mysql.cj.jdbc.Driver
-    security:
-        oauth2:
-            client:
-                registration:
-                    idsnucse:
-                        client-id: cse-waffle-dev
-                        client-secret: ${OIDC_CLIENT_SECRET}
-                        authorization-grant-type: authorization_code
-                        scope: openid, profile, email
-                        redirect-uri: http://localhost:8080/api/v1/login/oauth2/code/idsnucse
-                provider:
-                    idsnucse:
-                        issuer-uri: https://id.snucse.org/o
-                        jwk-set-uri: https://id.snucse.org/o/jwks
     servlet:
         multipart:
             enabled: true
@@ -64,6 +50,20 @@ spring:
         properties:
             hibernate:
                 dialect: com.wafflestudio.csereal.common.config.MySQLDialectCustom
+    security:
+        oauth2:
+            client:
+                registration:
+                    idsnucse:
+                        client-id: cse-waffle-dev
+                        client-secret: ${OIDC_CLIENT_SECRET}
+                        authorization-grant-type: authorization_code
+                        scope: openid, profile, email
+                        redirect-uri: http://localhost:8080/api/v1/login/oauth2/code/idsnucse
+                provider:
+                    idsnucse:
+                        issuer-uri: https://id.snucse.org/o
+                        jwk-set-uri: https://id.snucse.org/o/jwks
 
 logging.level:
     default: INFO

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,15 +8,15 @@ spring:
             client:
                 registration:
                     idsnucse:
-                        client-id: waffle-dev-local-testing
-                        client-secret: ${OIDC_CLIENT_SECRET_DEV}
+                        client-id: cse-waffle-dev
+                        client-secret: ${OIDC_CLIENT_SECRET}
                         authorization-grant-type: authorization_code
                         scope: openid, profile, email
                         redirect-uri: http://localhost:8080/api/v1/login/oauth2/code/idsnucse
                 provider:
                     idsnucse:
-                        issuer-uri: https://id-dev.bacchus.io/o
-                        jwk-set-uri: https://id-dev.bacchus.io/o/jwks
+                        issuer-uri: https://id.snucse.org/o
+                        jwk-set-uri: https://id.snucse.org/o/jwks
     servlet:
         multipart:
             enabled: true

--- a/src/test/kotlin/com/wafflestudio/csereal/core/reseach/service/ResearchSearchServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/reseach/service/ResearchSearchServiceTest.kt
@@ -1,6 +1,5 @@
 package com.wafflestudio.csereal.core.reseach.service
 
-import com.wafflestudio.csereal.core.member.database.ProfessorEntity
 import com.wafflestudio.csereal.core.member.database.ProfessorRepository
 import com.wafflestudio.csereal.core.member.database.ProfessorStatus
 import com.wafflestudio.csereal.core.member.dto.ProfessorDto
@@ -30,202 +29,254 @@ class ResearchSearchServiceTest(
     private val researchRepository: ResearchRepository,
     private val researchSearchRepository: ResearchSearchRepository,
     private val researchService: ResearchService
-) : BehaviorSpec({
-    extensions(SpringTestExtension(SpringTestLifecycleMode.Root))
+) : BehaviorSpec() {
+    init {
+        extensions(SpringTestExtension(SpringTestLifecycleMode.Root))
 
-    beforeSpec {
-    }
+        beforeSpec {
+        }
 
-    afterSpec {
-        professorRepository.deleteAll()
-        labRepository.deleteAll()
-        researchSearchRepository.deleteAll()
-    }
+        afterSpec {
+            professorRepository.deleteAll()
+            labRepository.deleteAll()
+            researchSearchRepository.deleteAll()
+        }
 
-    // Event Listener Test
-    Given("기존 lab이 존재할 때") {
-        // Save professors
-        val professor1 = professorRepository.save(
-            ProfessorEntity(
-                name = "professor1",
-                status = ProfessorStatus.ACTIVE,
-                academicRank = "professor",
-                email = null,
-                fax = null,
-                office = null,
-                phone = null,
-                website = null,
-                startDate = null,
-                endDate = null
+        // Event Listener Test
+        Given("기존 lab이 존재할 때") {
+            // Save professors
+//            val professor1 = professorRepository.save(
+//                ProfessorEntity(
+//                    name = "professor1",
+//                    status = ProfessorStatus.ACTIVE,
+//                    academicRank = "professor",
+//                    email = null,
+//                    fax = null,
+//                    office = null,
+//                    phone = null,
+//                    website = null,
+//                    startDate = null,
+//                    endDate = null
+//                )
+//            )
+            val professor1Dto = professorService.createProfessor(
+                createProfessorRequest = ProfessorDto(
+                    name = "professor1",
+                    email = null,
+                    status = ProfessorStatus.ACTIVE,
+                    academicRank = "professor",
+                    labId = null,
+                    labName = null,
+                    startDate = null,
+                    endDate = null,
+                    office = null,
+                    phone = null,
+                    fax = null,
+                    website = null,
+                    educations = emptyList(),
+                    researchAreas = emptyList(),
+                    careers = emptyList()
+                ),
+                mainImage = null
             )
-        )
-        val professor2 = professorRepository.save(
-            ProfessorEntity(
-                name = "professor2",
-                status = ProfessorStatus.ACTIVE,
-                academicRank = "professor",
-                email = null,
-                fax = null,
-                office = null,
-                phone = null,
-                website = null,
-                startDate = null,
-                endDate = null
+//            val professor2 = professorRepository.save(
+//                ProfessorEntity(
+//                    name = "professor2",
+//                    status = ProfessorStatus.ACTIVE,
+//                    academicRank = "professor",
+//                    email = null,
+//                    fax = null,
+//                    office = null,
+//                    phone = null,
+//                    website = null,
+//                    startDate = null,
+//                    endDate = null
+//                )
+//            )
+            val professor2Dto = professorService.createProfessor(
+                createProfessorRequest = ProfessorDto(
+                    name = "professor2",
+                    email = null,
+                    status = ProfessorStatus.ACTIVE,
+                    academicRank = "professor",
+                    labId = null,
+                    labName = null,
+                    startDate = null,
+                    endDate = null,
+                    office = null,
+                    phone = null,
+                    fax = null,
+                    website = null,
+                    educations = emptyList(),
+                    researchAreas = emptyList(),
+                    careers = emptyList()
+                ),
+                mainImage = null
             )
-        )
 
-        // Save research
-        val research = researchRepository.save(
-            ResearchEntity(
-                name = "research",
-                postType = ResearchPostType.GROUPS,
-                description = null
+            val professor1 = professorRepository.findByIdOrNull(professor1Dto.id)!!
+            val professor2 = professorRepository.findByIdOrNull(professor2Dto.id)!!
+
+            // Save research
+            val research = researchRepository.save(
+                ResearchEntity(
+                    name = "research",
+                    postType = ResearchPostType.GROUPS,
+                    description = null
+                )
             )
-        )
 
-        // Save lab
-        val labDto = LabDto(
-            id = -1,
-            name = "name",
-            professors = listOf(
-                LabProfessorResponse(professor1.id, professor1.name),
-                LabProfessorResponse(professor2.id, professor2.name)
-            ),
-            acronym = "acronym",
-            description = "description",
-            group = "research",
-            pdf = null,
-            location = "location",
-            tel = "tel",
-            websiteURL = "websiteURL",
-            youtube = "youtube"
-        )
+            // Save lab
+            val labDto = LabDto(
+                id = -1,
+                name = "name",
+                professors = listOf(
+                    LabProfessorResponse(professor1.id, professor1.name),
+                    LabProfessorResponse(professor2.id, professor2.name)
+                ),
+                acronym = "acronym",
+                description = "description",
+                group = "research",
+                pdf = null,
+                location = "location",
+                tel = "tel",
+                websiteURL = "websiteURL",
+                youtube = "youtube"
+            )
 
-        val emptyLabDto = LabDto(
-            id = -1,
-            name = "nameE",
-            professors = listOf(),
-            acronym = "acronymE",
-            description = "descriptionE",
-            group = "research",
-            pdf = null,
-            location = "locationE",
-            tel = "telE",
-            websiteURL = "websiteURLE",
-            youtube = "youtubeE"
-        )
+            val emptyLabDto = LabDto(
+                id = -1,
+                name = "nameE",
+                professors = listOf(),
+                acronym = "acronymE",
+                description = "descriptionE",
+                group = "research",
+                pdf = null,
+                location = "locationE",
+                tel = "telE",
+                websiteURL = "websiteURLE",
+                youtube = "youtubeE"
+            )
 
-        val createdLabDto = researchService.createLab(labDto, null)
-        val createdEmptyLabDto = researchService.createLab(emptyLabDto, null)
+            val createdLabDto = researchService.createLab(labDto, null)
+            val createdEmptyLabDto = researchService.createLab(emptyLabDto, null)
 
-        When("professor가 제거된다면") {
-            professorService.deleteProfessor(professor1.id)
+            When("professor가 제거된다면") {
+                professorService.deleteProfessor(professor1.id)
 
-            Then("검색 엔티티의 내용이 변경된다") {
-                val lab = labRepository.findByIdOrNull(createdLabDto.id)!!
-                val search = lab.researchSearch
+                Then("검색 엔티티의 내용이 변경된다") {
+                    val lab = labRepository.findByIdOrNull(createdLabDto.id)!!
+                    val search = lab.researchSearch
 
-                search shouldNotBe null
-                search!!.content shouldBe
-                    """
+                    search shouldNotBe null
+                    search!!.content shouldBe
+                        """
                         name
                         professor2
                         location
                         tel
                         acronym
+                        youtube
+                        research
                         description
                         websiteURL
                         
-                    """.trimIndent()
+                        """.trimIndent()
+                }
             }
-        }
 
-        When("professor가 추가된다면") {
-            val process3CreatedDto = professorService.createProfessor(
-                createProfessorRequest = ProfessorDto(
-                    name = "newProfessor",
-                    email = "email",
-                    status = ProfessorStatus.ACTIVE,
-                    academicRank = "academicRank",
-                    labId = createdLabDto.id,
-                    labName = null,
-                    startDate = LocalDate.now(),
-                    endDate = LocalDate.now(),
-                    office = "office",
-                    phone = "phone",
-                    fax = "fax",
-                    website = "website",
-                    educations = listOf("education1", "education2"),
-                    researchAreas = listOf("researchArea1", "researchArea2"),
-                    careers = listOf("career1", "career2")
-                ),
-                mainImage = null
-            )
+            When("professor가 추가된다면") {
+                val process3CreatedDto = professorService.createProfessor(
+                    createProfessorRequest = ProfessorDto(
+                        name = "newProfessor",
+                        email = "email",
+                        status = ProfessorStatus.ACTIVE,
+                        academicRank = "academicRank",
+                        labId = createdLabDto.id,
+                        labName = null,
+                        startDate = LocalDate.now(),
+                        endDate = LocalDate.now(),
+                        office = "office",
+                        phone = "phone",
+                        fax = "fax",
+                        website = "website",
+                        educations = listOf("education1", "education2"),
+                        researchAreas = listOf("researchArea1", "researchArea2"),
+                        careers = listOf("career1", "career2")
+                    ),
+                    mainImage = null
+                )
 
-            Then("검색 엔티티의 내용이 변경된다") {
-                val lab = labRepository.findByIdOrNull(createdLabDto.id)!!
-                val search = lab.researchSearch
+                Then("검색 엔티티의 내용이 변경된다") {
+                    val lab = labRepository.findByIdOrNull(createdLabDto.id)!!
+                    val search = lab.researchSearch
 
-                search shouldNotBe null
-                search!!.content shouldBe
-                    """
+                    search shouldNotBe null
+                    search!!.content shouldBe
+                        """
                         name
-                        professor1
                         professor2
                         newProfessor
                         location
                         tel
                         acronym
+                        youtube
+                        research
                         description
                         websiteURL
                         
-                    """.trimIndent()
+                        """.trimIndent()
+                }
             }
-        }
 
-        When("professor가 수정된다면") {
-            professorService.updateProfessor(
-                professor2.id,
-                ProfessorDto.of(professor2, null)
-                    .copy(name = "updateProfessor", labId = createdEmptyLabDto.id),
-                mainImage = null
-            )
+            When("professor가 수정된다면") {
+                professorService.updateProfessor(
+                    professor2.id,
+                    ProfessorDto.of(professor2, null)
+                        .copy(name = "updateProfessor", labId = createdEmptyLabDto.id),
+                    mainImage = null
+                )
 
-            Then("예전 검색 데이터에서 빠져야 한다.") {
-                val lab = labRepository.findByIdOrNull(createdLabDto.id)!!
-                val search = lab.researchSearch
+                Then("예전 검색 데이터에서 빠져야 한다.") {
+                    val lab = labRepository.findByIdOrNull(createdLabDto.id)!!
+                    val search = lab.researchSearch
 
-                search shouldNotBe null
-                search!!.content shouldBe
-                    """
+                    search shouldNotBe null
+                    search!!.content shouldBe
+                        """
                         name
-                        professor1
+                        newProfessor
                         location
                         tel
                         acronym
+                        youtube
+                        research
                         description
                         websiteURL
                         
-                    """.trimIndent()
-            }
+                        """.trimIndent()
+                }
 
-            Then("새로운 검색 데이터에 포함되어야 한다.") {
-                val lab = labRepository.findByIdOrNull(createdEmptyLabDto.id)!!
-                val search = lab.researchSearch
+                Then("새로운 검색 데이터에 포함되어야 한다.") {
+                    val lab = labRepository.findByIdOrNull(createdEmptyLabDto.id)!!
+                    val search = lab.researchSearch
 
-                search shouldNotBe null
-                search!!.content shouldBe
-                    """
+                    search shouldNotBe null
+                    search!!.content shouldBe
+                        """
                         nameE
                         updateProfessor
                         locationE
                         telE
                         acronymE
+                        youtubeE
+                        research
                         descriptionE
                         websiteURLE
                         
-                    """.trimIndent()
+                        """.trimIndent()
+                }
             }
         }
     }
-})
+}

--- a/src/test/kotlin/com/wafflestudio/csereal/core/reseach/service/ResearchSearchServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/reseach/service/ResearchSearchServiceTest.kt
@@ -1,0 +1,231 @@
+package com.wafflestudio.csereal.core.reseach.service
+
+import com.wafflestudio.csereal.core.member.database.ProfessorEntity
+import com.wafflestudio.csereal.core.member.database.ProfessorRepository
+import com.wafflestudio.csereal.core.member.database.ProfessorStatus
+import com.wafflestudio.csereal.core.member.dto.ProfessorDto
+import com.wafflestudio.csereal.core.member.service.ProfessorService
+import com.wafflestudio.csereal.core.research.database.*
+import com.wafflestudio.csereal.core.research.dto.LabDto
+import com.wafflestudio.csereal.core.research.dto.LabProfessorResponse
+import com.wafflestudio.csereal.core.research.service.ResearchSearchService
+import com.wafflestudio.csereal.core.research.service.ResearchService
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.extensions.spring.SpringTestExtension
+import io.kotest.extensions.spring.SpringTestLifecycleMode
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+
+@SpringBootTest
+@Transactional
+class ResearchSearchServiceTest(
+    private val researchSearchService: ResearchSearchService,
+    private val professorRepository: ProfessorRepository,
+    private val professorService: ProfessorService,
+    private val labRepository: LabRepository,
+    private val researchRepository: ResearchRepository,
+    private val researchSearchRepository: ResearchSearchRepository,
+    private val researchService: ResearchService
+) : BehaviorSpec({
+    extensions(SpringTestExtension(SpringTestLifecycleMode.Root))
+
+    beforeSpec {
+    }
+
+    afterSpec {
+        professorRepository.deleteAll()
+        labRepository.deleteAll()
+        researchSearchRepository.deleteAll()
+    }
+
+    // Event Listener Test
+    Given("기존 lab이 존재할 때") {
+        // Save professors
+        val professor1 = professorRepository.save(
+            ProfessorEntity(
+                name = "professor1",
+                status = ProfessorStatus.ACTIVE,
+                academicRank = "professor",
+                email = null,
+                fax = null,
+                office = null,
+                phone = null,
+                website = null,
+                startDate = null,
+                endDate = null
+            )
+        )
+        val professor2 = professorRepository.save(
+            ProfessorEntity(
+                name = "professor2",
+                status = ProfessorStatus.ACTIVE,
+                academicRank = "professor",
+                email = null,
+                fax = null,
+                office = null,
+                phone = null,
+                website = null,
+                startDate = null,
+                endDate = null
+            )
+        )
+
+        // Save research
+        val research = researchRepository.save(
+            ResearchEntity(
+                name = "research",
+                postType = ResearchPostType.GROUPS,
+                description = null
+            )
+        )
+
+        // Save lab
+        val labDto = LabDto(
+            id = -1,
+            name = "name",
+            professors = listOf(
+                LabProfessorResponse(professor1.id, professor1.name),
+                LabProfessorResponse(professor2.id, professor2.name)
+            ),
+            acronym = "acronym",
+            description = "description",
+            group = "research",
+            pdf = null,
+            location = "location",
+            tel = "tel",
+            websiteURL = "websiteURL",
+            youtube = "youtube"
+        )
+
+        val emptyLabDto = LabDto(
+            id = -1,
+            name = "nameE",
+            professors = listOf(),
+            acronym = "acronymE",
+            description = "descriptionE",
+            group = "research",
+            pdf = null,
+            location = "locationE",
+            tel = "telE",
+            websiteURL = "websiteURLE",
+            youtube = "youtubeE"
+        )
+
+        val createdLabDto = researchService.createLab(labDto, null)
+        val createdEmptyLabDto = researchService.createLab(emptyLabDto, null)
+
+        When("professor가 제거된다면") {
+            professorService.deleteProfessor(professor1.id)
+
+            Then("검색 엔티티의 내용이 변경된다") {
+                val lab = labRepository.findByIdOrNull(createdLabDto.id)!!
+                val search = lab.researchSearch
+
+                search shouldNotBe null
+                search!!.content shouldBe
+                    """
+                        name
+                        professor2
+                        location
+                        tel
+                        acronym
+                        description
+                        websiteURL
+                        
+                    """.trimIndent()
+            }
+        }
+
+        When("professor가 추가된다면") {
+            val process3CreatedDto = professorService.createProfessor(
+                createProfessorRequest = ProfessorDto(
+                    name = "newProfessor",
+                    email = "email",
+                    status = ProfessorStatus.ACTIVE,
+                    academicRank = "academicRank",
+                    labId = createdLabDto.id,
+                    labName = null,
+                    startDate = LocalDate.now(),
+                    endDate = LocalDate.now(),
+                    office = "office",
+                    phone = "phone",
+                    fax = "fax",
+                    website = "website",
+                    educations = listOf("education1", "education2"),
+                    researchAreas = listOf("researchArea1", "researchArea2"),
+                    careers = listOf("career1", "career2")
+                ),
+                mainImage = null
+            )
+
+            Then("검색 엔티티의 내용이 변경된다") {
+                val lab = labRepository.findByIdOrNull(createdLabDto.id)!!
+                val search = lab.researchSearch
+
+                search shouldNotBe null
+                search!!.content shouldBe
+                    """
+                        name
+                        professor1
+                        professor2
+                        newProfessor
+                        location
+                        tel
+                        acronym
+                        description
+                        websiteURL
+                        
+                    """.trimIndent()
+            }
+        }
+
+        When("professor가 수정된다면") {
+            professorService.updateProfessor(
+                professor2.id,
+                ProfessorDto.of(professor2, null)
+                    .copy(name = "updateProfessor", labId = createdEmptyLabDto.id),
+                mainImage = null
+            )
+
+            Then("예전 검색 데이터에서 빠져야 한다.") {
+                val lab = labRepository.findByIdOrNull(createdLabDto.id)!!
+                val search = lab.researchSearch
+
+                search shouldNotBe null
+                search!!.content shouldBe
+                    """
+                        name
+                        professor1
+                        location
+                        tel
+                        acronym
+                        description
+                        websiteURL
+                        
+                    """.trimIndent()
+            }
+
+            Then("새로운 검색 데이터에 포함되어야 한다.") {
+                val lab = labRepository.findByIdOrNull(createdEmptyLabDto.id)!!
+                val search = lab.researchSearch
+
+                search shouldNotBe null
+                search!!.content shouldBe
+                    """
+                        nameE
+                        updateProfessor
+                        locationE
+                        telE
+                        acronymE
+                        descriptionE
+                        websiteURLE
+                        
+                    """.trimIndent()
+            }
+        }
+    }
+})


### PR DESCRIPTION
## 제목
feat: Research 검색

### 한줄 요약
Research 검색 기능을 추가하였습니다

### Commit 요약
(HEAD)
a5863e0  Test: Fix test.
847bc05 Feat: Add search api for research.
5e9b571 Fix: fixed event listener logic
897e3e5 Test: ResearchSearchService listen professor event
634f0e9 Feat: Update research search when listen professor event.
bc13765 Feat: Publish event on professor modification.
c909984 Feat: create professor event.
970fe85 feat: enable async.
(BEGIN)

### 상세 설명
- Event 를 publish하고 listen하는 방식으로 professor가 수정될 시 lab의 search를 위해 생성한 텍스트 데이터를 업데이트 하도록 구성하였습니다.

### 참고사항
- mysql에 researchsearch 테이블에 full text index가 생성되어있지 않은 경우 생성해주어야 정상 작동합니다.
```mysql
ALTER TABLE research_search ADD FULLTEXT INDEX research_search_idx (content) WITH PARSER ngram;
```

### TODO
- lab update시 해당 lab의 research는 업데이트 되지 않도록 되어있습니다. 이 기능이 필요하다면 논의를 통해 도입해야 할 듯 싶습니다.

