### PR TITLE
Feat: Research 검색 결과 research 타입 상세화

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/api/res/ResearchSearchResElement.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/api/res/ResearchSearchResElement.kt
@@ -39,7 +39,6 @@ data class ResearchSearchResElement(
                         researchType = when (it.postType) {
                             ResearchPostType.GROUPS -> ResearchSearchType.RESEARCH_GROUP
                             ResearchPostType.CENTERS -> ResearchSearchType.RESEARCH_CENTER
-                            ResearchPostType.LABS -> ResearchSearchType.RESEARCH_LAB
                         },
                         partialDescription = partialDesc,
                         boldStartIdx = startIdx ?: 0,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/api/res/ResearchSearchResElement.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/api/res/ResearchSearchResElement.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.csereal.core.research.api.res
 import com.wafflestudio.csereal.common.CserealException
 import com.wafflestudio.csereal.common.properties.LanguageType
 import com.wafflestudio.csereal.common.utils.substringAroundKeyword
+import com.wafflestudio.csereal.core.research.database.ResearchPostType
 import com.wafflestudio.csereal.core.research.database.ResearchSearchEntity
 import com.wafflestudio.csereal.core.research.database.ResearchSearchType
 
@@ -35,7 +36,11 @@ data class ResearchSearchResElement(
                         id = it.id,
                         name = it.name,
                         language = it.language.let { ln -> LanguageType.makeLowercase(ln) },
-                        researchType = ResearchSearchType.RESEARCH,
+                        researchType = when (it.postType) {
+                            ResearchPostType.GROUPS -> ResearchSearchType.RESEARCH_GROUP
+                            ResearchPostType.CENTERS -> ResearchSearchType.RESEARCH_CENTER
+                            ResearchPostType.LABS -> ResearchSearchType.RESEARCH_LAB
+                        },
                         partialDescription = partialDesc,
                         boldStartIdx = startIdx ?: 0,
                         boldEndIdx = startIdx?.plus(keyword.length) ?: 0

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/database/ResearchPostType.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/database/ResearchPostType.kt
@@ -5,5 +5,5 @@ enum class ResearchPostType(
 ) {
     GROUPS("연구 그룹"),
     CENTERS("연구 센터"),
-    LABS("연구실 목록");
+    LABS("연구실 목록"); // TODO: Remove LABS if not used
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/database/ResearchPostType.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/database/ResearchPostType.kt
@@ -4,6 +4,5 @@ enum class ResearchPostType(
     val krName: String
 ) {
     GROUPS("연구 그룹"),
-    CENTERS("연구 센터"),
-    LABS("연구실 목록"); // TODO: Remove LABS if not used
+    CENTERS("연구 센터");
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/database/ResearchSearchEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/database/ResearchSearchEntity.kt
@@ -111,7 +111,6 @@ class ResearchSearchEntity(
 enum class ResearchSearchType {
     RESEARCH_GROUP,
     RESEARCH_CENTER,
-    RESEARCH_LAB, // TODO: Remove REMOVE_LAB if not used
     LAB,
     CONFERENCE;
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/database/ResearchSearchEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/database/ResearchSearchEntity.kt
@@ -95,17 +95,6 @@ class ResearchSearchEntity(
         }
     }
 
-    fun ofType(): ResearchSearchType {
-        return when {
-            research != null && lab == null && conferenceElement == null -> ResearchSearchType.RESEARCH
-            research == null && lab != null && conferenceElement == null -> ResearchSearchType.LAB
-            research == null && lab == null && conferenceElement != null -> ResearchSearchType.CONFERENCE
-            else -> throw RuntimeException(
-                "ResearchSearchEntity must have either research or lab or conference"
-            )
-        }
-    }
-
     fun update(research: ResearchEntity) {
         this.content = createContent(research)
     }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/database/ResearchSearchEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/database/ResearchSearchEntity.kt
@@ -109,7 +109,9 @@ class ResearchSearchEntity(
 }
 
 enum class ResearchSearchType {
-    RESEARCH,
+    RESEARCH_GROUP,
+    RESEARCH_CENTER,
+    RESEARCH_LAB, // TODO: Remove REMOVE_LAB if not used
     LAB,
     CONFERENCE;
 }

--- a/src/test/kotlin/com/wafflestudio/csereal/core/member/service/ProfessorServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/member/service/ProfessorServiceTest.kt
@@ -42,7 +42,7 @@ class ProfessorServiceTest(
             name = "researchName",
             description = null,
             websiteURL = null,
-            postType = ResearchPostType.LABS
+            postType = ResearchPostType.GROUPS
         )
         var labEntity = LabEntity(
             language = LanguageType.KO,
@@ -145,7 +145,7 @@ class ProfessorServiceTest(
             name = "researchName",
             description = null,
             websiteURL = null,
-            postType = ResearchPostType.LABS
+            postType = ResearchPostType.GROUPS
         )
         val labEntity1 = LabEntity(
             language = LanguageType.KO,


### PR DESCRIPTION
## Feat: Research 검색 결과 research 타입 상세화

### 한줄 요약

- RESEARCH를 RESEARCH_CENTER, RESEARCH_GROUP, RESEARCH_LAB으로 세부화하였습니다.
- 사용하지 않는 LAB 관련 코드를 제거하였습니다.

### 상세 설명

2608d03 Refactor: Remove unused method
66eecef Comment: Add comment
70e6385 Feat: Add specific research types to enum
3f7d0b4 Feat: Change to give more specified enum when it is research related column.
[0527a99](https://github.com/wafflestudio/csereal-server/pull/218/commits/0527a998bd4b5fb6a497f0669f8cefa8d75ceb44) [Refactor: Remove unused LAB entry from Research.](https://github.com/wafflestudio/csereal-server/pull/218/commits/0527a998bd4b5fb6a497f0669f8cefa8d75ceb44)
