### PR TITLE
fix: migrateConferences에서 authenticatedStaff 삭제

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/conference/api/ConferenceController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/conference/api/ConferenceController.kt
@@ -27,7 +27,6 @@ class ConferenceController(
         return ResponseEntity.ok(conferenceService.modifyConferences(conferenceModifyRequest))
     }
 
-    @AuthenticatedStaff
     @PostMapping("/migrate")
     fun migrateConferences(
         @RequestBody requestList: List<ConferenceDto>


### PR DESCRIPTION
## 제목
fix: migrateConferences에서 authenticatedStaff 삭제

### 한줄 요약

migrateConferences에서 authenticatedStaff 삭제

### 상세 설명

[02c8c5491fb5f6e8845b40e5974b5b4b7f665b6f]: Migrate에 불필요한 authenticatedStaff 삭제했습니다(다른 마이그레이션은 로그인 인증 안하고 있어서..)


