### PR TITLE
feat: staff에 language, migration 방법 추가

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/api/StaffController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/api/StaffController.kt
@@ -57,4 +57,12 @@ class StaffController(
     ): ResponseEntity<List<StaffDto>> {
         return ResponseEntity.ok(staffService.migrateStaff(requestList))
     }
+
+    @PatchMapping("/migrateImage/{staffId}")
+    fun migrateStaffImage(
+        @PathVariable staffId: Long,
+        @RequestPart("mainImage") mainImage: MultipartFile
+    ): ResponseEntity<StaffDto> {
+        return ResponseEntity.ok(staffService.migrateStaffImage(staffId, mainImage))
+    }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/api/StaffController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/api/StaffController.kt
@@ -29,8 +29,10 @@ class StaffController(
     }
 
     @GetMapping
-    fun getAllStaff(): ResponseEntity<List<SimpleStaffDto>> {
-        return ResponseEntity.ok(staffService.getAllStaff())
+    fun getAllStaff(
+        @RequestParam(required = false, defaultValue = "ko") language: String
+    ): ResponseEntity<List<SimpleStaffDto>> {
+        return ResponseEntity.ok(staffService.getAllStaff(language))
     }
 
     @AuthenticatedStaff

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/database/StaffEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/database/StaffEntity.kt
@@ -2,15 +2,16 @@ package com.wafflestudio.csereal.core.member.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
 import com.wafflestudio.csereal.common.controller.MainImageContentEntityType
+import com.wafflestudio.csereal.common.properties.LanguageType
 import com.wafflestudio.csereal.core.member.dto.StaffDto
 import com.wafflestudio.csereal.core.resource.mainImage.database.MainImageEntity
-import jakarta.persistence.CascadeType
-import jakarta.persistence.Entity
-import jakarta.persistence.OneToMany
-import jakarta.persistence.OneToOne
+import jakarta.persistence.*
 
 @Entity(name = "staff")
 class StaffEntity(
+    @Enumerated(EnumType.STRING)
+    var language: LanguageType,
+
     var name: String,
     var role: String,
 
@@ -30,8 +31,9 @@ class StaffEntity(
     override fun bringMainImage(): MainImageEntity? = mainImage
 
     companion object {
-        fun of(staffDto: StaffDto): StaffEntity {
+        fun of(languageType: LanguageType, staffDto: StaffDto): StaffEntity {
             return StaffEntity(
+                language = languageType,
                 name = staffDto.name,
                 role = staffDto.role,
                 office = staffDto.office,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/database/StaffRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/database/StaffRepository.kt
@@ -1,5 +1,8 @@
 package com.wafflestudio.csereal.core.member.database
 
+import com.wafflestudio.csereal.common.properties.LanguageType
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface StaffRepository : JpaRepository<StaffEntity, Long>
+interface StaffRepository : JpaRepository<StaffEntity, Long> {
+    fun findAllByLanguage(languageType: LanguageType): List<StaffEntity>
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/dto/StaffDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/dto/StaffDto.kt
@@ -1,11 +1,13 @@
 package com.wafflestudio.csereal.core.member.dto
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.wafflestudio.csereal.common.properties.LanguageType
 import com.wafflestudio.csereal.core.member.database.StaffEntity
 
 data class StaffDto(
     @JsonInclude(JsonInclude.Include.NON_NULL)
     var id: Long? = null,
+    val language: String,
     val name: String,
     val role: String,
     val office: String,
@@ -19,6 +21,7 @@ data class StaffDto(
         fun of(staffEntity: StaffEntity, imageURL: String?): StaffDto {
             return StaffDto(
                 id = staffEntity.id,
+                language = LanguageType.makeLowercase(staffEntity.language),
                 name = staffEntity.name,
                 role = staffEntity.role,
                 office = staffEntity.office,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/service/StaffService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/service/StaffService.kt
@@ -21,6 +21,7 @@ interface StaffService {
     fun updateStaff(staffId: Long, updateStaffRequest: StaffDto, mainImage: MultipartFile?): StaffDto
     fun deleteStaff(staffId: Long)
     fun migrateStaff(requestList: List<StaffDto>): List<StaffDto>
+    fun migrateStaffImage(staffId: Long, mainImage: MultipartFile): StaffDto
 }
 
 @Service
@@ -126,5 +127,17 @@ class StaffServiceImpl(
         }
 
         return list
+    }
+
+    @Transactional
+    override fun migrateStaffImage(staffId: Long, mainImage: MultipartFile): StaffDto {
+        val staff = staffRepository.findByIdOrNull(staffId)
+            ?: throw CserealException.Csereal404("해당 행정직원을 찾을 수 없습니다. staffId: $staffId")
+
+        mainImageService.uploadMainImage(staff, mainImage)
+
+        val imageURL = mainImageService.createImageURL(staff.mainImage)
+
+        return StaffDto.of(staff, imageURL)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/service/StaffService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/service/StaffService.kt
@@ -117,7 +117,9 @@ class StaffServiceImpl(
             }
 
             staff.memberSearch = MemberSearchEntity.create(staff)
+
             staffRepository.save(staff)
+
             list.add(StaffDto.of(staff, null))
         }
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/service/StaffService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/service/StaffService.kt
@@ -17,7 +17,7 @@ import org.springframework.web.multipart.MultipartFile
 interface StaffService {
     fun createStaff(createStaffRequest: StaffDto, mainImage: MultipartFile?): StaffDto
     fun getStaff(staffId: Long): StaffDto
-    fun getAllStaff(): List<SimpleStaffDto>
+    fun getAllStaff(language: String): List<SimpleStaffDto>
     fun updateStaff(staffId: Long, updateStaffRequest: StaffDto, mainImage: MultipartFile?): StaffDto
     fun deleteStaff(staffId: Long)
     fun migrateStaff(requestList: List<StaffDto>): List<StaffDto>
@@ -61,8 +61,10 @@ class StaffServiceImpl(
     }
 
     @Transactional(readOnly = true)
-    override fun getAllStaff(): List<SimpleStaffDto> {
-        return staffRepository.findAll().map {
+    override fun getAllStaff(language: String): List<SimpleStaffDto> {
+        val enumLanguageType = LanguageType.makeStringToLanguageType(language)
+
+        return staffRepository.findAllByLanguage(enumLanguageType).map {
             val imageURL = mainImageService.createImageURL(it.mainImage)
             SimpleStaffDto.of(it, imageURL)
         }.sortedBy { it.name }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/service/StaffService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/service/StaffService.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.csereal.core.member.service
 
 import com.wafflestudio.csereal.common.CserealException
+import com.wafflestudio.csereal.common.properties.LanguageType
 import com.wafflestudio.csereal.core.member.database.MemberSearchEntity
 import com.wafflestudio.csereal.core.member.database.StaffEntity
 import com.wafflestudio.csereal.core.member.database.StaffRepository
@@ -29,7 +30,8 @@ class StaffServiceImpl(
     private val mainImageService: MainImageService
 ) : StaffService {
     override fun createStaff(createStaffRequest: StaffDto, mainImage: MultipartFile?): StaffDto {
-        val staff = StaffEntity.of(createStaffRequest)
+        val enumLanguageType = LanguageType.makeStringToLanguageType(createStaffRequest.language)
+        val staff = StaffEntity.of(enumLanguageType, createStaffRequest)
 
         for (task in createStaffRequest.tasks) {
             TaskEntity.create(task, staff)
@@ -107,7 +109,8 @@ class StaffServiceImpl(
         val list = mutableListOf<StaffDto>()
 
         for (request in requestList) {
-            val staff = StaffEntity.of(request)
+            val enumLanguageType = LanguageType.makeStringToLanguageType(request.language)
+            val staff = StaffEntity.of(enumLanguageType, request)
 
             for (task in request.tasks) {
                 TaskEntity.create(task, staff)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/service/StaffService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/service/StaffService.kt
@@ -117,9 +117,7 @@ class StaffServiceImpl(
             }
 
             staff.memberSearch = MemberSearchEntity.create(staff)
-
             staffRepository.save(staff)
-
             list.add(StaffDto.of(staff, null))
         }
 


### PR DESCRIPTION
## 제목
feat: staff에 language, migration 방법 추가

### 한줄 요약
staff 패키지에 언어를 추가하고, migrateStaffImage을 추가하여 마이그레이션을 준비하였습니다

### 상세 설명

[e98e4ff44726e6e728738dd6ebe44b7a80981a86]: staffEntity에 language을 추가하여 한국어 영어 다 담도록 하였습니다.

[ff6baf258cab047f99aab8e23fd2cbe1b6cecea4][4f9ff8a4ddc0cc85ab0886039619b3d38738cc09]: 개인적인 실수가 있어서.. 여기랑은 상관없습니다!

[8b357277d9e97c0bf71cb73c7a22c405b04aa850]: staff를 읽을 때 language을 통해 구분할 수 있도록 하였습니다

[b4a7ee2a05ff91206abfd97f0b43d8745c56174c]: staff의 mainImage을 마이그레이션하는 방법을 도입했습니다. 마이그레이션 전에 이미지, 첨부파일을 올릴 때 이런 방식으로 올리려고 합니다.

### TODO
통과되면 스태프 마이그레이션 진행하겠습니다~
