### PR TITLE
about에 language field 추가

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/common/properties/LanguageType.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/properties/LanguageType.kt
@@ -1,5 +1,5 @@
 package com.wafflestudio.csereal.common.properties
 
 enum class LanguageType {
-    KOR, ENG
+    KO, EN
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/common/properties/LanguageType.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/properties/LanguageType.kt
@@ -1,0 +1,5 @@
+package com.wafflestudio.csereal.common.properties
+
+enum class LanguageType {
+    KOR, ENG
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/common/repository/LanguageRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/repository/LanguageRepository.kt
@@ -1,0 +1,21 @@
+package com.wafflestudio.csereal.common.repository
+
+import com.wafflestudio.csereal.common.CserealException
+import com.wafflestudio.csereal.common.properties.LanguageType
+import org.springframework.stereotype.Repository
+
+interface LanguageRepository {
+    fun makeStringToLanguageType(language: String): LanguageType
+}
+
+@Repository
+class LanguageRepositoryImpl : LanguageRepository {
+    override fun makeStringToLanguageType(language: String): LanguageType {
+        try {
+            val upperLanguageType = language.uppercase()
+            return LanguageType.valueOf(upperLanguageType)
+        } catch (e: IllegalArgumentException) {
+            throw CserealException.Csereal400("해당하는 enum을 찾을 수 없습니다")
+        }
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/api/AboutController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/api/AboutController.kt
@@ -34,26 +34,33 @@ class AboutController(
     }
 
     // read 목록이 하나
-    @GetMapping("/{postType}")
+    @GetMapping("/{language}/{postType}")
     fun readAbout(
+        @PathVariable language: String,
         @PathVariable postType: String
     ): ResponseEntity<AboutDto> {
-        return ResponseEntity.ok(aboutService.readAbout(postType))
+        return ResponseEntity.ok(aboutService.readAbout(language, postType))
     }
 
-    @GetMapping("/student-clubs")
-    fun readAllClubs(): ResponseEntity<List<AboutDto>> {
-        return ResponseEntity.ok(aboutService.readAllClubs())
+    @GetMapping("/{language}/student-clubs")
+    fun readAllClubs(
+        @PathVariable language: String
+    ): ResponseEntity<List<AboutDto>> {
+        return ResponseEntity.ok(aboutService.readAllClubs(language))
     }
 
-    @GetMapping("/facilities")
-    fun readAllFacilities(): ResponseEntity<List<AboutDto>> {
-        return ResponseEntity.ok(aboutService.readAllFacilities())
+    @GetMapping("/{language}/facilities")
+    fun readAllFacilities(
+        @PathVariable language: String
+    ): ResponseEntity<List<AboutDto>> {
+        return ResponseEntity.ok(aboutService.readAllFacilities(language))
     }
 
-    @GetMapping("/directions")
-    fun readAllDirections(): ResponseEntity<List<AboutDto>> {
-        return ResponseEntity.ok(aboutService.readAllDirections())
+    @GetMapping("/{language}/directions")
+    fun readAllDirections(
+        @PathVariable language: String
+    ): ResponseEntity<List<AboutDto>> {
+        return ResponseEntity.ok(aboutService.readAllDirections(language))
     }
 
     @GetMapping("/future-careers")

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/database/AboutEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/database/AboutEntity.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.csereal.core.about.database
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
 import com.wafflestudio.csereal.common.controller.AttachmentContentEntityType
 import com.wafflestudio.csereal.common.controller.MainImageContentEntityType
+import com.wafflestudio.csereal.common.properties.LanguageType
 import com.wafflestudio.csereal.core.about.dto.AboutDto
 import com.wafflestudio.csereal.core.resource.attachment.database.AttachmentEntity
 import com.wafflestudio.csereal.core.resource.mainImage.database.MainImageEntity
@@ -12,6 +13,8 @@ import jakarta.persistence.*
 class AboutEntity(
     @Enumerated(EnumType.STRING)
     var postType: AboutPostType,
+    @Enumerated(EnumType.STRING)
+    var language: LanguageType,
     var name: String?,
     var engName: String?,
 
@@ -34,9 +37,10 @@ class AboutEntity(
     override fun bringAttachments(): List<AttachmentEntity> = attachments
 
     companion object {
-        fun of(postType: AboutPostType, aboutDto: AboutDto): AboutEntity {
+        fun of(postType: AboutPostType, languageType: LanguageType, aboutDto: AboutDto): AboutEntity {
             return AboutEntity(
                 postType = postType,
+                language = languageType,
                 name = aboutDto.name,
                 engName = aboutDto.engName,
                 description = aboutDto.description,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/database/AboutRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/database/AboutRepository.kt
@@ -1,8 +1,9 @@
 package com.wafflestudio.csereal.core.about.database
 
+import com.wafflestudio.csereal.common.properties.LanguageType
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface AboutRepository : JpaRepository<AboutEntity, Long> {
-    fun findAllByPostTypeOrderByName(postType: AboutPostType): List<AboutEntity>
-    fun findByPostType(postType: AboutPostType): AboutEntity
+    fun findAllByLanguageAndPostTypeOrderByName(languageType: LanguageType, postType: AboutPostType): List<AboutEntity>
+    fun findByLanguageAndPostType(languageType: LanguageType, postType: AboutPostType): AboutEntity
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/AboutDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/AboutDto.kt
@@ -8,6 +8,7 @@ import java.time.LocalDateTime
 data class AboutDto(
     @JsonInclude(JsonInclude.Include.NON_NULL)
     val id: Long? = null,
+    val language: String,
     val name: String?,
     val engName: String?,
     val description: String,
@@ -26,6 +27,7 @@ data class AboutDto(
         ): AboutDto = entity.run {
             AboutDto(
                 id = this.id,
+                language = this.language.toString().lowercase(),
                 name = this.name,
                 engName = this.engName,
                 description = this.description,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/AboutRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/AboutRequest.kt
@@ -2,5 +2,6 @@ package com.wafflestudio.csereal.core.about.dto
 
 data class AboutRequest(
     val postType: String,
+    val language: String,
     val description: String
 )

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/DirectionDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/DirectionDto.kt
@@ -6,6 +6,7 @@ import com.wafflestudio.csereal.core.about.database.AboutEntity
 data class DirectionDto(
     @JsonInclude(JsonInclude.Include.NON_NULL)
     val id: Long? = null,
+    val language: String,
     val name: String,
     val engName: String,
     val description: String
@@ -14,6 +15,7 @@ data class DirectionDto(
         fun of(entity: AboutEntity): DirectionDto = entity.run {
             DirectionDto(
                 id = this.id,
+                language = this.language.toString().lowercase(),
                 name = this.name!!,
                 engName = this.engName!!,
                 description = this.description

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/FacilityDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/FacilityDto.kt
@@ -6,6 +6,7 @@ import com.wafflestudio.csereal.core.about.database.AboutEntity
 data class FacilityDto(
     @JsonInclude(JsonInclude.Include.NON_NULL)
     val id: Long? = null,
+    val language: String,
     val name: String,
     val description: String,
     val locations: List<String>
@@ -14,6 +15,7 @@ data class FacilityDto(
         fun of(entity: AboutEntity): FacilityDto = entity.run {
             FacilityDto(
                 id = this.id,
+                language = this.language.toString().lowercase(),
                 name = this.name!!,
                 description = this.description,
                 locations = this.locations.map { it.name }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/FutureCareersRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/FutureCareersRequest.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.csereal.core.about.dto
 
 data class FutureCareersRequest(
+    val language: String,
     val description: String,
     val stat: List<FutureCareersStatDto>,
     val companies: List<FutureCareersCompanyDto>

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/StudentClubDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/StudentClubDto.kt
@@ -6,6 +6,7 @@ import com.wafflestudio.csereal.core.about.database.AboutEntity
 data class StudentClubDto(
     @JsonInclude(JsonInclude.Include.NON_NULL)
     val id: Long? = null,
+    val language: String,
     val name: String,
     val engName: String,
     val description: String
@@ -14,6 +15,7 @@ data class StudentClubDto(
         fun of(entity: AboutEntity): StudentClubDto = entity.run {
             StudentClubDto(
                 id = this.id,
+                language = this.language.toString().lowercase(),
                 name = this.name!!,
                 engName = this.engName!!,
                 description = this.description

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/service/AboutService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/service/AboutService.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.csereal.core.about.service
 
 import com.wafflestudio.csereal.common.CserealException
+import com.wafflestudio.csereal.common.repository.LanguageRepository
 import com.wafflestudio.csereal.core.about.database.*
 import com.wafflestudio.csereal.core.about.dto.*
 import com.wafflestudio.csereal.core.about.dto.FutureCareersPage
@@ -38,7 +39,8 @@ class AboutServiceImpl(
     private val companyRepository: CompanyRepository,
     private val statRepository: StatRepository,
     private val mainImageService: MainImageService,
-    private val attachmentService: AttachmentService
+    private val attachmentService: AttachmentService,
+    private val languageRepository: LanguageRepository
 ) : AboutService {
     @Transactional
     override fun createAbout(
@@ -48,7 +50,8 @@ class AboutServiceImpl(
         attachments: List<MultipartFile>?
     ): AboutDto {
         val enumPostType = makeStringToEnum(postType)
-        val newAbout = AboutEntity.of(enumPostType, request)
+        val enumLanguageType = languageRepository.makeStringToLanguageType(request.language)
+        val newAbout = AboutEntity.of(enumPostType, enumLanguageType, request)
 
         if (request.locations != null) {
             for (location in request.locations) {
@@ -153,13 +156,16 @@ class AboutServiceImpl(
         val list = mutableListOf<AboutDto>()
 
         for (request in requestList) {
+            val language = request.language
+            val description = request.description
             val enumPostType = makeStringToEnum(request.postType)
 
             val aboutDto = AboutDto(
                 id = null,
+                language = language,
                 name = null,
                 engName = null,
-                description = request.description,
+                description = description,
                 year = null,
                 createdAt = null,
                 modifiedAt = null,
@@ -167,7 +173,9 @@ class AboutServiceImpl(
                 imageURL = null,
                 attachments = listOf()
             )
-            val newAbout = AboutEntity.of(enumPostType, aboutDto)
+
+            val languageType = languageRepository.makeStringToLanguageType(language)
+            val newAbout = AboutEntity.of(enumPostType, languageType, aboutDto)
 
             aboutRepository.save(newAbout)
 
@@ -179,11 +187,13 @@ class AboutServiceImpl(
     @Transactional
     override fun migrateFutureCareers(request: FutureCareersRequest): FutureCareersPage {
         val description = request.description
+        val language = request.language
         val statList = mutableListOf<FutureCareersStatDto>()
         val companyList = mutableListOf<FutureCareersCompanyDto>()
 
         val aboutDto = AboutDto(
             id = null,
+            language = language,
             name = null,
             engName = null,
             description = description,
@@ -194,7 +204,9 @@ class AboutServiceImpl(
             imageURL = null,
             attachments = listOf()
         )
-        val newAbout = AboutEntity.of(AboutPostType.FUTURE_CAREERS, aboutDto)
+
+        val languageType = languageRepository.makeStringToLanguageType(language)
+        val newAbout = AboutEntity.of(AboutPostType.FUTURE_CAREERS, languageType, aboutDto)
         aboutRepository.save(newAbout)
 
         for (stat in request.stat) {
@@ -238,10 +250,15 @@ class AboutServiceImpl(
         val list = mutableListOf<StudentClubDto>()
 
         for (request in requestList) {
+            val language = request.language
+            val name = request.name
+            val engName = request.engName
+
             val aboutDto = AboutDto(
                 id = null,
-                name = request.name,
-                engName = request.engName,
+                language = language,
+                name = name,
+                engName = engName,
                 description = request.description,
                 year = null,
                 createdAt = null,
@@ -250,7 +267,8 @@ class AboutServiceImpl(
                 imageURL = null,
                 attachments = listOf()
             )
-            val newAbout = AboutEntity.of(AboutPostType.STUDENT_CLUBS, aboutDto)
+            val languageType = languageRepository.makeStringToLanguageType(language)
+            val newAbout = AboutEntity.of(AboutPostType.STUDENT_CLUBS, languageType, aboutDto)
 
             aboutRepository.save(newAbout)
 
@@ -264,11 +282,15 @@ class AboutServiceImpl(
         val list = mutableListOf<FacilityDto>()
 
         for (request in requestList) {
+            val language = request.language
+            val name = request.name
+            val description = request.description
             val aboutDto = AboutDto(
                 id = null,
-                name = request.name,
+                language = language,
+                name = name,
                 engName = null,
-                description = request.description,
+                description = description,
                 year = null,
                 createdAt = null,
                 modifiedAt = null,
@@ -277,7 +299,8 @@ class AboutServiceImpl(
                 attachments = listOf()
             )
 
-            val newAbout = AboutEntity.of(AboutPostType.FACILITIES, aboutDto)
+            val languageType = languageRepository.makeStringToLanguageType(language)
+            val newAbout = AboutEntity.of(AboutPostType.FACILITIES, languageType, aboutDto)
 
             for (location in request.locations) {
                 LocationEntity.create(location, newAbout)
@@ -295,11 +318,17 @@ class AboutServiceImpl(
         val list = mutableListOf<DirectionDto>()
 
         for (request in requestList) {
+            val language = request.language
+            val name = request.name
+            val engName = request.engName
+            val description = request.description
+
             val aboutDto = AboutDto(
                 id = null,
-                name = request.name,
-                engName = request.engName,
-                description = request.description,
+                language = language,
+                name = name,
+                engName = engName,
+                description = description,
                 year = null,
                 createdAt = null,
                 modifiedAt = null,
@@ -308,7 +337,8 @@ class AboutServiceImpl(
                 attachments = listOf()
             )
 
-            val newAbout = AboutEntity.of(AboutPostType.DIRECTIONS, aboutDto)
+            val languageType = languageRepository.makeStringToLanguageType(language)
+            val newAbout = AboutEntity.of(AboutPostType.DIRECTIONS, languageType, aboutDto)
 
             aboutRepository.save(newAbout)
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/service/AboutService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/service/AboutService.kt
@@ -21,10 +21,10 @@ interface AboutService {
         attachments: List<MultipartFile>?
     ): AboutDto
 
-    fun readAbout(postType: String): AboutDto
-    fun readAllClubs(): List<AboutDto>
-    fun readAllFacilities(): List<AboutDto>
-    fun readAllDirections(): List<AboutDto>
+    fun readAbout(language: String, postType: String): AboutDto
+    fun readAllClubs(language: String): List<AboutDto>
+    fun readAllFacilities(language: String): List<AboutDto>
+    fun readAllDirections(language: String): List<AboutDto>
     fun readFutureCareers(): FutureCareersPage
     fun migrateAbout(requestList: List<AboutRequest>): List<AboutDto>
     fun migrateFutureCareers(request: FutureCareersRequest): FutureCareersPage
@@ -75,9 +75,10 @@ class AboutServiceImpl(
     }
 
     @Transactional(readOnly = true)
-    override fun readAbout(postType: String): AboutDto {
+    override fun readAbout(language: String, postType: String): AboutDto {
+        val languageType = languageRepository.makeStringToLanguageType(language)
         val enumPostType = makeStringToEnum(postType)
-        val about = aboutRepository.findByPostType(enumPostType)
+        val about = aboutRepository.findByLanguageAndPostType(languageType, enumPostType)
         val imageURL = mainImageService.createImageURL(about.mainImage)
         val attachmentResponses = attachmentService.createAttachmentResponses(about.attachments)
 
@@ -85,8 +86,9 @@ class AboutServiceImpl(
     }
 
     @Transactional(readOnly = true)
-    override fun readAllClubs(): List<AboutDto> {
-        val clubs = aboutRepository.findAllByPostTypeOrderByName(AboutPostType.STUDENT_CLUBS).map {
+    override fun readAllClubs(language: String): List<AboutDto> {
+        val languageType = languageRepository.makeStringToLanguageType(language)
+        val clubs = aboutRepository.findAllByLanguageAndPostTypeOrderByName(languageType, AboutPostType.STUDENT_CLUBS).map {
             val imageURL = mainImageService.createImageURL(it.mainImage)
             val attachmentResponses = attachmentService.createAttachmentResponses(it.attachments)
             AboutDto.of(it, imageURL, attachmentResponses)
@@ -96,8 +98,9 @@ class AboutServiceImpl(
     }
 
     @Transactional(readOnly = true)
-    override fun readAllFacilities(): List<AboutDto> {
-        val facilities = aboutRepository.findAllByPostTypeOrderByName(AboutPostType.FACILITIES).map {
+    override fun readAllFacilities(language: String): List<AboutDto> {
+        val languageType = languageRepository.makeStringToLanguageType(language)
+        val facilities = aboutRepository.findAllByLanguageAndPostTypeOrderByName(languageType, AboutPostType.FACILITIES).map {
             val imageURL = mainImageService.createImageURL(it.mainImage)
             val attachmentResponses = attachmentService.createAttachmentResponses(it.attachments)
             AboutDto.of(it, imageURL, attachmentResponses)
@@ -107,8 +110,9 @@ class AboutServiceImpl(
     }
 
     @Transactional(readOnly = true)
-    override fun readAllDirections(): List<AboutDto> {
-        val directions = aboutRepository.findAllByPostTypeOrderByName(AboutPostType.DIRECTIONS).map {
+    override fun readAllDirections(language: String): List<AboutDto> {
+        val languageType = languageRepository.makeStringToLanguageType(language)
+        val directions = aboutRepository.findAllByLanguageAndPostTypeOrderByName(languageType, AboutPostType.DIRECTIONS).map {
             val imageURL = mainImageService.createImageURL(it.mainImage)
             val attachments = attachmentService.createAttachmentResponses(it.attachments)
             AboutDto.of(it, imageURL, attachments)


### PR DESCRIPTION
## 제목
about에 language field 추가

### 한줄 요약
aboutEntity에 language field를 추가하고, AboutDto에서도 language을 추가하였습니다.

### 상세 설명

[988ab5687578f4bbc36f33c660fa7b14cedd1499]: aboutEntity에 language field을 추가하고 AboutDto에서도 language을 추가하였습니다. 
language는 AboutDto에서 String으로 받고, ko 아니면 en을 받기로 하였습니다.
서비스 단에서 String을 Enum으로 변경하여 ko와 en만 입력이 가능하도록 하였습니다.

[a79d9a77f3cec3af8fc7fe3a6b0a12976396d5a2]: about을 read할 때 language을 PathVariable로 읽도록 하였습니다.

만들고 나니, 로컬에서 잘 작동하였습니다.

### TODO
다른 엔티티들 중, 한국어 데이터 / 영어 데이터가 따로 있는 애들은 language 필드를 추가하려고 합니다.
마이그레이션할 때 검색 인덱스 추가하는건 이거 전체적으로 마무리하고 실행하려고 합니다.
