### PR TITLE
Fix: Notice 비밀글 표시 안되도록 수정

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
@@ -38,7 +38,7 @@ interface CustomNoticeRepository {
         isStaff: Boolean
     ): NoticeSearchResponse
 
-    fun totalSearchNotice(keyword: String, number: Int, stringLength: Int): NoticeTotalSearchResponse
+    fun totalSearchNotice(keyword: String, number: Int, stringLength: Int, isStaff: Boolean): NoticeTotalSearchResponse
 }
 
 @Component
@@ -49,7 +49,8 @@ class NoticeRepositoryImpl(
     override fun totalSearchNotice(
         keyword: String,
         number: Int,
-        stringLength: Int
+        stringLength: Int,
+        isStaff: Boolean
     ): NoticeTotalSearchResponse {
         val doubleTemplate = commonRepository.searchFullDoubleTextTemplate(
             keyword,
@@ -57,13 +58,15 @@ class NoticeRepositoryImpl(
             noticeEntity.plainTextDescription
         )
 
+        val privateBoolean = noticeEntity.isPrivate.eq(false).takeUnless { isStaff }
+
         val query = queryFactory.select(
             noticeEntity.id,
             noticeEntity.title,
             noticeEntity.createdAt,
             noticeEntity.plainTextDescription
         ).from(noticeEntity)
-            .where(doubleTemplate.gt(0.0))
+            .where(doubleTemplate.gt(0.0), privateBoolean)
 
         val total = query.clone().select(noticeEntity.countDistinct()).fetchOne()!!
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Component
 import java.time.LocalDateTime
 
 interface NoticeRepository : JpaRepository<NoticeEntity, Long>, CustomNoticeRepository {
+    fun findByIdAndIsPrivateFalse(id: Long): NoticeEntity?
     fun findAllByIsPrivateFalseAndIsImportantTrueAndIsDeletedFalse(): List<NoticeEntity>
     fun findAllByIsImportantTrueAndIsDeletedFalse(): List<NoticeEntity>
     fun findFirstByIsDeletedFalseAndIsPrivateFalseAndCreatedAtLessThanOrderByCreatedAtDesc(

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
@@ -23,9 +23,9 @@ interface NoticeService {
         isStaff: Boolean
     ): NoticeSearchResponse
 
-    fun searchTotalNotice(keyword: String, number: Int, stringLength: Int): NoticeTotalSearchResponse
+    fun searchTotalNotice(keyword: String, number: Int, stringLength: Int, isStaff: Boolean): NoticeTotalSearchResponse
 
-    fun readNotice(noticeId: Long): NoticeDto
+    fun readNotice(noticeId: Long, isStaff: Boolean): NoticeDto
     fun createNotice(request: NoticeDto, attachments: List<MultipartFile>?): NoticeDto
     fun updateNotice(
         noticeId: Long,
@@ -62,13 +62,17 @@ class NoticeServiceImpl(
     override fun searchTotalNotice(
         keyword: String,
         number: Int,
-        stringLength: Int
-    ) = noticeRepository.totalSearchNotice(keyword, number, stringLength)
+        stringLength: Int,
+        isStaff: Boolean
+    ) = noticeRepository.totalSearchNotice(keyword, number, stringLength, isStaff)
 
     @Transactional(readOnly = true)
-    override fun readNotice(noticeId: Long): NoticeDto {
-        val notice = noticeRepository.findByIdOrNull(noticeId)
-            ?: throw CserealException.Csereal404("존재하지 않는 공지사항입니다.(noticeId: $noticeId)")
+    override fun readNotice(noticeId: Long, isStaff: Boolean): NoticeDto {
+        val notice = if (isStaff) {
+            noticeRepository.findByIdOrNull(noticeId)
+        } else {
+            noticeRepository.findByIdAndIsPrivateFalse(noticeId)
+        } ?: throw CserealException.Csereal404("존재하지 않는 공지사항입니다.(noticeId: $noticeId)")
 
         if (notice.isDeleted) throw CserealException.Csereal404("삭제된 공지사항입니다.(noticeId: $noticeId)")
 


### PR DESCRIPTION
## Fix: Notice 비밀글 표시 안되도록 수정

### totalSearch와 read에서 staff가 아니어도 private 글을 보여주는 것을 수정하였습니다.

### 상세 설명
61fe801 Feat: Add FindByIdAndIsPrivateFalse
eee190a Fix: Change totalSearchNotice to get isStaff and hide private when not a staff.
1dc88d8 Fix: Change searchTotalNotice and readNotice to consider isStaff.
2562079 Fix: Change totalSearchNotice and readNotice to check authentication and get staff info.

