### PR TITLE
Refactor: LanguageType 경로 이동

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/common/enums/LanguageType.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/enums/LanguageType.kt
@@ -1,4 +1,4 @@
-package com.wafflestudio.csereal.common.properties
+package com.wafflestudio.csereal.common.enums
 
 import com.wafflestudio.csereal.common.CserealException
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/api/AboutController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/api/AboutController.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.about.api
 
 import com.wafflestudio.csereal.common.aop.AuthenticatedStaff
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.about.api.res.AboutSearchResBody
 import com.wafflestudio.csereal.core.about.dto.*
 import com.wafflestudio.csereal.core.about.dto.AboutRequest

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/api/res/AboutSearchElementDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/api/res/AboutSearchElementDto.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.about.api.res
 
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.common.utils.cleanTextFromHtml
 import com.wafflestudio.csereal.common.utils.substringAroundKeyword
 import com.wafflestudio.csereal.core.about.database.AboutEntity

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/database/AboutEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/database/AboutEntity.kt
@@ -3,7 +3,7 @@ package com.wafflestudio.csereal.core.about.database
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
 import com.wafflestudio.csereal.common.controller.AttachmentContentEntityType
 import com.wafflestudio.csereal.common.controller.MainImageContentEntityType
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.common.utils.StringListConverter
 import com.wafflestudio.csereal.common.utils.cleanTextFromHtml
 import com.wafflestudio.csereal.core.about.dto.AboutDto

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/database/AboutRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/database/AboutRepository.kt
@@ -2,7 +2,7 @@ package com.wafflestudio.csereal.core.about.database
 
 import com.querydsl.jpa.impl.JPAQuery
 import com.querydsl.jpa.impl.JPAQueryFactory
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.common.repository.CommonRepository
 import com.wafflestudio.csereal.common.utils.exchangeValidPageNum
 import com.wafflestudio.csereal.core.about.database.QAboutEntity.aboutEntity

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/AboutDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/AboutDto.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.about.dto
 
 import com.fasterxml.jackson.annotation.JsonInclude
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.about.database.AboutEntity
 import com.wafflestudio.csereal.core.resource.attachment.dto.AttachmentResponse
 import java.time.LocalDateTime

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/DirectionDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/DirectionDto.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.about.dto
 
 import com.fasterxml.jackson.annotation.JsonInclude
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.about.database.AboutEntity
 
 data class DirectionDto(

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/FacilityDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/FacilityDto.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.about.dto
 
 import com.fasterxml.jackson.annotation.JsonInclude
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.about.database.AboutEntity
 
 data class FacilityDto(

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/StudentClubDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/dto/StudentClubDto.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.about.dto
 
 import com.fasterxml.jackson.annotation.JsonInclude
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.about.database.AboutEntity
 import com.wafflestudio.csereal.core.resource.attachment.dto.AttachmentResponse
 import java.time.LocalDateTime

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/service/AboutService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/service/AboutService.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.about.service
 
 import com.wafflestudio.csereal.common.CserealException
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.about.api.res.AboutSearchElementDto
 import com.wafflestudio.csereal.core.about.api.res.AboutSearchResBody
 import com.wafflestudio.csereal.core.about.database.*

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/api/AcademicsController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/api/AcademicsController.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.academics.api
 
 import com.wafflestudio.csereal.common.aop.AuthenticatedStaff
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.academics.dto.*
 import com.wafflestudio.csereal.core.academics.service.AcademicsService
 import com.wafflestudio.csereal.core.academics.dto.ScholarshipDto

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/api/res/AcademicsSearchResElement.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/api/res/AcademicsSearchResElement.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.academics.api.res
 
 import com.wafflestudio.csereal.common.CserealException
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.common.utils.substringAroundKeyword
 import com.wafflestudio.csereal.core.academics.database.AcademicsPostType
 import com.wafflestudio.csereal.core.academics.database.AcademicsSearchEntity

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsEntity.kt
@@ -2,7 +2,7 @@ package com.wafflestudio.csereal.core.academics.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
 import com.wafflestudio.csereal.common.controller.AttachmentContentEntityType
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.academics.dto.AcademicsDto
 import com.wafflestudio.csereal.core.resource.attachment.database.AttachmentEntity
 import jakarta.persistence.*

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsRepository.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.academics.database
 
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface AcademicsRepository : JpaRepository<AcademicsEntity, Long> {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsSearchEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsSearchEntity.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.academics.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.common.utils.cleanTextFromHtml
 import jakarta.persistence.*
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsSearchRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsSearchRepository.kt
@@ -2,7 +2,7 @@ package com.wafflestudio.csereal.core.academics.database
 
 import com.querydsl.jpa.impl.JPAQuery
 import com.querydsl.jpa.impl.JPAQueryFactory
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.common.repository.CommonRepository
 import com.wafflestudio.csereal.common.utils.exchangeValidPageNum
 import com.wafflestudio.csereal.core.academics.database.QAcademicsEntity.academicsEntity

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/CourseEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/CourseEntity.kt
@@ -2,7 +2,7 @@ package com.wafflestudio.csereal.core.academics.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
 import com.wafflestudio.csereal.common.controller.AttachmentContentEntityType
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.academics.dto.CourseDto
 import com.wafflestudio.csereal.core.resource.attachment.database.AttachmentEntity
 import jakarta.persistence.*

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/CourseRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/CourseRepository.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.academics.database
 
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface CourseRepository : JpaRepository<CourseEntity, Long> {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/ScholarshipEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/ScholarshipEntity.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.academics.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.academics.dto.ScholarshipDto
 import jakarta.persistence.*
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/dto/AcademicsDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/dto/AcademicsDto.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.academics.dto
 
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.academics.database.AcademicsEntity
 import com.wafflestudio.csereal.core.resource.attachment.dto.AttachmentResponse
 import java.time.LocalDateTime

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/dto/CourseDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/dto/CourseDto.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.academics.dto
 
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.academics.database.CourseEntity
 import com.wafflestudio.csereal.core.resource.attachment.dto.AttachmentResponse
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/dto/ScholarshipDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/dto/ScholarshipDto.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.academics.dto
 
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.academics.database.ScholarshipEntity
 
 data class ScholarshipDto(

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/service/AcademicsSearchService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/service/AcademicsSearchService.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.academics.service
 
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.academics.api.res.AcademicsSearchResBody
 import com.wafflestudio.csereal.core.academics.database.*
 import com.wafflestudio.csereal.core.main.event.RefreshSearchEvent

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/service/AcademicsService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/service/AcademicsService.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.academics.service
 
 import com.wafflestudio.csereal.common.CserealException
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.academics.database.*
 import com.wafflestudio.csereal.core.academics.dto.*
 import com.wafflestudio.csereal.core.resource.attachment.service.AttachmentService

--- a/src/main/kotlin/com/wafflestudio/csereal/core/admissions/api/AdmissionsController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admissions/api/AdmissionsController.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.admissions.api
 
 import com.wafflestudio.csereal.common.aop.AuthenticatedStaff
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.admissions.api.req.AdmissionReqBody
 import com.wafflestudio.csereal.core.admissions.dto.AdmissionsDto
 import com.wafflestudio.csereal.core.admissions.api.req.AdmissionMigrateElem

--- a/src/main/kotlin/com/wafflestudio/csereal/core/admissions/api/res/AdmissionSearchResElem.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admissions/api/res/AdmissionSearchResElem.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.admissions.api.res
 
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.common.utils.substringAroundKeyword
 import com.wafflestudio.csereal.core.admissions.database.AdmissionsEntity
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/admissions/database/AdmissionsEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admissions/database/AdmissionsEntity.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.admissions.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.common.utils.cleanTextFromHtml
 import com.wafflestudio.csereal.core.admissions.api.req.AdmissionReqBody
 import com.wafflestudio.csereal.core.admissions.dto.AdmissionsDto

--- a/src/main/kotlin/com/wafflestudio/csereal/core/admissions/database/AdmissionsRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admissions/database/AdmissionsRepository.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.admissions.database
 
 import com.querydsl.jpa.impl.JPAQueryFactory
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.common.repository.CommonRepository
 import com.wafflestudio.csereal.common.utils.exchangeValidPageNum
 import com.wafflestudio.csereal.core.admissions.database.QAdmissionsEntity.admissionsEntity

--- a/src/main/kotlin/com/wafflestudio/csereal/core/admissions/dto/AdmissionsDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admissions/dto/AdmissionsDto.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.admissions.dto
 
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.admissions.database.AdmissionsEntity
 import java.time.LocalDateTime
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/admissions/service/AdmissionsService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admissions/service/AdmissionsService.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.admissions.service
 
 import com.wafflestudio.csereal.common.CserealException
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.admissions.api.req.AdmissionMigrateElem
 import com.wafflestudio.csereal.core.admissions.api.req.AdmissionReqBody
 import com.wafflestudio.csereal.core.admissions.api.res.AdmissionSearchResBody

--- a/src/main/kotlin/com/wafflestudio/csereal/core/admissions/type/AdmissionsMainType.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admissions/type/AdmissionsMainType.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.admissions.type
 
 import com.wafflestudio.csereal.common.CserealException
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 
 enum class AdmissionsMainType(
     val ko: String,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/admissions/type/AdmissionsPostType.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admissions/type/AdmissionsPostType.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.admissions.type
 
 import com.wafflestudio.csereal.common.CserealException
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 
 enum class AdmissionsPostType(
     val ko: String,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/conference/database/ConferenceEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/conference/database/ConferenceEntity.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.conference.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.conference.dto.ConferenceDto
 import com.wafflestudio.csereal.core.research.database.ResearchSearchEntity
 import jakarta.persistence.*

--- a/src/main/kotlin/com/wafflestudio/csereal/core/conference/dto/ConferenceDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/conference/dto/ConferenceDto.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.conference.dto
 
 import com.fasterxml.jackson.annotation.JsonInclude
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.conference.database.ConferenceEntity
 
 data class ConferenceDto(

--- a/src/main/kotlin/com/wafflestudio/csereal/core/conference/service/ConferenceService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/conference/service/ConferenceService.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.conference.service
 
 import com.wafflestudio.csereal.common.CserealException
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.conference.database.ConferenceEntity
 import com.wafflestudio.csereal.core.conference.database.ConferencePageEntity
 import com.wafflestudio.csereal.core.conference.database.ConferencePageRepository

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/api/MemberSearchController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/api/MemberSearchController.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.member.api
 
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.member.service.MemberSearchService
 import jakarta.validation.Valid
 import jakarta.validation.constraints.Positive

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/api/res/MemberSearchResponseElement.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/api/res/MemberSearchResponseElement.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.member.api.res
 
 import com.wafflestudio.csereal.common.CserealException
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.member.database.MemberSearchEntity
 import com.wafflestudio.csereal.core.member.database.MemberSearchType
 import com.wafflestudio.csereal.core.resource.mainImage.database.MainImageEntity

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/database/MemberSearchEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/database/MemberSearchEntity.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.member.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import jakarta.persistence.*
 
 @Entity(name = "member_search")

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/database/MemberSearchRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/database/MemberSearchRepository.kt
@@ -2,7 +2,7 @@ package com.wafflestudio.csereal.core.member.database
 
 import com.querydsl.jpa.impl.JPAQuery
 import com.querydsl.jpa.impl.JPAQueryFactory
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.common.repository.CommonRepository
 import com.wafflestudio.csereal.common.utils.exchangeValidPageNum
 import com.wafflestudio.csereal.core.member.database.QMemberSearchEntity.memberSearchEntity

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/database/ProfessorEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/database/ProfessorEntity.kt
@@ -2,7 +2,7 @@ package com.wafflestudio.csereal.core.member.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
 import com.wafflestudio.csereal.common.controller.MainImageContentEntityType
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.member.dto.ProfessorDto
 import com.wafflestudio.csereal.core.research.database.LabEntity
 import com.wafflestudio.csereal.core.resource.mainImage.database.MainImageEntity

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/database/ProfessorRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/database/ProfessorRepository.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.member.database
 
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface ProfessorRepository : JpaRepository<ProfessorEntity, Long> {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/database/StaffEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/database/StaffEntity.kt
@@ -2,7 +2,7 @@ package com.wafflestudio.csereal.core.member.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
 import com.wafflestudio.csereal.common.controller.MainImageContentEntityType
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.member.dto.StaffDto
 import com.wafflestudio.csereal.core.resource.mainImage.database.MainImageEntity
 import jakarta.persistence.*

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/database/StaffRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/database/StaffRepository.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.member.database
 
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface StaffRepository : JpaRepository<StaffEntity, Long> {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/dto/ProfessorDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/dto/ProfessorDto.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.member.dto
 
 import com.fasterxml.jackson.annotation.JsonInclude
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.member.database.ProfessorEntity
 import com.wafflestudio.csereal.core.member.database.ProfessorStatus
 import java.time.LocalDate

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/dto/StaffDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/dto/StaffDto.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.member.dto
 
 import com.fasterxml.jackson.annotation.JsonInclude
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.member.database.StaffEntity
 
 data class StaffDto(

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/service/MemberSearchService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/service/MemberSearchService.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.member.service
 
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.main.event.RefreshSearchEvent
 import com.wafflestudio.csereal.core.member.api.res.MemberSearchResBody
 import com.wafflestudio.csereal.core.member.database.MemberSearchEntity

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/service/ProfessorService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/service/ProfessorService.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.member.service
 
 import com.wafflestudio.csereal.common.CserealException
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.common.utils.startsWithEnglish
 import com.wafflestudio.csereal.core.member.database.*
 import com.wafflestudio.csereal.core.member.dto.ProfessorDto

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/service/StaffService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/service/StaffService.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.member.service
 
 import com.wafflestudio.csereal.common.CserealException
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.member.database.MemberSearchEntity
 import com.wafflestudio.csereal.core.member.database.StaffEntity
 import com.wafflestudio.csereal.core.member.database.StaffRepository

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/api/ResearchController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/api/ResearchController.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.research.api
 
 import com.wafflestudio.csereal.common.aop.AuthenticatedStaff
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.research.dto.LabDto
 import com.wafflestudio.csereal.core.research.dto.LabUpdateRequest
 import com.wafflestudio.csereal.core.research.dto.ResearchDto

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/api/res/ResearchSearchResElement.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/api/res/ResearchSearchResElement.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.research.api.res
 
 import com.wafflestudio.csereal.common.CserealException
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.common.utils.substringAroundKeyword
 import com.wafflestudio.csereal.core.research.database.ResearchPostType
 import com.wafflestudio.csereal.core.research.database.ResearchSearchEntity

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/database/LabEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/database/LabEntity.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.research.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.member.database.ProfessorEntity
 import com.wafflestudio.csereal.core.research.dto.LabDto
 import com.wafflestudio.csereal.core.research.dto.LabUpdateRequest

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/database/LabRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/database/LabRepository.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.research.database
 
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface LabRepository : JpaRepository<LabEntity, Long> {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/database/ResearchEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/database/ResearchEntity.kt
@@ -3,7 +3,7 @@ package com.wafflestudio.csereal.core.research.database
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
 import com.wafflestudio.csereal.common.controller.AttachmentContentEntityType
 import com.wafflestudio.csereal.common.controller.MainImageContentEntityType
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.research.dto.ResearchDto
 import com.wafflestudio.csereal.core.resource.attachment.database.AttachmentEntity
 import com.wafflestudio.csereal.core.resource.mainImage.database.MainImageEntity

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/database/ResearchRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/database/ResearchRepository.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.research.database
 
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface ResearchRepository : JpaRepository<ResearchEntity, Long> {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/database/ResearchSearchEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/database/ResearchSearchEntity.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.research.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.common.utils.cleanTextFromHtml
 import com.wafflestudio.csereal.core.conference.database.ConferenceEntity
 import jakarta.persistence.*

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/database/ResearchSearchRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/database/ResearchSearchRepository.kt
@@ -2,7 +2,7 @@ package com.wafflestudio.csereal.core.research.database
 
 import com.querydsl.jpa.impl.JPAQuery
 import com.querydsl.jpa.impl.JPAQueryFactory
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.common.repository.CommonRepository
 import com.wafflestudio.csereal.common.utils.exchangeValidPageNum
 import com.wafflestudio.csereal.core.conference.database.QConferenceEntity.conferenceEntity

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/dto/LabDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/dto/LabDto.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.research.dto
 
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.research.database.LabEntity
 import com.wafflestudio.csereal.core.resource.attachment.dto.AttachmentResponse
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/dto/ResearchDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/dto/ResearchDto.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.research.dto
 
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.research.database.ResearchEntity
 import com.wafflestudio.csereal.core.research.database.ResearchPostType
 import com.wafflestudio.csereal.core.resource.attachment.dto.AttachmentResponse

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/service/ResearchSearchService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/service/ResearchSearchService.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.research.service
 
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.conference.database.ConferenceRepository
 import com.wafflestudio.csereal.core.main.event.RefreshSearchEvent
 import com.wafflestudio.csereal.core.member.event.ProfessorCreatedEvent

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/service/ResearchService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/service/ResearchService.kt
@@ -2,7 +2,7 @@ package com.wafflestudio.csereal.core.research.service
 
 import com.wafflestudio.csereal.common.CserealException
 import com.wafflestudio.csereal.common.properties.EndpointProperties
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.member.database.ProfessorRepository
 import com.wafflestudio.csereal.core.research.database.*
 import com.wafflestudio.csereal.core.research.dto.*

--- a/src/test/kotlin/com/wafflestudio/csereal/core/admissions/service/AdmissionsServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/admissions/service/AdmissionsServiceTest.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.admissions.service
 
 import com.wafflestudio.csereal.common.CserealException
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.admissions.api.req.AdmissionReqBody
 import com.wafflestudio.csereal.core.admissions.database.AdmissionsEntity
 import com.wafflestudio.csereal.core.admissions.database.AdmissionsRepository

--- a/src/test/kotlin/com/wafflestudio/csereal/core/conference/service/ConferenceServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/conference/service/ConferenceServiceTest.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.conference.service
 
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.conference.database.ConferenceEntity
 import com.wafflestudio.csereal.core.conference.database.ConferencePageEntity
 import com.wafflestudio.csereal.core.conference.database.ConferencePageRepository

--- a/src/test/kotlin/com/wafflestudio/csereal/core/member/service/ProfessorServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/member/service/ProfessorServiceTest.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.member.service
 
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.member.database.MemberSearchRepository
 import com.wafflestudio.csereal.core.member.database.ProfessorRepository
 import com.wafflestudio.csereal.core.member.database.ProfessorStatus

--- a/src/test/kotlin/com/wafflestudio/csereal/core/member/service/StaffServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/member/service/StaffServiceTest.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.member.service
 
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.member.database.MemberSearchRepository
 import com.wafflestudio.csereal.core.member.database.StaffRepository
 import com.wafflestudio.csereal.core.member.dto.StaffDto

--- a/src/test/kotlin/com/wafflestudio/csereal/core/reseach/service/ResearchSearchServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/reseach/service/ResearchSearchServiceTest.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.reseach.service
 
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.member.database.ProfessorRepository
 import com.wafflestudio.csereal.core.member.database.ProfessorStatus
 import com.wafflestudio.csereal.core.member.dto.ProfessorDto

--- a/src/test/kotlin/com/wafflestudio/csereal/core/reseach/service/ResearchServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/reseach/service/ResearchServiceTest.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.reseach.service
 
-import com.wafflestudio.csereal.common.properties.LanguageType
+import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.member.database.ProfessorEntity
 import com.wafflestudio.csereal.core.member.database.ProfessorRepository
 import com.wafflestudio.csereal.core.member.database.ProfessorStatus


### PR DESCRIPTION
## Refactor: LanguageType 경로 이동

### 한줄 요약
기존 properties 경로가 부적절하여 enums 경로를 새로 생성하여 이동시켰습니다.