### PR TITLE
Feat: 게시물 제외 통합검색에 사용되는 field들 refersh하는 API 추가

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/service/AboutService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/service/AboutService.kt
@@ -6,8 +6,10 @@ import com.wafflestudio.csereal.core.about.api.res.AboutSearchElementDto
 import com.wafflestudio.csereal.core.about.api.res.AboutSearchResBody
 import com.wafflestudio.csereal.core.about.database.*
 import com.wafflestudio.csereal.core.about.dto.*
+import com.wafflestudio.csereal.core.main.event.RefreshSearchEvent
 import com.wafflestudio.csereal.core.resource.attachment.service.AttachmentService
 import com.wafflestudio.csereal.core.resource.mainImage.service.MainImageService
+import org.springframework.context.event.EventListener
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -183,6 +185,14 @@ class AboutServiceImpl(
             FutureCareersCompanyDto.of(it)
         }
         return FutureCareersPage(description, statList, companyList)
+    }
+
+    @Transactional
+    @EventListener
+    fun refreshSearchEventListener(event: RefreshSearchEvent) {
+        aboutRepository.findAll().forEach {
+            syncSearchOfAbout(it)
+        }
     }
 
     @Transactional

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/service/AboutService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/service/AboutService.kt
@@ -12,6 +12,7 @@ import com.wafflestudio.csereal.core.resource.mainImage.service.MainImageService
 import org.springframework.context.event.EventListener
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
 
@@ -187,9 +188,9 @@ class AboutServiceImpl(
         return FutureCareersPage(description, statList, companyList)
     }
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @EventListener
-    fun refreshSearchEventListener(event: RefreshSearchEvent) {
+    fun refreshSearchListener(event: RefreshSearchEvent) {
         aboutRepository.findAll().forEach {
             syncSearchOfAbout(it)
         }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/api/MainController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/api/MainController.kt
@@ -15,4 +15,9 @@ class MainController(
     fun readMain(): MainResponse {
         return mainService.readMain()
     }
+
+    @GetMapping("/search/refresh")
+    fun refreshSearches() {
+        mainService.refreshSearch()
+    }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/event/RefreshSearchEvent.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/event/RefreshSearchEvent.kt
@@ -1,0 +1,3 @@
+package com.wafflestudio.csereal.core.main.event
+
+class RefreshSearchEvent

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/service/MainService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/service/MainService.kt
@@ -3,17 +3,21 @@ package com.wafflestudio.csereal.core.main.service
 import com.wafflestudio.csereal.core.main.database.MainRepository
 import com.wafflestudio.csereal.core.main.dto.MainResponse
 import com.wafflestudio.csereal.core.main.dto.NoticesResponse
+import com.wafflestudio.csereal.core.main.event.RefreshSearchEvent
 import com.wafflestudio.csereal.core.notice.database.TagInNoticeEnum
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 interface MainService {
     fun readMain(): MainResponse
+    fun refreshSearch()
 }
 
 @Service
 class MainServiceImpl(
-    private val mainRepository: MainRepository
+    private val mainRepository: MainRepository,
+    private val eventPublisher: ApplicationEventPublisher
 ) : MainService {
     @Transactional(readOnly = true)
     override fun readMain(): MainResponse {
@@ -28,5 +32,9 @@ class MainServiceImpl(
         val importants = mainRepository.readMainImportant()
 
         return MainResponse(slides, notices, importants)
+    }
+
+    override fun refreshSearch() {
+        eventPublisher.publishEvent(RefreshSearchEvent())
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/service/ProfessorService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/service/ProfessorService.kt
@@ -122,7 +122,7 @@ class ProfessorServiceImpl(
                         else -> a.name.compareTo(b.name)
                     }
                 }
-                
+
         return ProfessorPageDto(description, professors)
     }
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/service/ProfessorService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/service/ProfessorService.kt
@@ -94,6 +94,8 @@ class ProfessorServiceImpl(
     @Transactional(readOnly = true)
     override fun getActiveProfessors(language: String): ProfessorPageDto {
         val enumLanguageType = LanguageType.makeStringToLanguageType(language)
+
+        // TODO: Refactor to save in database
         val description = "컴퓨터공학부는 35명의 훌륭한 교수진과 최신 시설을 갖추고 400여 명의 학부생과 " +
             "350여 명의 대학원생에게 세계 최고 수준의 교육 연구 환경을 제공하고 있다. 2005년에는 서울대학교 " +
             "최초로 외국인 정교수인 Robert Ian McKay 교수를 임용한 것을 시작으로 교내에서 가장 국제화가 " +
@@ -102,6 +104,7 @@ class ProfessorServiceImpl(
             " 학기 전공 필수 과목을 비롯한 30% 이상의 과목이 영어로 개설되고 있어 외국인 학생의 학업을 돕는 " +
             "동시에 한국인 학생이 세계로 진출하는 초석이 되고 있다. 또한 CSE int’l Luncheon을 개최하여 " +
             "학부 내 외국인 구성원의 화합과 생활의 불편함을 최소화하는 등 학부 차원에서 최선을 다하고 있다."
+
         val professors =
             professorRepository.findByLanguageAndStatusNot(
                 enumLanguageType,
@@ -111,6 +114,7 @@ class ProfessorServiceImpl(
                 SimpleProfessorDto.of(it, imageURL)
             }
                 .sortedBy { it.name }
+
         return ProfessorPageDto(description, professors)
     }
 


### PR DESCRIPTION
## Feat: 게시물 제외 통합검색에 사용되는 field들 refersh하는 API 추가

### 한줄 요약
- 현재 많은 요구사항과 CUD API의 부재로 인하여 db에 직접적으로 페이지를 수정하는 일이 많음.
- 원래는 CUD API를 사용하여 검색에 사용되는 field까지 적절히 update되어야 하지만 불가능한 상황
- 따라서 게시물 (notice, news, seminar)를 제외한 통합 검색에 사용되는 모든 검색 field를 update해주는 API 추가
`http GET /api/v1/search/refresh`

### 상세 설명

d90800c Feat: Add refresh search event
b6ad1ea Feat: Add api for trigger refresh search indexes.
f6d2548 Feat: Add refresh search event listener for about entity.
252d0cd Feat: Add refresh search event listener for academics entity.
d1fba44 Feat: Add refresh search event listener for admission entity.
550369d Feat: Add refresh search event listener for member entity.
653a376 Feat: Add refresh search event listener for research entity.
