### PR TITLE
CICD: 배포, 개발계 분리 적용

### DIFF
--- a/.github/workflows/database.yaml
+++ b/.github/workflows/database.yaml
@@ -33,6 +33,7 @@ jobs:
         with:
           host: ${{secrets.SSH_HOST}}
           username: ${{secrets.SSH_USER}}
+          port: ${{secrets.SSH_PORT}}
           key: ${{secrets.SSH_KEY}}
           source: "docker-compose-db.yml, .env"
           target: "~/app"
@@ -44,6 +45,7 @@ jobs:
         with:
           host: ${{secrets.SSH_HOST}}
           username: ${{secrets.SSH_USER}}
+          port: ${{secrets.SSH_PORT}}
           key: ${{secrets.SSH_KEY}}
           script: |
             cd ~/app

--- a/.github/workflows/database_dev.yaml
+++ b/.github/workflows/database_dev.yaml
@@ -1,0 +1,52 @@
+on:
+  push:
+    branches:
+      - develop
+    paths:
+        - docker-compose-db.yml
+        - db_config/*
+        - .github/workflows/database.yaml
+
+jobs:
+  database-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+
+      -
+        name: Create .env file
+        run: |
+          echo "MYSQL_ROOT_PASSWORD=${{secrets.MYSQL_ROOT_PASSWORD}}" > .env
+          echo "MYSQL_USER=${{secrets.MYSQL_USER}}" >> .env
+          echo "MYSQL_PASSWORD=${{secrets.MYSQL_PASSWORD}}" >> .env
+          echo "MYSQL_DATABASE=${{secrets.MYSQL_DATABASE}}" >> .env
+
+      -
+        name: SCP Command to Transfer Files
+        uses: appleboy/scp-action@v0.1.4
+        with:
+          host: ${{secrets.SSH_HOST_DEV}}
+          username: ${{secrets.SSH_USER}}
+          key: ${{secrets.SSH_KEY}}
+          source: "docker-compose-db.yml, .env"
+          target: "~/app"
+          overwrite: true
+
+      -
+        name: SSH Remote Commands
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{secrets.SSH_HOST_DEV}}
+          username: ${{secrets.SSH_USER}}
+          key: ${{secrets.SSH_KEY}}
+          script: |
+            cd ~/app
+            source .env
+            docker-compose -f docker-compose-db.yml down
+            docker-compose -f docker-compose-db.yml up -d

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -68,6 +68,7 @@ jobs:
                 with:
                     host: ${{secrets.SSH_HOST}}
                     username: ${{secrets.SSH_USER}}
+                    port: ${{secrets.SSH_PORT}}
                     key: ${{secrets.SSH_KEY}}
                     source: "docker-compose-backend.yml, .env"
                     target: "~/app"
@@ -77,6 +78,7 @@ jobs:
                 with:
                     host: ${{secrets.SSH_HOST}}
                     username: ${{secrets.SSH_USER}}
+                    port: ${{secrets.SSH_PORT}}
                     key: ${{secrets.SSH_KEY}}
                     script: |
                         cd ~/app

--- a/.github/workflows/deploy_dev.yaml
+++ b/.github/workflows/deploy_dev.yaml
@@ -1,7 +1,7 @@
 on:
     push:
         branches:
-            - main
+            - develop
         paths:
             - docker-compose-backend.yml
             - Dockerfile
@@ -57,16 +57,16 @@ jobs:
                     echo "MYSQL_USER=${{secrets.MYSQL_USER}}" >> .env
                     echo "MYSQL_PASSWORD=${{secrets.MYSQL_PASSWORD}}" >> .env
                     echo "MYSQL_DATABASE=${{secrets.MYSQL_DATABASE}}" >> .env
-                    echo "PROFILE=prod" >> .env
+                    echo "PROFILE=dev" >> .env
                     echo "OIDC_CLIENT_SECRET=${{secrets.OIDC_CLIENT_SECRET}}" >> .env
-                    echo "URL=${{secrets.URL}}" >> .env
-                    echo "SLACK_TOKEN=${{secrets.SLACK_TOKEN}}" >> .env
-                    echo "SLACK_CHANNEL=${{secrets.SLACK_CHANNEL}}" >> .env
+                    echo "URL=${{secrets.URL_DEV}}" >> .env
+                    # echo "SLACK_TOKEN=${{secrets.SLACK_TOKEN}}" >> .env
+                    # echo "SLACK_CHANNEL=${{secrets.SLACK_CHANNEL}}" >> .env
 
             -   name: SCP Command to Transfer Files
                 uses: appleboy/scp-action@v0.1.4
                 with:
-                    host: ${{secrets.SSH_HOST}}
+                    host: ${{secrets.SSH_HOST_DEV}}
                     username: ${{secrets.SSH_USER}}
                     key: ${{secrets.SSH_KEY}}
                     source: "docker-compose-backend.yml, .env"
@@ -75,10 +75,10 @@ jobs:
             -   name: SSH Remote Commands
                 uses: appleboy/ssh-action@v1.0.0
                 with:
-                    host: ${{secrets.SSH_HOST}}
+                    host: ${{secrets.SSH_HOST_DEV}}
                     username: ${{secrets.SSH_USER}}
                     key: ${{secrets.SSH_KEY}}
-                    script: |
+                    script: | 
                         cd ~/app
                         source .env
                         docker-compose -f docker-compose-backend.yml down

--- a/.github/workflows/proxy.yaml
+++ b/.github/workflows/proxy.yaml
@@ -28,6 +28,7 @@ jobs:
         with:
           host: ${{secrets.SSH_HOST}}
           username: ${{secrets.SSH_USER}}
+          port: ${{secrets.SSH_PORT}}
           key: ${{secrets.SSH_KEY}}
           source: "docker-compose-caddy.yml, .env, caddy/Caddyfile"
           target: "~/proxy"
@@ -39,6 +40,7 @@ jobs:
         with:
           host: ${{secrets.SSH_HOST}}
           username: ${{secrets.SSH_USER}}
+          port: ${{secrets.SSH_PORT}}
           key: ${{secrets.SSH_KEY}}
           script: |
             cd ~/proxy

--- a/.github/workflows/proxy_dev.yaml
+++ b/.github/workflows/proxy_dev.yaml
@@ -1,0 +1,47 @@
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - docker-compose-caddy.yml
+      - caddy/Caddyfile
+      - .github/workflows/proxy.yaml
+
+jobs:
+  proxy-initialize:
+    runs-on: ubuntu-latest
+
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+
+      -
+        name: Create .env file
+        run: |
+          echo "URL=${{secrets.URL_DEV}}" > .env
+          echo "LOCAL_IP=${{secrets.LOCAL_IP_DEV}}" >> .env
+
+      -
+        name: SCP Command to Transfer Files
+        uses: appleboy/scp-action@v0.1.4
+        with:
+          host: ${{secrets.SSH_HOST_DEV}}
+          username: ${{secrets.SSH_USER}}
+          key: ${{secrets.SSH_KEY}}
+          source: "docker-compose-caddy.yml, .env, caddy/Caddyfile"
+          target: "~/proxy"
+          overwrite: true
+
+      -
+        name: SSH Command to Run Docker Compose
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{secrets.SSH_HOST_DEV}}
+          username: ${{secrets.SSH_USER}}
+          key: ${{secrets.SSH_KEY}}
+          script: |
+            cd ~/proxy
+            source .env
+            docker-compose -f docker-compose-caddy.yml down
+            docker-compose -f docker-compose-caddy.yml up -d

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -9,15 +9,15 @@
 	abort @backend_denied
 
 	# Backend
-	reverse_proxy /api/* host.docker.internal:8080 #host.docker.internal:8081 # For blue/green
+	reverse_proxy /api/* host.docker.internal:8080
 
 	# Old file serving
-	reverse_proxy /sites/default/files/* host.docker.internal:8080 #host.docker.internal:8081 # For blue/green
+	reverse_proxy /sites/default/files/* host.docker.internal:8080
 
     # Login
-    reverse_proxy /oauth2/authorization/idsnucse host.docker.internal:8080 #host.docker.internal:8081 # For blue/green
+    reverse_proxy /oauth2/authorization/idsnucse host.docker.internal:8080 
 
 	# Swagger
-	reverse_proxy /swagger-ui/* host.docker.internal:8080 #host.docker.internal:8081 # For blue/green
-	reverse_proxy /api-docs/* host.docker.internal:8080 #host.docker.internal:8081 # For blue/green
+	reverse_proxy /swagger-ui/* host.docker.internal:8080 
+	reverse_proxy /api-docs/* host.docker.internal:8080 
 }

--- a/docker-compose-backend.yml
+++ b/docker-compose-backend.yml
@@ -23,25 +23,3 @@ services:
             - host.docker.internal:host-gateway
         restart: always
         image: ghcr.io/wafflestudio/csereal-server/server_image:latest
-    # TODO: Activate after implementing health check
-#  blue:
-#    container_name: csereal_server_blue
-#    build:
-#      context: ./
-#      args:
-#        PROFILE: ${PROFILE}
-#    ports:
-#      - 8081:8080
-#    volumes:
-#      - ./cse-files:/app/cse-files
-#      - ./attachment:/app/attachment
-#    environment:
-#      SPRING_DATASOURCE_URL: "jdbc:mysql://host.docker.internal:3306/${MYSQL_DATABASE}?serverTimezone=Asia/Seoul&useSSL=false&allowPublicKeyRetrieval=true"
-#      SPRING_DATASOURCE_USERNAME: ${MYSQL_USER}
-#      SPRING_DATASOURCE_PASSWORD: ${MYSQL_PASSWORD}
-#      OIDC_CLIENT_SECRET_DEV: ${OIDC_CLIENT_SECRET_DEV}
-#      URL: ${URL}
-#    extra_hosts:
-#      - host.docker.internal:host-gateway
-#    restart: always
-#    image: ghcr.io/wafflestudio/csereal-server/server_image:latest

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,6 +6,10 @@ spring:
         active: local
     datasource:
         driver-class-name: com.mysql.cj.jdbc.Driver
+    jpa:
+        properties:
+            hibernate:
+                dialect: com.wafflestudio.csereal.common.config.MySQLDialectCustom
     servlet:
         multipart:
             enabled: true
@@ -50,9 +54,6 @@ spring:
             ddl-auto: update
         show-sql: true
         open-in-view: false
-        properties:
-            hibernate:
-                dialect: com.wafflestudio.csereal.common.config.MySQLDialectCustom
     security:
         oauth2:
             client:
@@ -80,11 +81,8 @@ spring:
     config.activate.on-profile: prod
     jpa:
         hibernate:
-            ddl-auto: update # TODO: change to validate (or none) when save actual data to server
+            ddl-auto: validate
         open-in-view: false
-        properties:
-            hibernate:
-                dialect: com.wafflestudio.csereal.common.config.MySQLDialectCustom
     security:
         oauth2:
             client:
@@ -116,6 +114,42 @@ login-page: https://${URL}
 slack:
     token: ${SLACK_TOKEN}
     channel: ${SLACK_CHANNEL}
+
+---
+spring:
+    config.activate.on-profile: dev
+    jpa:
+        hibernate:
+            ddl-auto: update 
+        show-sql: true
+        open-in-view: false
+    security:
+        oauth2:
+            client:
+                registration:
+                    idsnucse:
+                        client-id: cse-waffle-dev
+                        client-secret: ${OIDC_CLIENT_SECRET}
+                        authorization-grant-type: authorization_code
+                        scope: openid, profile, email
+                        redirect-uri: https://${URL}/api/v1/login/oauth2/code/idsnucse
+                provider:
+                    idsnucse:
+                        issuer-uri: https://id.snucse.org/o
+                        jwk-set-uri: https://id.snucse.org/o/jwks
+
+csereal:
+    upload:
+        path: /app/files/
+
+oldFiles:
+    path: /app/cse-files/
+
+endpoint:
+    backend: https://${URL}/api
+    frontend: https://${URL}
+
+login-page: https://${URL}
 
 ---
 spring:

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -42,10 +42,17 @@
         </root>
     </springProfile>
 
+    <springProfile name="dev">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE" />
+        </root>
+    </springProfile>
+
     <springProfile name="prod">
         <root level="INFO">
             <appender-ref ref="CONSOLE" />
             <appender-ref ref="ASYNC_SLACK" />
         </root>
     </springProfile>
+
 </configuration>


### PR DESCRIPTION
## CICD: 배포, 개발계 분리 적용

### 한줄 요약
- prod 환경이 추가됨에 따라 develop, main 브랜치가 각각 개발계, 배포계 서버로 deploy되도록 github action workflow 추가.
- Spring Profile에 dev 추가. slack 알림은 prod에서만 발생하도록 하였고 dev 환경에서 sql 로그가 보이도록 설정 변경. prod 환경은 ddl-auto를 validation으로 변경.

### 상세 설명

84acfd8 CICD: Add dev deployment workflow
96ea7b0 Refactor: Remove unused comments
aa82ed3 Config: Add dev profile
88bb2a4 CICD: Add ssh port for production deploy environment

### TODO
- main 브랜치로 merge하여 정상 작동 테스트 필요함.
