### PR TITLE
fix: course 띄어쓰기 그대로 유지

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/CourseEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/CourseEntity.kt
@@ -40,7 +40,7 @@ class CourseEntity(
                 language = languageType,
                 classification = courseDto.classification,
                 code = courseDto.code,
-                name = courseDto.name.replace(" ", "-"),
+                name = courseDto.name,
                 credit = courseDto.credit,
                 grade = courseDto.grade,
                 description = courseDto.description


### PR DESCRIPTION
## 제목
fix: course 띄어쓰기 그대로 유지

### 한줄 요약
course 띄어쓰기 그대로 유지하였습니다.

### 상세 설명

[51b6beb5257d1077ee82e5eff8ea33cf85a9c69b]: 원래 과목들 띄어쓰기를 ‘-’로 대체했었는데, 행정실에서 – 지워달라고 하기도 하고, 이제는 들어가있을 이유도 없어서 그냥 이름의 띄어쓰기 그대로 유지하면서 저장할 예정입니다.

### TODO
