### PR TITLE
Hotfix: 누락된 Slack 정보 compose 파일에 추가.

### DIFF
--- a/docker-compose-backend.yml
+++ b/docker-compose-backend.yml
@@ -17,6 +17,8 @@ services:
             SPRING_DATASOURCE_PASSWORD: ${MYSQL_PASSWORD}
             OIDC_CLIENT_SECRET: ${OIDC_CLIENT_SECRET}
             URL: ${URL}
+            SLACK_TOKEN: ${SLACK_TOKEN}
+            SLACK_CHANNEL: ${SLACK_CHANNEL}
         extra_hosts:
             - host.docker.internal:host-gateway
         restart: always


### PR DESCRIPTION
## Hotfix: 누락된 Slack 정보 compose 파일에 추가.

### 한줄 요약
`docker-compose-backend.yml`에 slack 정보가 environment에 누락되어 spring boot이 정상적으로 실행되지 못하고 있어 이를 수정.