### PR TITLE
Feat: 학사 및 교과 검색 기능 추가

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/common/utils/Utils.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/utils/Utils.kt
@@ -26,3 +26,11 @@ fun substringAroundKeyword(keyword: String, content: String, amount: Int): Pair<
         (index - frontIndex) to content.substring(frontIndex, backIndex)
     }
 }
+
+fun exchangePageNum(pageSize: Int, pageNum: Int, total: Long): Int {
+    return if ((pageNum - 1) * pageSize < total) {
+        pageNum
+    } else {
+        Math.ceil(total.toDouble() / pageSize).toInt()
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/common/utils/Utils.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/utils/Utils.kt
@@ -28,6 +28,11 @@ fun substringAroundKeyword(keyword: String, content: String, amount: Int): Pair<
 }
 
 fun exchangePageNum(pageSize: Int, pageNum: Int, total: Long): Int {
+    // Validate
+    if (!(pageSize > 0 && pageNum > 0 && total >= 0)) {
+        throw RuntimeException()
+    }
+
     return if ((pageNum - 1) * pageSize < total) {
         pageNum
     } else {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/api/AcademicsController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/api/AcademicsController.kt
@@ -4,6 +4,7 @@ import com.wafflestudio.csereal.common.aop.AuthenticatedStaff
 import com.wafflestudio.csereal.core.academics.dto.*
 import com.wafflestudio.csereal.core.academics.service.AcademicsService
 import com.wafflestudio.csereal.core.academics.dto.ScholarshipDto
+import com.wafflestudio.csereal.core.academics.service.AcademicsSearchService
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -12,7 +13,8 @@ import org.springframework.web.multipart.MultipartFile
 @RequestMapping("/api/v1/academics")
 @RestController
 class AcademicsController(
-    private val academicsService: AcademicsService
+    private val academicsService: AcademicsService,
+    private val academicsSearchService: AcademicsSearchService
 ) {
     @AuthenticatedStaff
     @PostMapping("/{studentType}/{postType}")
@@ -95,4 +97,24 @@ class AcademicsController(
     fun getScholarship(@PathVariable scholarshipId: Long): ResponseEntity<ScholarshipDto> {
         return ResponseEntity.ok(academicsService.readScholarship(scholarshipId))
     }
+
+    @GetMapping("/search/top")
+    fun searchTop(
+        @RequestParam(required = true) keyword: String,
+        @RequestParam(required = true) number: Int
+    ) = academicsSearchService.searchTopAcademics(
+        keyword = keyword,
+        number = number
+    )
+
+    @GetMapping("/search")
+    fun searchAcademics(
+        @RequestParam(required = true) keyword: String,
+        @RequestParam(required = true) pageSize: Int,
+        @RequestParam(required = true) pageNum: Int
+    ) = academicsSearchService.searchAcademics(
+        keyword = keyword,
+        pageSize = pageSize,
+        pageNum = pageNum
+    )
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsEntity.kt
@@ -14,7 +14,7 @@ class AcademicsEntity(
     @Enumerated(EnumType.STRING)
     var postType: AcademicsPostType,
 
-    var name: String?,
+    var name: String,
     var description: String,
     var year: Int?,
     var time: String?,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsEntity.kt
@@ -20,7 +20,10 @@ class AcademicsEntity(
     var time: String?,
 
     @OneToMany(mappedBy = "academics", cascade = [CascadeType.ALL], orphanRemoval = true)
-    var attachments: MutableList<AttachmentEntity> = mutableListOf()
+    var attachments: MutableList<AttachmentEntity> = mutableListOf(),
+
+    @OneToOne(mappedBy = "academics", cascade = [CascadeType.ALL], orphanRemoval = true)
+    var academicsSearch: AcademicsSearchEntity? = null
 
 ) : BaseTimeEntity(), AttachmentContentEntityType {
     override fun bringAttachments() = attachments

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsSearchEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsSearchEntity.kt
@@ -4,7 +4,7 @@ import com.wafflestudio.csereal.common.config.BaseTimeEntity
 import com.wafflestudio.csereal.common.utils.cleanTextFromHtml
 import jakarta.persistence.*
 
-@Entity
+@Entity(name = "academics_search")
 class AcademicsSearchEntity(
     @Column(columnDefinition = "TEXT", nullable = false)
     var content: String,
@@ -25,19 +25,22 @@ class AcademicsSearchEntity(
     companion object {
         fun create(academics: AcademicsEntity): AcademicsSearchEntity {
             return AcademicsSearchEntity(
+                academics = academics,
                 content = createContent(academics)
             )
         }
 
         fun create(course: CourseEntity): AcademicsSearchEntity {
             return AcademicsSearchEntity(
+                course = course,
                 content = createContent(course)
             )
         }
 
         fun create(scholarship: ScholarshipEntity): AcademicsSearchEntity {
             return AcademicsSearchEntity(
-                content = scholarship.description
+                scholarship = scholarship,
+                content = createContent(scholarship)
             )
         }
 
@@ -65,9 +68,8 @@ class AcademicsSearchEntity(
                 sb.appendLine(it.name)
                 sb.appendLine(it.credit)
                 sb.appendLine(it.grade)
-                it.description?.let {
-                        description ->
-                    sb.appendLine(description)
+                it.description?.let { desc ->
+                    sb.appendLine(cleanTextFromHtml(desc))
                 }
 
                 sb.toString()
@@ -78,7 +80,9 @@ class AcademicsSearchEntity(
                 val sb = StringBuilder()
                 sb.appendLine(it.studentType.value)
                 sb.appendLine(it.name)
-                sb.appendLine(it.description)
+                sb.appendLine(
+                    cleanTextFromHtml(it.description)
+                )
                 sb.toString()
             }
     }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsSearchEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsSearchEntity.kt
@@ -1,0 +1,124 @@
+package com.wafflestudio.csereal.core.academics.database
+
+import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.utils.cleanTextFromHtml
+import jakarta.persistence.*
+
+@Entity
+class AcademicsSearchEntity(
+    @Column(columnDefinition = "TEXT", nullable = false)
+    var content: String,
+
+    @OneToOne
+    @JoinColumn(name = "academics_id")
+    val academics: AcademicsEntity? = null,
+
+    @OneToOne
+    @JoinColumn(name = "course_id")
+    val course: CourseEntity? = null,
+
+    @OneToOne
+    @JoinColumn(name = "scholarship_id")
+    val scholarship: ScholarshipEntity? = null
+
+) : BaseTimeEntity() {
+    companion object {
+        fun create(academics: AcademicsEntity): AcademicsSearchEntity {
+            return AcademicsSearchEntity(
+                content = createContent(academics)
+            )
+        }
+
+        fun create(course: CourseEntity): AcademicsSearchEntity {
+            return AcademicsSearchEntity(
+                content = createContent(course)
+            )
+        }
+
+        fun create(scholarship: ScholarshipEntity): AcademicsSearchEntity {
+            return AcademicsSearchEntity(
+                content = scholarship.description
+            )
+        }
+
+        fun createContent(academics: AcademicsEntity): String {
+            val sb = StringBuilder()
+            academics.name?.let { sb.appendLine(it) }
+            academics.time?.let { sb.appendLine(it) }
+            academics.year?.let { sb.appendLine(it) }
+            sb.appendLine(academics.studentType.value)
+            sb.appendLine(
+                cleanTextFromHtml(
+                    academics.description
+                )
+            )
+
+            return sb.toString()
+        }
+
+        fun createContent(course: CourseEntity) =
+            course.let {
+                val sb = StringBuilder()
+                sb.appendLine(it.studentType.value)
+                sb.appendLine(it.classification)
+                sb.appendLine(it.code)
+                sb.appendLine(it.name)
+                sb.appendLine(it.credit)
+                sb.appendLine(it.grade)
+                it.description?.let {
+                        description ->
+                    sb.appendLine(description)
+                }
+
+                sb.toString()
+            }
+
+        fun createContent(scholarship: ScholarshipEntity) =
+            scholarship.let {
+                val sb = StringBuilder()
+                sb.appendLine(it.studentType.value)
+                sb.appendLine(it.name)
+                sb.appendLine(it.description)
+                sb.toString()
+            }
+    }
+
+    fun update(academics: AcademicsEntity) {
+        this.content = createContent(academics)
+    }
+
+    fun update(course: CourseEntity) {
+        this.content = createContent(course)
+    }
+
+    fun update(scholarship: ScholarshipEntity) {
+        this.content = createContent(scholarship)
+    }
+
+    @PrePersist
+    @PreUpdate
+    fun checkType() {
+        if (!(
+            (academics != null && course == null && scholarship == null) ||
+                (academics == null && course != null && scholarship == null) ||
+                (academics == null && course == null && scholarship != null)
+            )
+        ) {
+            throw IllegalStateException("AcademicsSearchEntity must have only one type of entity")
+        }
+    }
+
+    fun ofType() =
+        when {
+            academics != null && course == null && scholarship == null -> AcademicsSearchType.ACADEMICS
+            academics == null && course != null && scholarship == null -> AcademicsSearchType.COURSE
+            academics == null && course == null && scholarship != null -> AcademicsSearchType.SCHOLARSHIP
+            else -> throw IllegalStateException("AcademicsSearchEntity must have only one type of entity")
+        }
+}
+
+enum class AcademicsSearchType {
+    ACADEMICS,
+    COURSE,
+    SCHOLARSHIP
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsSearchEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsSearchEntity.kt
@@ -43,7 +43,7 @@ class AcademicsSearchEntity(
 
         fun createContent(academics: AcademicsEntity): String {
             val sb = StringBuilder()
-            academics.name?.let { sb.appendLine(it) }
+            academics.name.let { sb.appendLine(it) }
             academics.time?.let { sb.appendLine(it) }
             academics.year?.let { sb.appendLine(it) }
             sb.appendLine(academics.studentType.value)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsSearchRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsSearchRepository.kt
@@ -1,0 +1,87 @@
+package com.wafflestudio.csereal.core.academics.database
+
+import com.querydsl.jpa.impl.JPAQuery
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.wafflestudio.csereal.common.repository.CommonRepository
+import com.wafflestudio.csereal.core.academics.database.QAcademicsEntity.academicsEntity
+import com.wafflestudio.csereal.core.academics.database.QAcademicsSearchEntity.academicsSearchEntity
+import com.wafflestudio.csereal.core.academics.database.QCourseEntity.courseEntity
+import com.wafflestudio.csereal.core.academics.database.QScholarshipEntity.scholarshipEntity
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import com.wafflestudio.csereal.common.utils.exchangePageNum
+
+interface AcademicsSearchRepository : JpaRepository<AcademicsSearchEntity, Long>, AcademicsSearchCustomRepository
+
+interface AcademicsSearchCustomRepository {
+    fun searchAcademics(keyword: String, pageSize: Int, pageNum: Int): Pair<List<AcademicsSearchEntity>, Long>
+    fun searchTopAcademics(keyword: String, number: Int): List<AcademicsSearchEntity>
+}
+
+@Repository
+class AcademicsSearchCustomRepositoryImpl(
+    private val queryFactory: JPAQueryFactory,
+    private val commonRepository: CommonRepository
+) : AcademicsSearchCustomRepository {
+    override fun searchTopAcademics(keyword: String, number: Int): List<AcademicsSearchEntity> {
+        return searchQuery(keyword)
+            .limit(number.toLong())
+            .fetch()
+    }
+
+    override fun searchAcademics(
+        keyword: String,
+        pageSize: Int,
+        pageNum: Int
+    ): Pair<List<AcademicsSearchEntity>, Long> {
+        val query = searchQuery(keyword)
+        val total = getSearchCount(keyword)
+
+        val validPageNum = exchangePageNum(pageSize, pageNum, total)
+        val validOffset = (if (validPageNum >= 1) validPageNum - 1 else 0) * pageSize.toLong()
+        val queryResult = query.offset(validOffset)
+            .limit(pageSize.toLong())
+            .fetch()
+
+        return queryResult to total
+    }
+
+    fun searchQuery(keyword: String): JPAQuery<AcademicsSearchEntity> {
+        val searchDoubleTemplate = commonRepository.searchFullSingleTextTemplate(
+            keyword,
+            academicsSearchEntity.content
+        )
+
+        return queryFactory.selectFrom(
+            academicsSearchEntity
+        ).leftJoin(
+            academicsSearchEntity.academics,
+            academicsEntity
+        ).fetchJoin()
+            .leftJoin(
+                academicsSearchEntity.course,
+                courseEntity
+            ).fetchJoin()
+            .leftJoin(
+                academicsSearchEntity.scholarship,
+                scholarshipEntity
+            ).fetchJoin()
+            .where(
+                searchDoubleTemplate.gt(0.0)
+            )
+    }
+
+    fun getSearchCount(keyword: String): Long {
+        val searchDoubleTemplate = commonRepository.searchFullSingleTextTemplate(
+            keyword,
+            academicsSearchEntity.content
+        )
+
+        return queryFactory.select(
+            academicsSearchEntity.countDistinct()
+        ).from(academicsSearchEntity)
+            .where(
+                searchDoubleTemplate.gt(0.0)
+            ).fetchOne()!!
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsStudentType.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsStudentType.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.csereal.core.academics.database
 
-enum class AcademicsStudentType {
-    UNDERGRADUATE, GRADUATE
+enum class AcademicsStudentType(val value: String) {
+    UNDERGRADUATE("학부"),
+    GRADUATE("대학원");
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/CourseEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/CourseEntity.kt
@@ -7,6 +7,7 @@ import com.wafflestudio.csereal.core.resource.attachment.database.AttachmentEnti
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Entity
 import jakarta.persistence.OneToMany
+import jakarta.persistence.OneToOne
 
 @Entity(name = "course")
 class CourseEntity(
@@ -27,7 +28,10 @@ class CourseEntity(
     var description: String?,
 
     @OneToMany(mappedBy = "course", cascade = [CascadeType.ALL], orphanRemoval = true)
-    var attachments: MutableList<AttachmentEntity> = mutableListOf()
+    var attachments: MutableList<AttachmentEntity> = mutableListOf(),
+
+    @OneToOne(mappedBy = "course", cascade = [CascadeType.ALL], orphanRemoval = true)
+    var academicsSearch: AcademicsSearchEntity? = null
 
 ) : BaseTimeEntity(), AttachmentContentEntityType {
     override fun bringAttachments() = attachments

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/ScholarshipEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/ScholarshipEntity.kt
@@ -12,7 +12,10 @@ class ScholarshipEntity(
     val name: String,
 
     @Column(columnDefinition = "text")
-    val description: String
+    val description: String,
+
+    @OneToOne(mappedBy = "scholarship", cascade = [CascadeType.ALL], orphanRemoval = true)
+    var academicsSearch: AcademicsSearchEntity? = null
 
 ) : BaseTimeEntity() {
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/dto/AcademicsDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/dto/AcademicsDto.kt
@@ -5,14 +5,14 @@ import com.wafflestudio.csereal.core.resource.attachment.dto.AttachmentResponse
 import java.time.LocalDateTime
 
 data class AcademicsDto(
-    val id: Long,
+    val id: Long = -1, // TODO: Seperate to multiple DTOs or set this as nullable
     val name: String,
     val description: String,
-    val year: Int?,
-    val time: String?,
-    val createdAt: LocalDateTime?,
-    val modifiedAt: LocalDateTime?,
-    val attachments: List<AttachmentResponse>?
+    val year: Int? = null,
+    val time: String? = null,
+    val createdAt: LocalDateTime? = null,
+    val modifiedAt: LocalDateTime? = null,
+    val attachments: List<AttachmentResponse>? = null
 ) {
     companion object {
         fun of(entity: AcademicsEntity, attachmentResponses: List<AttachmentResponse>): AcademicsDto = entity.run {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/dto/AcademicsDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/dto/AcademicsDto.kt
@@ -6,7 +6,7 @@ import java.time.LocalDateTime
 
 data class AcademicsDto(
     val id: Long,
-    val name: String?,
+    val name: String,
     val description: String,
     val year: Int?,
     val time: String?,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/dto/AcademicsSearchPageResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/dto/AcademicsSearchPageResponse.kt
@@ -1,0 +1,18 @@
+package com.wafflestudio.csereal.core.academics.dto
+
+import com.wafflestudio.csereal.core.academics.database.AcademicsSearchEntity
+
+data class AcademicsSearchPageResponse(
+    val academics: List<AcademicsSearchResponseElement>,
+    val total: Long
+) {
+    companion object {
+        fun of(
+            academics: List<AcademicsSearchEntity>,
+            total: Long
+        ) = AcademicsSearchPageResponse(
+            academics = academics.map(AcademicsSearchResponseElement::of),
+            total = total
+        )
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/dto/AcademicsSearchResponseElement.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/dto/AcademicsSearchResponseElement.kt
@@ -1,0 +1,43 @@
+package com.wafflestudio.csereal.core.academics.dto
+
+import com.wafflestudio.csereal.common.CserealException
+import com.wafflestudio.csereal.core.academics.database.AcademicsSearchEntity
+import com.wafflestudio.csereal.core.academics.database.AcademicsSearchType
+
+data class AcademicsSearchResponseElement(
+    val id: Long,
+    val name: String,
+    val academicsType: AcademicsSearchType
+) {
+    companion object {
+        fun of(academicsSearch: AcademicsSearchEntity): AcademicsSearchResponseElement {
+            return when {
+                academicsSearch.academics != null &&
+                    academicsSearch.course == null &&
+                    academicsSearch.scholarship == null ->
+                    AcademicsSearchResponseElement(
+                        id = academicsSearch.academics!!.id,
+                        name = academicsSearch.academics!!.name,
+                        academicsType = AcademicsSearchType.ACADEMICS
+                    )
+                academicsSearch.academics == null &&
+                    academicsSearch.course != null &&
+                    academicsSearch.scholarship == null ->
+                    AcademicsSearchResponseElement(
+                        id = academicsSearch.course!!.id,
+                        name = academicsSearch.course!!.name,
+                        academicsType = AcademicsSearchType.COURSE
+                    )
+                academicsSearch.academics == null &&
+                    academicsSearch.course == null &&
+                    academicsSearch.scholarship != null ->
+                    AcademicsSearchResponseElement(
+                        id = academicsSearch.scholarship!!.id,
+                        name = academicsSearch.scholarship!!.name,
+                        academicsType = AcademicsSearchType.SCHOLARSHIP
+                    )
+                else -> throw CserealException.Csereal401("AcademicsSearchEntity의 연결이 올바르지 않습니다.")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/dto/AcademicsSearchTopResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/dto/AcademicsSearchTopResponse.kt
@@ -1,0 +1,15 @@
+package com.wafflestudio.csereal.core.academics.dto
+
+import com.wafflestudio.csereal.core.academics.database.AcademicsSearchEntity
+
+data class AcademicsSearchTopResponse(
+    val topAcademics: List<AcademicsSearchResponseElement>
+) {
+    companion object {
+        fun of(
+            topAcademics: List<AcademicsSearchEntity>
+        ) = AcademicsSearchTopResponse(
+            topAcademics = topAcademics.map(AcademicsSearchResponseElement::of)
+        )
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/service/AcademicsSearchService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/service/AcademicsSearchService.kt
@@ -1,0 +1,39 @@
+package com.wafflestudio.csereal.core.academics.service
+
+import com.wafflestudio.csereal.core.academics.database.AcademicsSearchRepository
+import com.wafflestudio.csereal.core.academics.dto.AcademicsSearchPageResponse
+import com.wafflestudio.csereal.core.academics.dto.AcademicsSearchTopResponse
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+interface AcademicsSearchService {
+    fun searchAcademics(keyword: String, pageSize: Int, pageNum: Int): AcademicsSearchPageResponse
+    fun searchTopAcademics(keyword: String, number: Int): AcademicsSearchTopResponse
+}
+
+@Service
+class AcademicsSearchServiceImpl(
+    private val academicsSearchRepository: AcademicsSearchRepository
+) : AcademicsSearchService {
+    @Transactional(readOnly = true)
+    override fun searchTopAcademics(keyword: String, number: Int) =
+        AcademicsSearchTopResponse.of(
+            academicsSearchRepository.searchTopAcademics(
+                keyword = keyword,
+                number = number
+            )
+        )
+
+    @Transactional(readOnly = true)
+    override fun searchAcademics(keyword: String, pageSize: Int, pageNum: Int) =
+        academicsSearchRepository.searchAcademics(
+            keyword = keyword,
+            pageSize = pageSize,
+            pageNum = pageNum
+        ).let {
+            AcademicsSearchPageResponse.of(
+                academics = it.first,
+                total = it.second
+            )
+        }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/service/AcademicsService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/service/AcademicsService.kt
@@ -96,6 +96,7 @@ class AcademicsServiceImpl(
         return academicsYearResponses
     }
 
+    @Transactional(readOnly = true)
     override fun readGeneralStudies(): GeneralStudiesPageResponse {
         val academicsEntity = academicsRepository.findByStudentTypeAndPostType(
             AcademicsStudentType.UNDERGRADUATE,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/service/AcademicsService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/service/AcademicsService.kt
@@ -30,6 +30,10 @@ interface AcademicsService {
     fun readScholarship(scholarshipId: Long): ScholarshipDto
 }
 
+// TODO: add Update, Delete method
+//       remember to update academicsSearch Field on Update method
+//       remember to mark delete of academicsSearch Field on Delete mark method
+
 @Service
 class AcademicsServiceImpl(
     private val academicsRepository: AcademicsRepository,
@@ -51,6 +55,11 @@ class AcademicsServiceImpl(
 
         if (attachments != null) {
             attachmentService.uploadAllAttachments(newAcademics, attachments)
+        }
+
+        // create search data
+        newAcademics.apply {
+            academicsSearch = AcademicsSearchEntity.create(this)
         }
 
         academicsRepository.save(newAcademics)
@@ -103,13 +112,18 @@ class AcademicsServiceImpl(
     @Transactional
     override fun createCourse(studentType: String, request: CourseDto, attachments: List<MultipartFile>?): CourseDto {
         val enumStudentType = makeStringToAcademicsStudentType(studentType)
-        val newCourse = CourseEntity.of(enumStudentType, request)
+        var newCourse = CourseEntity.of(enumStudentType, request)
 
         if (attachments != null) {
             attachmentService.uploadAllAttachments(newCourse, attachments)
         }
 
-        courseRepository.save(newCourse)
+        // create search data
+        newCourse.apply {
+            academicsSearch = AcademicsSearchEntity.create(this)
+        }
+
+        newCourse = courseRepository.save(newCourse)
 
         val attachmentResponses = attachmentService.createAttachmentResponses(newCourse.attachments)
 
@@ -138,9 +152,14 @@ class AcademicsServiceImpl(
     @Transactional
     override fun createScholarshipDetail(studentType: String, request: ScholarshipDto): ScholarshipDto {
         val enumStudentType = makeStringToAcademicsStudentType(studentType)
-        val newScholarship = ScholarshipEntity.of(enumStudentType, request)
+        var newScholarship = ScholarshipEntity.of(enumStudentType, request)
 
-        scholarshipRepository.save(newScholarship)
+        // create search data
+        newScholarship.apply {
+            academicsSearch = AcademicsSearchEntity.create(this)
+        }
+
+        newScholarship = scholarshipRepository.save(newScholarship)
 
         return ScholarshipDto.of(newScholarship)
     }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/service/AcademicsService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/service/AcademicsService.kt
@@ -51,7 +51,7 @@ class AcademicsServiceImpl(
         val enumStudentType = makeStringToAcademicsStudentType(studentType)
         val enumPostType = makeStringToAcademicsPostType(postType)
 
-        val newAcademics = AcademicsEntity.of(enumStudentType, enumPostType, request)
+        var newAcademics = AcademicsEntity.of(enumStudentType, enumPostType, request)
 
         if (attachments != null) {
             attachmentService.uploadAllAttachments(newAcademics, attachments)
@@ -62,7 +62,7 @@ class AcademicsServiceImpl(
             academicsSearch = AcademicsSearchEntity.create(this)
         }
 
-        academicsRepository.save(newAcademics)
+        newAcademics = academicsRepository.save(newAcademics)
 
         val attachmentResponses = attachmentService.createAttachmentResponses(newAcademics.attachments)
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,20 +3,6 @@ spring:
         active: local
     datasource:
         driver-class-name: com.mysql.cj.jdbc.Driver
-    security:
-        oauth2:
-            client:
-                registration:
-                    idsnucse:
-                        client-id: cse-waffle-dev
-                        client-secret: ${OIDC_CLIENT_SECRET}
-                        authorization-grant-type: authorization_code
-                        scope: openid, profile, email
-                        redirect-uri: http://localhost:8080/api/v1/login/oauth2/code/idsnucse
-                provider:
-                    idsnucse:
-                        issuer-uri: https://id.snucse.org/o
-                        jwk-set-uri: https://id.snucse.org/o/jwks
     servlet:
         multipart:
             enabled: true
@@ -64,6 +50,20 @@ spring:
         properties:
             hibernate:
                 dialect: com.wafflestudio.csereal.common.config.MySQLDialectCustom
+    security:
+        oauth2:
+            client:
+                registration:
+                    idsnucse:
+                        client-id: cse-waffle-dev
+                        client-secret: ${OIDC_CLIENT_SECRET}
+                        authorization-grant-type: authorization_code
+                        scope: openid, profile, email
+                        redirect-uri: http://localhost:8080/api/v1/login/oauth2/code/idsnucse
+                provider:
+                    idsnucse:
+                        issuer-uri: https://id.snucse.org/o
+                        jwk-set-uri: https://id.snucse.org/o/jwks
 
 logging.level:
     default: INFO

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,6 +3,20 @@ spring:
         active: local
     datasource:
         driver-class-name: com.mysql.cj.jdbc.Driver
+    security:
+        oauth2:
+            client:
+                registration:
+                    idsnucse:
+                        client-id: cse-waffle-dev
+                        client-secret: ${OIDC_CLIENT_SECRET}
+                        authorization-grant-type: authorization_code
+                        scope: openid, profile, email
+                        redirect-uri: http://localhost:8080/api/v1/login/oauth2/code/idsnucse
+                provider:
+                    idsnucse:
+                        issuer-uri: https://id.snucse.org/o
+                        jwk-set-uri: https://id.snucse.org/o/jwks
     servlet:
         multipart:
             enabled: true
@@ -50,20 +64,6 @@ spring:
         properties:
             hibernate:
                 dialect: com.wafflestudio.csereal.common.config.MySQLDialectCustom
-    security:
-        oauth2:
-            client:
-                registration:
-                    idsnucse:
-                        client-id: cse-waffle-dev
-                        client-secret: ${OIDC_CLIENT_SECRET}
-                        authorization-grant-type: authorization_code
-                        scope: openid, profile, email
-                        redirect-uri: http://localhost:8080/api/v1/login/oauth2/code/idsnucse
-                provider:
-                    idsnucse:
-                        issuer-uri: https://id.snucse.org/o
-                        jwk-set-uri: https://id.snucse.org/o/jwks
 
 logging.level:
     default: INFO

--- a/src/test/kotlin/com/wafflestudio/csereal/common/util/UtilsTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/common/util/UtilsTest.kt
@@ -1,7 +1,9 @@
 package com.wafflestudio.csereal.common.util
 
 import com.wafflestudio.csereal.common.utils.cleanTextFromHtml
+import com.wafflestudio.csereal.common.utils.exchangePageNum
 import com.wafflestudio.csereal.common.utils.substringAroundKeyword
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 
@@ -98,6 +100,48 @@ class UtilsTest : BehaviorSpec({
 
             Then("should return full content") {
                 result shouldBe content
+            }
+        }
+    }
+
+    Given("Using exchangePageNum to get valid page number") {
+        When("Given variables are not positive") {
+            val totalMinus = Triple<Int, Int, Long>(1, 1, -1)
+            val pageSizeZero = Triple<Int, Int, Long>(0, 1, 1)
+            val pageNumZero = Triple<Int, Int, Long>(1, 0, 1)
+
+            Then("should throw AssertionError") {
+                shouldThrow<RuntimeException> {
+                    exchangePageNum(totalMinus.first, totalMinus.second, totalMinus.third)
+                }
+                shouldThrow<RuntimeException> {
+                    exchangePageNum(pageSizeZero.first, pageSizeZero.second, pageSizeZero.third)
+                }
+                shouldThrow<RuntimeException> {
+                    exchangePageNum(pageNumZero.first, pageNumZero.second, pageNumZero.third)
+                }
+            }
+        }
+
+        When("Given page is in the range") {
+            val pageSize = 10
+            val total = 100L
+            val pageNum = 3
+
+            Then("Should return pageNum itself") {
+                val resultPageNum = exchangePageNum(pageSize, pageNum, total)
+                resultPageNum shouldBe pageNum
+            }
+        }
+
+        When("Given page is out of range (bigger)") {
+            val pageSize = 10
+            val total = 104L
+            val pageNum = 15
+
+            Then("Should return last page number") {
+                val resultPageNum = exchangePageNum(pageSize, pageNum, total)
+                resultPageNum shouldBe 11
             }
         }
     }

--- a/src/test/kotlin/com/wafflestudio/csereal/core/academics/AcademicsServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/academics/AcademicsServiceTest.kt
@@ -1,0 +1,78 @@
+//package com.wafflestudio.csereal.core.academics
+//
+//import com.wafflestudio.csereal.core.academics.database.AcademicsRepository
+//import com.wafflestudio.csereal.core.academics.database.AcademicsSearchRepository
+//import com.wafflestudio.csereal.core.academics.dto.AcademicsDto
+//import com.wafflestudio.csereal.core.academics.service.AcademicsService
+//import io.kotest.core.spec.style.BehaviorSpec
+//import io.kotest.extensions.spring.SpringTestExtension
+//import io.kotest.extensions.spring.SpringTestLifecycleMode
+//import io.kotest.matchers.shouldBe
+//import io.kotest.matchers.shouldNotBe
+//import jakarta.transaction.Transactional
+//import org.springframework.boot.test.context.SpringBootTest
+//import org.springframework.data.repository.findByIdOrNull
+//import org.springframework.test.context.ActiveProfiles
+//
+//
+// TODO: Fix test issue
+//@SpringBootTest
+//@ActiveProfiles("test")
+//@Transactional
+//class AcademicsServiceTest (
+//    private val academicsService: AcademicsService,
+//    private val academicsRepository: AcademicsRepository,
+//    private val academicsSearchRepository: AcademicsSearchRepository,
+//): BehaviorSpec({
+//    extensions(SpringTestExtension(SpringTestLifecycleMode.Root))
+//
+//    Given("첨부파일 없는 Academics를 생성하려고 할 때") {
+//        val studentType = "undergraduate"
+//        val enumPostType = "guide"
+//        val request = AcademicsDto(
+//            name = "name",
+//            description = "<p>description</p>",
+//            year = 2023,
+//            time = "12:43",
+//        )
+//
+//        When("Academics를 생성한다면") {
+//            val returnDto = academicsService.createAcademics(studentType, enumPostType, request, null)
+//
+//            Then("Academics가 생성되어야 한다.") {
+//                val id = returnDto.id
+//                val savedAcademics = academicsRepository.findByIdOrNull(id)
+//
+//                savedAcademics shouldNotBe null
+//                savedAcademics!!.let {
+//                    it.name shouldBe request.name
+//                    it.description shouldBe request.description
+//                    it.year shouldBe request.year
+//                    it.time shouldBe request.time
+//                }
+//            }
+//
+//            Then("검색 데이터가 생성되어야 한다.") {
+//                val savedAcademics = academicsRepository.findByIdOrNull(returnDto.id)!!
+//                val createdSearch = savedAcademics.academicsSearch?.id.let {
+//                    academicsSearchRepository.findByIdOrNull(it)
+//                }
+//
+//                createdSearch shouldNotBe null
+//                createdSearch!!.let {
+//                    it.academics shouldBe savedAcademics
+//                    it.course shouldBe null
+//                    it.scholarship shouldBe null
+//                    it.content shouldBe """
+//                        name
+//                        12:43
+//                        2023
+//                        학부생
+//                        description
+//
+//                    """.trimIndent()
+//                }
+//            }
+//        }
+//    }
+//})


### PR DESCRIPTION
## Feat: 학사 및 교과 검색 기능 추가

### 상세 설명

5cff1b2 Feat: AcademicsStudentType에 값 지정.
855ce7f Feat: AcademicsSearchEntity 추가
9c6d1be Feat: 각 entity에 search 관계 추가
c61215e Feat: 각 entity create하는 서비스 method에 search entity도 생성하도록 추가.
b50360c Feat: Add academicsSearchRepository
e441334 Feat: Add dto for search
418efee Refactor: Make name field of academics non null
3bac72f Feat: Add exchangePageNum to utils.
ef5c538 Feat: Add academics search service
5bac832 Feat: Add search api for academics.
852ec44 Feat: add validation code for utils.exchangePageNum
8469527 Test: Add testcode for exchangePageNum
c57616f REfactor: Add transactional readonly for readGeneralStudies
121e12f fix: apply newacademics to use after saved cached entity.
016517f fix: fix to add target enitity when create of search entity is called.
e20d2b9 refactor: add default values for nullable values.
eb078aa Temp: test code, should be fixed h2 issue.


### TODO

- Academics, Course, Scholarship Update, Delete 추가
- AcademicsService 테스트 코드 동작하도록 수정 및 작성
