### PR TITLE
fix: 인증 로직 수정

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/common/mockauth/DevAuthController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/mockauth/DevAuthController.kt
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController
 
 //TODO: 정식 릴리즈 후에는 dev 서버에서만 가능하게
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/api/v1")
 class DevAuthController(
     private val authenticationManager: AuthenticationManager,
     private val userRepository: UserRepository,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
@@ -1,6 +1,8 @@
 package com.wafflestudio.csereal.core.notice.api
 
+import com.wafflestudio.csereal.common.CserealException
 import com.wafflestudio.csereal.common.aop.AuthenticatedStaff
+import com.wafflestudio.csereal.common.mockauth.CustomPrincipal
 import com.wafflestudio.csereal.core.notice.dto.*
 import com.wafflestudio.csereal.core.notice.service.NoticeService
 import com.wafflestudio.csereal.core.user.database.Role
@@ -12,7 +14,7 @@ import org.hibernate.validator.constraints.Length
 import org.springframework.data.domain.PageRequest
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.core.Authentication
 import org.springframework.security.oauth2.core.oidc.user.OidcUser
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
@@ -29,10 +31,16 @@ class NoticeController(
         @RequestParam(required = false) keyword: String?,
         @RequestParam(required = false) pageNum: Int?,
         @RequestParam(required = false, defaultValue = "20") pageSize: Int,
-        @AuthenticationPrincipal oidcUser: OidcUser?
+        authentication: Authentication?
     ): ResponseEntity<NoticeSearchResponse> {
-        val isStaff = oidcUser?.let {
-            val username = it.idToken.getClaim<String>("username")
+        val principal = authentication?.principal
+
+        val isStaff = principal?.let {
+            val username = when (principal) {
+                is OidcUser -> principal.idToken.getClaim("username")
+                is CustomPrincipal -> principal.userEntity.username
+                else -> throw CserealException.Csereal401("Unsupported principal type")
+            }
             val user = userRepository.findByUsername(username)
             user?.role == Role.ROLE_STAFF
         } ?: false

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/api/SeminarController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/api/SeminarController.kt
@@ -1,6 +1,8 @@
 package com.wafflestudio.csereal.core.seminar.api
 
+import com.wafflestudio.csereal.common.CserealException
 import com.wafflestudio.csereal.common.aop.AuthenticatedStaff
+import com.wafflestudio.csereal.common.mockauth.CustomPrincipal
 import com.wafflestudio.csereal.core.seminar.dto.SeminarDto
 import com.wafflestudio.csereal.core.seminar.dto.SeminarSearchResponse
 import com.wafflestudio.csereal.core.seminar.service.SeminarService
@@ -9,7 +11,7 @@ import com.wafflestudio.csereal.core.user.database.UserRepository
 import jakarta.validation.Valid
 import org.springframework.data.domain.PageRequest
 import org.springframework.http.ResponseEntity
-import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.security.core.Authentication
 import org.springframework.security.oauth2.core.oidc.user.OidcUser
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
@@ -25,10 +27,16 @@ class SeminarController(
         @RequestParam(required = false) keyword: String?,
         @RequestParam(required = false) pageNum: Int?,
         @RequestParam(required = false, defaultValue = "10") pageSize: Int,
-        @AuthenticationPrincipal oidcUser: OidcUser?
+        authentication: Authentication?
     ): ResponseEntity<SeminarSearchResponse> {
-        val isStaff = oidcUser?.let {
-            val username = it.idToken.getClaim<String>("username")
+        val principal = authentication?.principal
+
+        val isStaff = principal?.let {
+            val username = when (principal) {
+                is OidcUser -> principal.idToken.getClaim("username")
+                is CustomPrincipal -> principal.userEntity.username
+                else -> throw CserealException.Csereal401("Unsupported principal type")
+            }
             val user = userRepository.findByUsername(username)
             user?.role == Role.ROLE_STAFF
         } ?: false


### PR DESCRIPTION
## AuthenticationPrincipal 어노테이션 사용한 인증 로직 수정

### 한줄 요약

몇몇 컨트롤러에서 AuthenticationPrincipal 어노테이션을 이용해서 OidcUser를 바로 주입받는 방식을 사용했었는데, 로그인 모킹 이후 이 부분이 바이패스가 안돼서 Authentication 객체를 주입받고 principal 타입에 따라 로직을 분기 처리하도록 수정 하였습니다.