### PR TITLE
fix: stat year 2050년까지 확장

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/database/StatRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/database/StatRepository.kt
@@ -3,5 +3,6 @@ package com.wafflestudio.csereal.core.about.database
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface StatRepository : JpaRepository<StatEntity, Long> {
+    fun findAllByYear(year: Int): List<StatEntity>
     fun findAllByYearAndDegree(year: Int, degree: Degree): List<StatEntity>
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/database/StatRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/database/StatRepository.kt
@@ -1,8 +1,12 @@
 package com.wafflestudio.csereal.core.about.database
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 interface StatRepository : JpaRepository<StatEntity, Long> {
     fun findAllByYear(year: Int): List<StatEntity>
     fun findAllByYearAndDegree(year: Int, degree: Degree): List<StatEntity>
+
+    @Query("SELECT MAX(s.year) FROM stat s")
+    fun findMaxYear(): Int
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/service/AboutService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/service/AboutService.kt
@@ -168,19 +168,21 @@ class AboutServiceImpl(
             ).description
 
         val statList = mutableListOf<FutureCareersStatDto>()
-        for (i: Int in 2021 downTo 2011) {
-            val bachelor = statRepository.findAllByYearAndDegree(i, Degree.BACHELOR).map {
-                FutureCareersStatDegreeDto.of(it)
+        for (i: Int in 2050 downTo 2011) {
+            if (statRepository.findAllByYear(i).isNotEmpty()) {
+                val bachelor = statRepository.findAllByYearAndDegree(i, Degree.BACHELOR).map {
+                    FutureCareersStatDegreeDto.of(it)
+                }
+                val master = statRepository.findAllByYearAndDegree(i, Degree.MASTER).map {
+                    FutureCareersStatDegreeDto.of(it)
+                }
+                val doctor = statRepository.findAllByYearAndDegree(i, Degree.DOCTOR).map {
+                    FutureCareersStatDegreeDto.of(it)
+                }
+                statList.add(
+                    FutureCareersStatDto(i, bachelor, master, doctor)
+                )
             }
-            val master = statRepository.findAllByYearAndDegree(i, Degree.MASTER).map {
-                FutureCareersStatDegreeDto.of(it)
-            }
-            val doctor = statRepository.findAllByYearAndDegree(i, Degree.DOCTOR).map {
-                FutureCareersStatDegreeDto.of(it)
-            }
-            statList.add(
-                FutureCareersStatDto(i, bachelor, master, doctor)
-            )
         }
         val companyList = companyRepository.findAllByOrderByYearDesc().map {
             FutureCareersCompanyDto.of(it)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/service/AboutService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/service/AboutService.kt
@@ -168,21 +168,20 @@ class AboutServiceImpl(
             ).description
 
         val statList = mutableListOf<FutureCareersStatDto>()
-        for (i: Int in 2050 downTo 2011) {
-            if (statRepository.findAllByYear(i).isNotEmpty()) {
-                val bachelor = statRepository.findAllByYearAndDegree(i, Degree.BACHELOR).map {
-                    FutureCareersStatDegreeDto.of(it)
-                }
-                val master = statRepository.findAllByYearAndDegree(i, Degree.MASTER).map {
-                    FutureCareersStatDegreeDto.of(it)
-                }
-                val doctor = statRepository.findAllByYearAndDegree(i, Degree.DOCTOR).map {
-                    FutureCareersStatDegreeDto.of(it)
-                }
-                statList.add(
-                    FutureCareersStatDto(i, bachelor, master, doctor)
-                )
+        val maxYear = statRepository.findMaxYear()
+        for (i: Int in maxYear downTo 2011) {
+            val bachelor = statRepository.findAllByYearAndDegree(i, Degree.BACHELOR).map {
+                FutureCareersStatDegreeDto.of(it)
             }
+            val master = statRepository.findAllByYearAndDegree(i, Degree.MASTER).map {
+                FutureCareersStatDegreeDto.of(it)
+            }
+            val doctor = statRepository.findAllByYearAndDegree(i, Degree.DOCTOR).map {
+                FutureCareersStatDegreeDto.of(it)
+            }
+            statList.add(
+                FutureCareersStatDto(i, bachelor, master, doctor)
+            )
         }
         val companyList = companyRepository.findAllByOrderByYearDesc().map {
             FutureCareersCompanyDto.of(it)


### PR DESCRIPTION
## 제목
fix: stat year 2050년까지 확장

### 한줄 요약
stat year 2050년까지 확장하였습니다.

### 상세 설명

[0abed42881de01642f60951b1ddf3c47e28003d9]: 이번에 졸업생 진로가 2022년, 2023년이 추가되었는데, 기존의 거는 2021년으로 하드코딩 되어있어서 그냥 연도를 2050년까지 확장하고 졸업생 진로가 저장된 연도 내역만 표시되도록 했습니다. 테스트 결과 2050년~2024년은 안나옵니다!

