### PR TITLE
feat: staff 마이그레이션 검색인덱스도 추가

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/service/StaffService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/service/StaffService.kt
@@ -113,6 +113,8 @@ class StaffServiceImpl(
                 TaskEntity.create(task, staff)
             }
 
+            staff.memberSearch = MemberSearchEntity.create(staff)
+
             staffRepository.save(staff)
 
             list.add(StaffDto.of(staff, null))


### PR DESCRIPTION
## 제목
feat: staff 마이그레이션 검색인덱스도 추가

### 한줄 요약
staff 마이그레이션할 때 검색 인덱스도 추가하도록 했습니다


### 상세 설명

[bfaee72]: 마이그레이션 준비 중입니다. staff 추가할 때 member_search 테이블에 행정직원 내용이 추가되도록 하였습니다.

### TODO
다른 테이블에도 search 반영하려고 하고 있고, 필드에 language 추가해서 같은 테이블에 한국어판, 영문판에 따라 ko, en 넣으려고 합니다
