### PR TITLE
Config: Spring Boot 3.2, Java 21로 업그레이드, Virtual Thread 적용

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -20,8 +20,8 @@ jobs:
       - name: Setup Java JDK
         uses: actions/setup-java@v3.12.0
         with:
-          java-version: '17'
-          distribution: 'adopt'
+          java-version: '21'
+          distribution: 'temurin'
 
       - name: Build with Gradle
         run: ./gradlew clean build -x test

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,8 +28,8 @@ jobs:
             -   name: Setup Java JDK
                 uses: actions/setup-java@v3.12.0
                 with:
-                    java-version: '17'
-                    distribution: 'adopt'
+                    java-version: '21'
+                    distribution: 'temurin'
 
             -   run: ./gradlew clean bootJar -x test
 

--- a/.github/workflows/ktlint-check.yml
+++ b/.github/workflows/ktlint-check.yml
@@ -14,7 +14,8 @@ jobs:
             -   name: Set up JDK
                 uses: actions/setup-java@v1
                 with:
-                    java-version: 17
+                    java-version: 21
+                    distribution: 'temurin'
             -   name: Grant execute permission for gradlew
                 run: chmod +x gradlew
             -   name: ktlintCheck with Gradle

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-slim
+FROM openjdk:21-slim
 
 # Set profile
 ARG PROFILE

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     kotlin("plugin.spring") version "1.9.22"
     kotlin("plugin.jpa") version "1.9.22"
     kotlin("kapt") version "1.9.22"
-    id("org.jlleitschuh.gradle.ktlint") version "12.1.0"
+    id("org.jlleitschuh.gradle.ktlint") version "11.6.0"
 }
 
 group = "com.wafflestudio"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,20 +1,20 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id("org.springframework.boot") version "3.0.8"
-    id("io.spring.dependency-management") version "1.1.0"
-    kotlin("jvm") version "1.7.22"
-    kotlin("plugin.spring") version "1.7.22"
-    kotlin("plugin.jpa") version "1.7.22"
-    kotlin("kapt") version "1.7.10"
-    id("org.jlleitschuh.gradle.ktlint") version "11.6.0"
+    id("org.springframework.boot") version "3.2.3"
+    id("io.spring.dependency-management") version "1.1.4"
+    kotlin("jvm") version "1.9.22"
+    kotlin("plugin.spring") version "1.9.22"
+    kotlin("plugin.jpa") version "1.9.22"
+    kotlin("kapt") version "1.9.22"
+    id("org.jlleitschuh.gradle.ktlint") version "12.1.0"
 }
 
 group = "com.wafflestudio"
 version = "0.0.1-SNAPSHOT"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
 }
 
 repositories {
@@ -29,33 +29,33 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
-    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.4.0")
     runtimeOnly("com.mysql:mysql-connector-j")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-test")
 
     // kotest
-    testImplementation("io.kotest:kotest-runner-junit5-jvm:5.7.1")
-    testImplementation("io.kotest:kotest-assertions-core-jvm:5.7.1")
-    testImplementation("io.kotest:kotest-property-jvm:5.7.1")
+    testImplementation("io.kotest:kotest-runner-junit5-jvm:5.8.1")
+    testImplementation("io.kotest:kotest-assertions-core-jvm:5.8.1")
+    testImplementation("io.kotest:kotest-property-jvm:5.8.1")
     implementation("io.kotest.extensions:kotest-extensions-spring:1.1.3")
 
     // mockk
-    testImplementation("io.mockk:mockk:1.13.7")
+    testImplementation("io.mockk:mockk:1.13.10")
     testImplementation("com.ninja-squad:springmockk:4.0.2")
 
     // h2 database
     implementation("org.springframework.boot:spring-boot-starter-jdbc")
     testImplementation("com.h2database:h2")
 
-    //queryDsl
-    implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
-    kapt("com.querydsl:querydsl-apt:5.0.0:jakarta")
+    // queryDsl
+    implementation("com.querydsl:querydsl-jpa:5.1.0:jakarta")
+    kapt("com.querydsl:querydsl-apt:5.1.0:jakarta")
     kapt("jakarta.annotation:jakarta.annotation-api")
     kapt("jakarta.persistence:jakarta.persistence-api")
 
     // 태그 제거
-    implementation("org.jsoup:jsoup:1.15.4")
+    implementation("org.jsoup:jsoup:1.17.2")
 
     // 이미지 업로드
     implementation("commons-io:commons-io:2.11.0")
@@ -85,7 +85,7 @@ apply {
 tasks.withType<KotlinCompile> {
     kotlinOptions {
         freeCompilerArgs += "-Xjsr305=strict"
-        jvmTarget = "17"
+        jvmTarget = "21"
     }
 }
 

--- a/src/main/kotlin/com/wafflestudio/csereal/common/config/MySQLDialectCustom.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/config/MySQLDialectCustom.kt
@@ -1,18 +1,18 @@
 package com.wafflestudio.csereal.common.config
 
+import org.hibernate.boot.model.FunctionContributions
 import org.hibernate.dialect.DatabaseVersion
 import org.hibernate.dialect.MySQLDialect
-import org.hibernate.query.spi.QueryEngine
 import org.hibernate.type.StandardBasicTypes
 
 class MySQLDialectCustom : MySQLDialect(
     DatabaseVersion.make(8)
 ) {
-    override fun initializeFunctionRegistry(queryEngine: QueryEngine?) {
-        super.initializeFunctionRegistry(queryEngine)
+    override fun initializeFunctionRegistry(functionContributions: FunctionContributions?) {
+        super.initializeFunctionRegistry(functionContributions)
 
-        val basicTypeRegistry = queryEngine?.typeConfiguration?.basicTypeRegistry
-        val functionRegistry = queryEngine?.sqmFunctionRegistry
+        val basicTypeRegistry = functionContributions?.typeConfiguration?.basicTypeRegistry
+        val functionRegistry = functionContributions?.functionRegistry
 
         if (basicTypeRegistry != null && functionRegistry != null) {
             functionRegistry.registerPattern(

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,7 +1,7 @@
 spring:
     threads:
         virtual:
-            enabled: true
+            enabled: false
     profiles:
         active: local
     datasource:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,4 +1,7 @@
 spring:
+    threads:
+        virtual:
+            enabled: true
     profiles:
         active: local
     datasource:


### PR DESCRIPTION
## Config: Spring Boot 3.2, Java 21로 업그레이드, Virtual Thread 적용

### 상세 설명
- Spring Boot 3.2, Java 21로 업그레이드하였습니다.
- **Java Virtual Thread**를 사용하도록 하였습니다.
    - 위 설정을 적용하기 위해서 업그레이드 하였습니다.
    간단하게 보자면 기존의 os 스레드와의 1:1 매칭 대신 many to many로 경량화 스레드와 매칭되도록 하여 context switch 비용을 줄이는 기술입니다.
    - 근데 로컬에서 간단하게 테스트했을때는 속도만 봤을때는 오히려 살짝 느린거 같긴 해서 적용할지 고민되긴 합니다... 이부분 피드백 부탁드립니다.
    - 참고링크: https://spring.io/blog/2022/10/11/embracing-virtual-threads#will-your-application-benefit-from-virtual-threads

### 커밋
4ac8a79 Config: Update spring boot to 3.2
d9fb33c Config: Change docker jdk version to 21
5562281 Config: Revert ktlint version.
37ce54b Fix: Update deprecated method.
37fb303 COnfig: Update jdk as 21
037d74b Config: Enable java virtual thread.
