### PR TITLE
Refactor: Admission 언어 추가 및 리팩터링 진행

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/admissions/api/AdmissionsController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admissions/api/AdmissionsController.kt
@@ -29,7 +29,7 @@ class AdmissionsController(
         return admissionsService.createAdmission(req, mainType, postType)
     }
 
-    @GetMapping
+    @GetMapping("/{mainTypeStr}/{postTypeStr}")
     fun readAdmission(
         @PathVariable(required = true) mainTypeStr: String,
         @PathVariable(required = true) postTypeStr: String,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/admissions/api/AdmissionsController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admissions/api/AdmissionsController.kt
@@ -1,17 +1,15 @@
 package com.wafflestudio.csereal.core.admissions.api
 
 import com.wafflestudio.csereal.common.aop.AuthenticatedStaff
+import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.core.admissions.api.req.AdmissionReqBody
 import com.wafflestudio.csereal.core.admissions.dto.AdmissionsDto
-import com.wafflestudio.csereal.core.admissions.dto.AdmissionsRequest
+import com.wafflestudio.csereal.core.admissions.api.req.AdmissionMigrateElem
 import com.wafflestudio.csereal.core.admissions.service.AdmissionsService
+import com.wafflestudio.csereal.core.admissions.type.AdmissionsMainType
+import com.wafflestudio.csereal.core.admissions.type.AdmissionsPostType
 import jakarta.validation.Valid
-import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RequestMapping("/api/v1/admissions")
 @RestController
@@ -19,40 +17,32 @@ class AdmissionsController(
     private val admissionsService: AdmissionsService
 ) {
     @AuthenticatedStaff
-    @PostMapping("/undergraduate/{postType}")
-    fun createUndergraduateAdmissions(
-        @PathVariable postType: String,
+    @PostMapping("/{mainTypeStr}/{postTypeStr}")
+    fun createAdmission(
+        @PathVariable(required = true) mainTypeStr: String,
+        @PathVariable(required = true) postTypeStr: String,
         @Valid @RequestBody
-        request: AdmissionsDto
+        req: AdmissionReqBody
     ): AdmissionsDto {
-        return admissionsService.createUndergraduateAdmissions(postType, request)
+        val mainType = AdmissionsMainType.fromJsonValue(mainTypeStr)
+        val postType = AdmissionsPostType.fromJsonValue(postTypeStr)
+        return admissionsService.createAdmission(req, mainType, postType)
     }
 
-    @AuthenticatedStaff
-    @PostMapping("/graduate")
-    fun createGraduateAdmissions(
-        @Valid @RequestBody
-        request: AdmissionsDto
+    @GetMapping
+    fun readAdmission(
+        @PathVariable(required = true) mainTypeStr: String,
+        @PathVariable(required = true) postTypeStr: String,
+        @RequestParam(required = true, defaultValue = "ko") language: String
     ): AdmissionsDto {
-        return admissionsService.createGraduateAdmissions(request)
-    }
-
-    @GetMapping("/undergraduate/{postType}")
-    fun readUndergraduateAdmissions(
-        @PathVariable postType: String
-    ): ResponseEntity<AdmissionsDto> {
-        return ResponseEntity.ok(admissionsService.readUndergraduateAdmissions(postType))
-    }
-
-    @GetMapping("/graduate")
-    fun readGraduateAdmissions(): ResponseEntity<AdmissionsDto> {
-        return ResponseEntity.ok(admissionsService.readGraduateAdmissions())
+        val mainType = AdmissionsMainType.fromJsonValue(mainTypeStr)
+        val postType = AdmissionsPostType.fromJsonValue(postTypeStr)
+        val languageType = LanguageType.makeStringToLanguageType(language)
+        return admissionsService.readAdmission(mainType, postType, languageType)
     }
 
     @PostMapping("/migrate")
     fun migrateAdmissions(
-        @RequestBody requestList: List<AdmissionsRequest>
-    ): ResponseEntity<List<AdmissionsDto>> {
-        return ResponseEntity.ok(admissionsService.migrateAdmissions(requestList))
-    }
+        @RequestBody reqList: List<@Valid AdmissionMigrateElem>
+    ): List<AdmissionsDto> = admissionsService.migrateAdmissions(reqList)
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/admissions/api/req/AdmissionMigrateElem.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admissions/api/req/AdmissionMigrateElem.kt
@@ -1,0 +1,11 @@
+package com.wafflestudio.csereal.core.admissions.api.req
+
+import org.jetbrains.annotations.NotNull
+
+data class AdmissionMigrateElem(
+    @field:NotNull val name: String?,
+    val mainType: String,
+    val postType: String,
+    val language: String,
+    @field:NotNull val description: String?
+)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/admissions/api/req/AdmissionReqBody.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admissions/api/req/AdmissionReqBody.kt
@@ -1,0 +1,9 @@
+package com.wafflestudio.csereal.core.admissions.api.req
+
+import org.jetbrains.annotations.NotNull
+
+data class AdmissionReqBody(
+    @field:NotNull val name: String?,
+    val language: String = "ko",
+    @field:NotNull val description: String?
+)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/admissions/database/AdmissionsEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admissions/database/AdmissionsEntity.kt
@@ -1,28 +1,63 @@
 package com.wafflestudio.csereal.core.admissions.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.core.admissions.api.req.AdmissionReqBody
 import com.wafflestudio.csereal.core.admissions.dto.AdmissionsDto
+import com.wafflestudio.csereal.core.admissions.type.AdmissionsMainType
+import com.wafflestudio.csereal.core.admissions.type.AdmissionsPostType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
 
 @Entity(name = "admissions")
+@Table(
+    uniqueConstraints = [
+        UniqueConstraint(columnNames = ["language", "mainType", "postType"])
+    ]
+)
 class AdmissionsEntity(
+    val name: String,
+
+    @Enumerated(EnumType.STRING)
+    val language: LanguageType,
+
+    @Enumerated(EnumType.STRING)
+    val mainType: AdmissionsMainType,
+
     @Enumerated(EnumType.STRING)
     val postType: AdmissionsPostType,
-    val pageName: String,
 
     @Column(columnDefinition = "mediumText")
     val description: String
 ) : BaseTimeEntity() {
     companion object {
-        fun of(postType: AdmissionsPostType, pageName: String, admissionsDto: AdmissionsDto): AdmissionsEntity {
-            return AdmissionsEntity(
-                postType = postType,
-                pageName = pageName,
-                description = admissionsDto.description
-            )
-        }
+        fun of(
+            mainType: AdmissionsMainType,
+            postType: AdmissionsPostType,
+            name: String,
+            admissionsDto: AdmissionsDto
+        ) = AdmissionsEntity(
+            mainType = mainType,
+            postType = postType,
+            name = name,
+            description = admissionsDto.description,
+            language = LanguageType.makeStringToLanguageType(admissionsDto.language)
+        )
+
+        fun of(
+            mainType: AdmissionsMainType,
+            postType: AdmissionsPostType,
+            req: AdmissionReqBody
+        ) = AdmissionsEntity(
+            mainType = mainType,
+            postType = postType,
+            name = req.name!!,
+            description = req.description!!,
+            language = LanguageType.makeStringToLanguageType(req.language)
+        )
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/admissions/database/AdmissionsPostType.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admissions/database/AdmissionsPostType.kt
@@ -1,5 +1,0 @@
-package com.wafflestudio.csereal.core.admissions.database
-
-enum class AdmissionsPostType {
-    GRADUATE, UNDERGRADUATE_EARLY_ADMISSION, UNDERGRADUATE_REGULAR_ADMISSION,
-}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/admissions/database/AdmissionsRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admissions/database/AdmissionsRepository.kt
@@ -1,7 +1,14 @@
 package com.wafflestudio.csereal.core.admissions.database
 
+import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.core.admissions.type.AdmissionsMainType
+import com.wafflestudio.csereal.core.admissions.type.AdmissionsPostType
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface AdmissionsRepository : JpaRepository<AdmissionsEntity, Long> {
-    fun findByPostType(postType: AdmissionsPostType): AdmissionsEntity
+    fun findByMainTypeAndPostTypeAndLanguage(
+        mainType: AdmissionsMainType,
+        postType: AdmissionsPostType,
+        language: LanguageType
+    ): AdmissionsEntity?
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/admissions/dto/AdmissionsDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admissions/dto/AdmissionsDto.kt
@@ -1,23 +1,30 @@
 package com.wafflestudio.csereal.core.admissions.dto
 
-import com.fasterxml.jackson.annotation.JsonInclude
+import com.wafflestudio.csereal.common.properties.LanguageType
 import com.wafflestudio.csereal.core.admissions.database.AdmissionsEntity
 import java.time.LocalDateTime
 
 data class AdmissionsDto(
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    val id: Long? = null,
+    val id: Long,
+    val name: String,
+    val mainType: String,
+    val postType: String,
+    val language: String,
     val description: String,
-    val createdAt: LocalDateTime?,
-    val modifiedAt: LocalDateTime?
+    val createdAt: LocalDateTime,
+    val modifiedAt: LocalDateTime
 ) {
     companion object {
         fun of(entity: AdmissionsEntity): AdmissionsDto = entity.run {
             AdmissionsDto(
                 id = this.id,
+                name = this.name,
+                mainType = this.mainType.toJsonValue(),
+                postType = this.postType.toJsonValue(),
+                language = LanguageType.makeLowercase(this.language),
                 description = this.description,
-                createdAt = this.createdAt,
-                modifiedAt = this.modifiedAt
+                createdAt = this.createdAt!!,
+                modifiedAt = this.modifiedAt!!
             )
         }
     }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/admissions/dto/AdmissionsRequest.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admissions/dto/AdmissionsRequest.kt
@@ -1,6 +1,0 @@
-package com.wafflestudio.csereal.core.admissions.dto
-
-data class AdmissionsRequest(
-    val postType: String,
-    val description: String
-)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/admissions/service/AdmissionsService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admissions/service/AdmissionsService.kt
@@ -1,20 +1,29 @@
 package com.wafflestudio.csereal.core.admissions.service
 
 import com.wafflestudio.csereal.common.CserealException
+import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.core.admissions.api.req.AdmissionReqBody
 import com.wafflestudio.csereal.core.admissions.database.AdmissionsEntity
-import com.wafflestudio.csereal.core.admissions.database.AdmissionsPostType
+import com.wafflestudio.csereal.core.admissions.type.AdmissionsPostType
 import com.wafflestudio.csereal.core.admissions.database.AdmissionsRepository
 import com.wafflestudio.csereal.core.admissions.dto.AdmissionsDto
-import com.wafflestudio.csereal.core.admissions.dto.AdmissionsRequest
+import com.wafflestudio.csereal.core.admissions.api.req.AdmissionMigrateElem
+import com.wafflestudio.csereal.core.admissions.type.AdmissionsMainType
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 interface AdmissionsService {
-    fun createUndergraduateAdmissions(postType: String, request: AdmissionsDto): AdmissionsDto
-    fun createGraduateAdmissions(request: AdmissionsDto): AdmissionsDto
-    fun readUndergraduateAdmissions(postType: String): AdmissionsDto
-    fun readGraduateAdmissions(): AdmissionsDto
-    fun migrateAdmissions(requestList: List<AdmissionsRequest>): List<AdmissionsDto>
+    fun createAdmission(
+        req: AdmissionReqBody,
+        mainType: AdmissionsMainType,
+        postType: AdmissionsPostType
+    ): AdmissionsDto
+    fun readAdmission(
+        mainType: AdmissionsMainType,
+        postType: AdmissionsPostType,
+        language: LanguageType
+    ): AdmissionsDto
+    fun migrateAdmissions(requestList: List<AdmissionMigrateElem>): List<AdmissionsDto>
 }
 
 @Service
@@ -22,87 +31,43 @@ class AdmissionsServiceImpl(
     private val admissionsRepository: AdmissionsRepository
 ) : AdmissionsService {
     @Transactional
-    override fun createUndergraduateAdmissions(postType: String, request: AdmissionsDto): AdmissionsDto {
-        val enumPostType = makeStringToAdmissionsPostType(postType)
-
-        val pageName = when (enumPostType) {
-            AdmissionsPostType.UNDERGRADUATE_EARLY_ADMISSION -> "수시 모집"
-            AdmissionsPostType.UNDERGRADUATE_REGULAR_ADMISSION -> "정시 모집"
-            else -> throw CserealException.Csereal404("해당하는 페이지를 찾을 수 없습니다.")
-        }
-
-        val newAdmissions = AdmissionsEntity.of(enumPostType, pageName, request)
-
-        admissionsRepository.save(newAdmissions)
-
-        return AdmissionsDto.of(newAdmissions)
-    }
-
-    @Transactional
-    override fun createGraduateAdmissions(request: AdmissionsDto): AdmissionsDto {
-        val newAdmissions: AdmissionsEntity = AdmissionsEntity.of(AdmissionsPostType.GRADUATE, "전기/후기 모집", request)
-
-        admissionsRepository.save(newAdmissions)
-
-        return AdmissionsDto.of(newAdmissions)
+    override fun createAdmission(
+        req: AdmissionReqBody,
+        mainType: AdmissionsMainType,
+        postType: AdmissionsPostType
+    ) = admissionsRepository.save(
+        AdmissionsEntity.of(mainType, postType, req)
+    ).let {
+        AdmissionsDto.of(it)
     }
 
     @Transactional(readOnly = true)
-    override fun readUndergraduateAdmissions(postType: String): AdmissionsDto {
-        return when (postType) {
-            "early" -> AdmissionsDto.of(
-                admissionsRepository.findByPostType(AdmissionsPostType.UNDERGRADUATE_EARLY_ADMISSION)
-            )
-
-            "regular" -> AdmissionsDto.of(
-                admissionsRepository.findByPostType(AdmissionsPostType.UNDERGRADUATE_REGULAR_ADMISSION)
-            )
-
-            else -> throw CserealException.Csereal404("해당하는 페이지를 찾을 수 없습니다.")
-        }
-    }
-
-    @Transactional(readOnly = true)
-    override fun readGraduateAdmissions(): AdmissionsDto {
-        return AdmissionsDto.of(admissionsRepository.findByPostType(AdmissionsPostType.GRADUATE))
-    }
+    override fun readAdmission(
+        mainType: AdmissionsMainType,
+        postType: AdmissionsPostType,
+        language: LanguageType
+    ) = admissionsRepository.findByMainTypeAndPostTypeAndLanguage(
+        mainType,
+        postType,
+        language
+    )?.let { AdmissionsDto.of(it) }
+        ?: throw CserealException.Csereal404("해당하는 페이지를 찾을 수 없습니다.")
 
     @Transactional
-    override fun migrateAdmissions(requestList: List<AdmissionsRequest>): List<AdmissionsDto> {
-        val list = mutableListOf<AdmissionsDto>()
-
-        for (request in requestList) {
-            val enumPostType = makeStringToAdmissionsPostType(request.postType)
-
-            val pageName = when (enumPostType) {
-                AdmissionsPostType.UNDERGRADUATE_EARLY_ADMISSION -> "수시 모집"
-                AdmissionsPostType.UNDERGRADUATE_REGULAR_ADMISSION -> "정시 모집"
-                AdmissionsPostType.GRADUATE -> "대학원"
-                else -> throw CserealException.Csereal404("해당하는 페이지를 찾을 수 없습니다.")
-            }
-
-            val admissionsDto = AdmissionsDto(
-                id = null,
-                description = request.description,
-                createdAt = null,
-                modifiedAt = null
-            )
-
-            val newAdmissions = AdmissionsEntity.of(enumPostType, pageName, admissionsDto)
-
-            admissionsRepository.save(newAdmissions)
-
-            list.add(AdmissionsDto.of(newAdmissions))
-        }
-        return list
-    }
-
-    private fun makeStringToAdmissionsPostType(postType: String): AdmissionsPostType {
-        try {
-            val upperPostType = postType.replace("-", "_").uppercase()
-            return AdmissionsPostType.valueOf(upperPostType)
-        } catch (e: IllegalArgumentException) {
-            throw CserealException.Csereal400("해당하는 enum을 찾을 수 없습니다")
-        }
+    override fun migrateAdmissions(requestList: List<AdmissionMigrateElem>) = requestList.map {
+        val mainType = AdmissionsMainType.fromJsonValue(it.mainType)
+        val postType = AdmissionsPostType.fromJsonValue(it.postType)
+        val language = LanguageType.makeStringToLanguageType(it.language)
+        AdmissionsEntity(
+            name = it.name!!,
+            mainType = mainType,
+            postType = postType,
+            language = language,
+            description = it.description!!
+        )
+    }.let {
+        admissionsRepository.saveAll(it)
+    }.map {
+        AdmissionsDto.of(it)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/admissions/type/AdmissionsMainType.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admissions/type/AdmissionsMainType.kt
@@ -1,0 +1,21 @@
+package com.wafflestudio.csereal.core.admissions.type
+
+import com.wafflestudio.csereal.common.CserealException
+
+enum class AdmissionsMainType {
+    UNDERGRADUATE,
+    GRADUATE,
+    INTERNATIONAL;
+
+    fun toJsonValue() = this.name.lowercase()
+
+    companion object {
+        fun fromJsonValue(field: String) = try {
+            field
+                .uppercase()
+                .let { AdmissionsMainType.valueOf(it) }
+        } catch (e: IllegalArgumentException) {
+            throw CserealException.Csereal400("존재하지 않는 Admission Main Type입니다.")
+        }
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/admissions/type/AdmissionsPostType.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admissions/type/AdmissionsPostType.kt
@@ -1,0 +1,28 @@
+package com.wafflestudio.csereal.core.admissions.type
+
+import com.wafflestudio.csereal.common.CserealException
+
+enum class AdmissionsPostType {
+    // For graduate, undergraduate
+    EARLY_ADMISSION,
+    REGULAR_ADMISSION,
+
+    // For international
+    UNDERGRADUATE,
+    GRADUATE,
+    EXCHANGE_VISITING,
+    SCHOLARSHIPS;
+
+    fun toJsonValue() = this.name.lowercase()
+
+    companion object {
+        fun fromJsonValue(field: String) =
+            try {
+                field.replace('_', '-')
+                    .uppercase()
+                    .let { AdmissionsPostType.valueOf(it) }
+            } catch (e: IllegalArgumentException) {
+                throw CserealException.Csereal400("잘못된 Admission Post Type이 주어졌습니다.")
+            }
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/admissions/type/AdmissionsPostType.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admissions/type/AdmissionsPostType.kt
@@ -18,7 +18,7 @@ enum class AdmissionsPostType {
     companion object {
         fun fromJsonValue(field: String) =
             try {
-                field.replace('_', '-')
+                field.replace('-', '_')
                     .uppercase()
                     .let { AdmissionsPostType.valueOf(it) }
             } catch (e: IllegalArgumentException) {

--- a/src/test/kotlin/com/wafflestudio/csereal/core/admissions/service/AdmissionsServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/admissions/service/AdmissionsServiceTest.kt
@@ -1,0 +1,122 @@
+package com.wafflestudio.csereal.core.admissions.service
+
+import com.wafflestudio.csereal.common.CserealException
+import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.core.admissions.api.req.AdmissionReqBody
+import com.wafflestudio.csereal.core.admissions.database.AdmissionsEntity
+import com.wafflestudio.csereal.core.admissions.database.AdmissionsRepository
+import com.wafflestudio.csereal.core.admissions.type.AdmissionsMainType
+import com.wafflestudio.csereal.core.admissions.type.AdmissionsPostType
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.extensions.spring.SpringTestExtension
+import io.kotest.extensions.spring.SpringTestLifecycleMode
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Profile
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.transaction.annotation.Transactional
+
+@SpringBootTest
+@Profile("test")
+@Transactional
+class AdmissionsServiceTest(
+    private val admissionsService: AdmissionsService,
+    private val admissionsRepository: AdmissionsRepository
+) : BehaviorSpec({
+    extensions(SpringTestExtension(SpringTestLifecycleMode.Root))
+
+    afterContainer {
+        admissionsRepository.deleteAll()
+    }
+
+    Given("AdmissionReqBody, AdmissionMainType, AdmissionPostType이 주어졌을 때") {
+        val req = AdmissionReqBody(
+            name = "name",
+            language = "ko",
+            description = "description"
+        )
+        val mainType = AdmissionsMainType.UNDERGRADUATE
+        val postType = AdmissionsPostType.REGULAR_ADMISSION
+
+        When("createAdmission이 호출되면") {
+            val result = admissionsService.createAdmission(req, mainType, postType)
+
+            Then("주어진 정보와 일치하는 AdmissionDto가 반환된다.") {
+                result.name shouldBe req.name
+                result.mainType shouldBe mainType.toJsonValue()
+                result.postType shouldBe postType.toJsonValue()
+                result.language shouldBe req.language
+                result.description shouldBe req.description
+            }
+
+            Then("주어진 정보와 일치하는 AdmissionEnitity가 생성된다.") {
+                val entity = admissionsRepository.findByIdOrNull(result.id)
+                entity shouldNotBe null
+                entity!!.name shouldBe req.name
+                entity.mainType shouldBe mainType
+                entity.postType shouldBe postType
+                entity.language shouldBe LanguageType.makeStringToLanguageType(req.language)
+                entity.description shouldBe req.description
+            }
+        }
+    }
+    Given("AdmissionReqBody에 잘못된 Language가 주어졌을 때") {
+        val req = AdmissionReqBody(
+            name = "name",
+            language = "wrong",
+            description = "description"
+        )
+        val mainType = AdmissionsMainType.UNDERGRADUATE
+        val postType = AdmissionsPostType.REGULAR_ADMISSION
+        When("createAdmission이 호출되면") {
+            Then("Csereal400 에러가 발생한다.") {
+                shouldThrow<CserealException.Csereal400> {
+                    admissionsService.createAdmission(req, mainType, postType)
+                }
+            }
+        }
+    }
+
+    Given("Admission이 존재할 때") {
+        val admission = AdmissionsEntity(
+            name = "name",
+            mainType = AdmissionsMainType.INTERNATIONAL,
+            postType = AdmissionsPostType.EXCHANGE_VISITING,
+            language = LanguageType.EN,
+            description = "description"
+        ).let {
+            admissionsRepository.save(it)
+        }
+
+        When("존재하는 readAdmission이 호출되면") {
+            val mainType = AdmissionsMainType.INTERNATIONAL
+            val postType = AdmissionsPostType.EXCHANGE_VISITING
+            val language = LanguageType.EN
+            val result = admissionsService.readAdmission(mainType, postType, language)
+
+            Then("주어진 정보와 일치하는 AdmissionDto가 반환된다.") {
+                result.let {
+                    it.name shouldBe admission.name
+                    it.mainType shouldBe admission.mainType.toJsonValue()
+                    it.postType shouldBe admission.postType.toJsonValue()
+                    it.language shouldBe LanguageType.makeLowercase(admission.language)
+                    it.description shouldBe admission.description
+                }
+            }
+        }
+
+        When("존재하지 않는 readAdmission이 호출되면") {
+            Then("Csereal404 에러가 발생한다.") {
+                shouldThrow<CserealException.Csereal404> {
+                    admissionsService.readAdmission(
+                        AdmissionsMainType.UNDERGRADUATE,
+                        AdmissionsPostType.REGULAR_ADMISSION,
+                        LanguageType.KO
+                    )
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
## 제목
Refactor: Admission 리팩터링 진행
### 한줄 요약
- language column 추가
- mainType을 추가하여 (graduate, undergraduate, international) 추후 변경에 대해서도 쉽게 변경 가능하도록 하고 중복되는 method를 줄였음
- Request body를 따로 추가하여 API의 명확도를 올림
- 기존 API와 큰 차이를 가지지 않도록 고려하였음.

### 상세 설명

dfe4654 Feat: Move type to type dir, and add main type enum.
0e5cd6e Refactor: Add request body for create, and changed migrate elem body.
4d49b2b Feat: Change pagename -> name, add language and mainType column, add unique constraints.
b244133 Refactor: Remove unused request dto.
62d3556 Refactor: Change AdmissionsDto by adding columns, to be able to used as pure dto.
84d86dd Feat: Change to more specific search query.
05c2e3d Feat: Change multiple methods to few methods, by using mainType.
b1897a4 Feat: Change to few controller by using mainType, and use request bodies instead of dto.
c51d48d Test: AdmissionsServiceTest
06adc4c Fix: Add mapping path variable.
a72049b  Fix: Fix replacing logic.



### TODO

- 해당 사항 적용될 경우, 이를 기반으로 Admission 검색 기능 생성
