### PR TITLE
fix: pdf 타입 AttachmentResponse로 변경

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/dto/LabDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/dto/LabDto.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.csereal.core.research.dto
 
 import com.wafflestudio.csereal.common.properties.LanguageType
 import com.wafflestudio.csereal.core.research.database.LabEntity
+import com.wafflestudio.csereal.core.resource.attachment.dto.AttachmentResponse
 
 data class LabDto(
     val id: Long,
@@ -11,14 +12,14 @@ data class LabDto(
     val location: String?,
     val tel: String?,
     val acronym: String?,
-    val pdf: String?,
+    val pdf: AttachmentResponse?,
     val youtube: String?,
     val group: String,
     val description: String?,
     val websiteURL: String?
 ) {
     companion object {
-        fun of(entity: LabEntity, pdfURL: String): LabDto = entity.run {
+        fun of(entity: LabEntity, pdf: AttachmentResponse?): LabDto = entity.run {
             LabDto(
                 id = this.id,
                 language = LanguageType.makeLowercase(entity.language),
@@ -27,7 +28,7 @@ data class LabDto(
                 location = this.location,
                 tel = this.tel,
                 acronym = this.acronym,
-                pdf = pdfURL,
+                pdf = pdf,
                 youtube = this.youtube,
                 group = this.research.name,
                 description = this.description,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/service/AttachmentService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/service/AttachmentService.kt
@@ -33,7 +33,7 @@ interface AttachmentService {
         contentEntityType: AttachmentContentEntityType,
         requestAttachments: List<MultipartFile>
     ): List<AttachmentDto>
-
+    fun createOneAttachmentResponse(attachment: AttachmentEntity?): AttachmentResponse?
     fun createAttachmentResponses(attachments: List<AttachmentEntity>?): List<AttachmentResponse>
 
     fun deleteAttachments(ids: List<Long>?)
@@ -109,6 +109,23 @@ class AttachmentServiceImpl(
             )
         }
         return attachmentsList
+    }
+
+    @Transactional
+    override fun createOneAttachmentResponse(attachment: AttachmentEntity?): AttachmentResponse? {
+        var attachmentDto: AttachmentResponse? = null
+        if (attachment != null) {
+            if (attachment.isDeleted == false) {
+                attachmentDto = AttachmentResponse(
+                    id = attachment.id,
+                    name = attachment.filename.substringAfter("_"),
+                    url = "${endpointProperties.backend}/v1/file/${attachment.filename}",
+                    bytes = attachment.size
+                )
+            }
+        }
+
+        return attachmentDto
     }
 
     @Transactional


### PR DESCRIPTION
## 제목
fix: pdf 타입 AttachmentResponse로 변경

### 한줄 요약
pdf 타입 AttachmentResponse로 변경

### 상세 설명

[bf154df3b8d6b6168c1347fbc0e9c04c64fdf4a9]: 엔티티의 pdf는 그대로 놔두고, dto의 pdf를 attachmentResponse 타입으로 바꿨습니다

### TODO
