### PR TITLE
CICD: env 파일 분리, 서버 docker image tag 분리

### DIFF
--- a/.github/workflows/database.yaml
+++ b/.github/workflows/database.yaml
@@ -22,10 +22,10 @@ jobs:
       -
         name: Create .env file
         run: |
-          echo "MYSQL_ROOT_PASSWORD=${{secrets.MYSQL_ROOT_PASSWORD}}" > .env
-          echo "MYSQL_USER=${{secrets.MYSQL_USER}}" >> .env
-          echo "MYSQL_PASSWORD=${{secrets.MYSQL_PASSWORD}}" >> .env
-          echo "MYSQL_DATABASE=${{secrets.MYSQL_DATABASE}}" >> .env
+          echo "MYSQL_ROOT_PASSWORD=${{secrets.MYSQL_ROOT_PASSWORD}}" > .env_db
+          echo "MYSQL_USER=${{secrets.MYSQL_USER}}" >> .env_db
+          echo "MYSQL_PASSWORD=${{secrets.MYSQL_PASSWORD}}" >> .env_db
+          echo "MYSQL_DATABASE=${{secrets.MYSQL_DATABASE}}" >> .env_db
 
       -
         name: SCP Command to Transfer Files
@@ -35,7 +35,7 @@ jobs:
           username: ${{secrets.SSH_USER}}
           port: ${{secrets.SSH_PORT}}
           key: ${{secrets.SSH_KEY}}
-          source: "docker-compose-db.yml, .env"
+          source: "docker-compose-db.yml, .env_db"
           target: "~/app"
           overwrite: true
 
@@ -49,6 +49,6 @@ jobs:
           key: ${{secrets.SSH_KEY}}
           script: |
             cd ~/app
-            source .env
+            source .env_db
             docker compose -f docker-compose-db.yml down
             docker compose -f docker-compose-db.yml up -d

--- a/.github/workflows/database_dev.yaml
+++ b/.github/workflows/database_dev.yaml
@@ -22,10 +22,10 @@ jobs:
       -
         name: Create .env file
         run: |
-          echo "MYSQL_ROOT_PASSWORD=${{secrets.MYSQL_ROOT_PASSWORD}}" > .env
-          echo "MYSQL_USER=${{secrets.MYSQL_USER}}" >> .env
-          echo "MYSQL_PASSWORD=${{secrets.MYSQL_PASSWORD}}" >> .env
-          echo "MYSQL_DATABASE=${{secrets.MYSQL_DATABASE}}" >> .env
+          echo "MYSQL_ROOT_PASSWORD=${{secrets.MYSQL_ROOT_PASSWORD}}" > .env_db
+          echo "MYSQL_USER=${{secrets.MYSQL_USER}}" >> .env_db
+          echo "MYSQL_PASSWORD=${{secrets.MYSQL_PASSWORD}}" >> .env_db
+          echo "MYSQL_DATABASE=${{secrets.MYSQL_DATABASE}}" >> .env_db
 
       -
         name: SCP Command to Transfer Files
@@ -34,7 +34,7 @@ jobs:
           host: ${{secrets.SSH_HOST_DEV}}
           username: ${{secrets.SSH_USER}}
           key: ${{secrets.SSH_KEY}}
-          source: "docker-compose-db.yml, .env"
+          source: "docker-compose-db.yml, .env_db"
           target: "~/app"
           overwrite: true
 
@@ -47,6 +47,6 @@ jobs:
           key: ${{secrets.SSH_KEY}}
           script: |
             cd ~/app
-            source .env
+            source .env_db
             docker-compose -f docker-compose-db.yml down
             docker-compose -f docker-compose-db.yml up -d

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -48,20 +48,20 @@ jobs:
                     build-args: |
                         PROFILE=prod
                     tags: |
-                        ghcr.io/wafflestudio/csereal-server/server_image:latest
+                        ghcr.io/wafflestudio/csereal-server/server_image:prod
                         ghcr.io/wafflestudio/csereal-server/server_image:${{github.sha}}
 
             -   name: Create .env file
                 run: |
-                    echo "MYSQL_ROOT_PASSWORD=${{secrets.MYSQL_ROOT_PASSWORD}}" > .env
-                    echo "MYSQL_USER=${{secrets.MYSQL_USER}}" >> .env
-                    echo "MYSQL_PASSWORD=${{secrets.MYSQL_PASSWORD}}" >> .env
-                    echo "MYSQL_DATABASE=${{secrets.MYSQL_DATABASE}}" >> .env
-                    echo "PROFILE=prod" >> .env
-                    echo "OIDC_CLIENT_SECRET=${{secrets.OIDC_CLIENT_SECRET}}" >> .env
-                    echo "URL=${{secrets.URL}}" >> .env
-                    echo "SLACK_TOKEN=${{secrets.SLACK_TOKEN}}" >> .env
-                    echo "SLACK_CHANNEL=${{secrets.SLACK_CHANNEL}}" >> .env
+                    echo "PROFILE=prod" > .env_server
+                    echo "MYSQL_ROOT_PASSWORD=${{secrets.MYSQL_ROOT_PASSWORD}}" >> .env_server
+                    echo "MYSQL_USER=${{secrets.MYSQL_USER}}" >> .env_server
+                    echo "MYSQL_PASSWORD=${{secrets.MYSQL_PASSWORD}}" >> .env_server
+                    echo "MYSQL_DATABASE=${{secrets.MYSQL_DATABASE}}" >> .env_server
+                    echo "OIDC_CLIENT_SECRET=${{secrets.OIDC_CLIENT_SECRET}}" >> .env_server
+                    echo "URL=${{secrets.URL}}" >> .env_server
+                    echo "SLACK_TOKEN=${{secrets.SLACK_TOKEN}}" >> .env_server
+                    echo "SLACK_CHANNEL=${{secrets.SLACK_CHANNEL}}" >> .env_server
 
             -   name: SCP Command to Transfer Files
                 uses: appleboy/scp-action@v0.1.4
@@ -70,7 +70,7 @@ jobs:
                     username: ${{secrets.SSH_USER}}
                     port: ${{secrets.SSH_PORT}}
                     key: ${{secrets.SSH_KEY}}
-                    source: "docker-compose-backend.yml, .env"
+                    source: "docker-compose-backend.yml, .env_server"
                     target: "~/app"
                     overwrite: true
             -   name: SSH Remote Commands
@@ -82,7 +82,7 @@ jobs:
                     key: ${{secrets.SSH_KEY}}
                     script: |
                         cd ~/app
-                        source .env
+                        source .env_server
                         docker compose -f docker-compose-backend.yml down
                         docker compose -f docker-compose-backend.yml pull
                         docker compose -f docker-compose-backend.yml up -d

--- a/.github/workflows/deploy_dev.yaml
+++ b/.github/workflows/deploy_dev.yaml
@@ -46,22 +46,23 @@ jobs:
                     context: .
                     push: true
                     build-args: |
-                        PROFILE=prod
+                        PROFILE=dev
                     tags: |
                         ghcr.io/wafflestudio/csereal-server/server_image:latest
+                        ghcr.io/wafflestudio/csereal-server/server_image:dev
                         ghcr.io/wafflestudio/csereal-server/server_image:${{github.sha}}
 
             -   name: Create .env file
                 run: |
-                    echo "MYSQL_ROOT_PASSWORD=${{secrets.MYSQL_ROOT_PASSWORD}}" > .env
-                    echo "MYSQL_USER=${{secrets.MYSQL_USER}}" >> .env
-                    echo "MYSQL_PASSWORD=${{secrets.MYSQL_PASSWORD}}" >> .env
-                    echo "MYSQL_DATABASE=${{secrets.MYSQL_DATABASE}}" >> .env
-                    echo "PROFILE=dev" >> .env
-                    echo "OIDC_CLIENT_SECRET=${{secrets.OIDC_CLIENT_SECRET}}" >> .env
-                    echo "URL=${{secrets.URL_DEV}}" >> .env
-                    # echo "SLACK_TOKEN=${{secrets.SLACK_TOKEN}}" >> .env
-                    # echo "SLACK_CHANNEL=${{secrets.SLACK_CHANNEL}}" >> .env
+                    echo "PROFILE=dev" > .env_server
+                    echo "MYSQL_ROOT_PASSWORD=${{secrets.MYSQL_ROOT_PASSWORD}}" >> .env_server
+                    echo "MYSQL_USER=${{secrets.MYSQL_USER}}" >> .env_server
+                    echo "MYSQL_PASSWORD=${{secrets.MYSQL_PASSWORD}}" >> .env_server
+                    echo "MYSQL_DATABASE=${{secrets.MYSQL_DATABASE}}" >> .env_server
+                    echo "OIDC_CLIENT_SECRET=${{secrets.OIDC_CLIENT_SECRET}}" >> .env_server
+                    echo "URL=${{secrets.URL_DEV}}" >> .env_server
+                    # echo "SLACK_TOKEN=${{secrets.SLACK_TOKEN}}" >> .env_server
+                    # echo "SLACK_CHANNEL=${{secrets.SLACK_CHANNEL}}" >> .env_server
 
             -   name: SCP Command to Transfer Files
                 uses: appleboy/scp-action@v0.1.4
@@ -69,7 +70,7 @@ jobs:
                     host: ${{secrets.SSH_HOST_DEV}}
                     username: ${{secrets.SSH_USER}}
                     key: ${{secrets.SSH_KEY}}
-                    source: "docker-compose-backend.yml, .env"
+                    source: "docker-compose-backend.yml, .env_server"
                     target: "~/app"
                     overwrite: true
             -   name: SSH Remote Commands
@@ -80,7 +81,7 @@ jobs:
                     key: ${{secrets.SSH_KEY}}
                     script: | 
                         cd ~/app
-                        source .env
+                        source .env_server
                         docker-compose -f docker-compose-backend.yml down
                         docker-compose -f docker-compose-backend.yml pull
                         docker-compose -f docker-compose-backend.yml up -d

--- a/.github/workflows/deploy_dev.yaml
+++ b/.github/workflows/deploy_dev.yaml
@@ -48,7 +48,6 @@ jobs:
                     build-args: |
                         PROFILE=dev
                     tags: |
-                        ghcr.io/wafflestudio/csereal-server/server_image:latest
                         ghcr.io/wafflestudio/csereal-server/server_image:dev
                         ghcr.io/wafflestudio/csereal-server/server_image:${{github.sha}}
 

--- a/.github/workflows/proxy.yaml
+++ b/.github/workflows/proxy.yaml
@@ -19,8 +19,8 @@ jobs:
       -
         name: Create .env file
         run: |
-          echo "URL=${{secrets.URL}}" > .env
-          echo "LOCAL_IP=${{secrets.LOCAL_IP}}" >> .env
+          echo "URL=${{secrets.URL}}" > .env_proxy
+          echo "LOCAL_IP=${{secrets.LOCAL_IP}}" >> .env_proxy
 
       -
         name: SCP Command to Transfer Files
@@ -30,7 +30,7 @@ jobs:
           username: ${{secrets.SSH_USER}}
           port: ${{secrets.SSH_PORT}}
           key: ${{secrets.SSH_KEY}}
-          source: "docker-compose-caddy.yml, .env, caddy/Caddyfile"
+          source: "docker-compose-caddy.yml, .env_proxy, caddy/Caddyfile"
           target: "~/proxy"
           overwrite: true
 
@@ -44,6 +44,6 @@ jobs:
           key: ${{secrets.SSH_KEY}}
           script: |
             cd ~/proxy
-            source .env
+            source .env_proxy
             docker compose -f docker-compose-caddy.yml down
             docker compose -f docker-compose-caddy.yml up -d

--- a/.github/workflows/proxy_dev.yaml
+++ b/.github/workflows/proxy_dev.yaml
@@ -19,8 +19,8 @@ jobs:
       -
         name: Create .env file
         run: |
-          echo "URL=${{secrets.URL_DEV}}" > .env
-          echo "LOCAL_IP=${{secrets.LOCAL_IP_DEV}}" >> .env
+          echo "URL=${{secrets.URL_DEV}}" > .env_proxy
+          echo "LOCAL_IP=${{secrets.LOCAL_IP_DEV}}" >> .env_proxy
 
       -
         name: SCP Command to Transfer Files
@@ -29,7 +29,7 @@ jobs:
           host: ${{secrets.SSH_HOST_DEV}}
           username: ${{secrets.SSH_USER}}
           key: ${{secrets.SSH_KEY}}
-          source: "docker-compose-caddy.yml, .env, caddy/Caddyfile"
+          source: "docker-compose-caddy.yml, .env_proxy, caddy/Caddyfile"
           target: "~/proxy"
           overwrite: true
 
@@ -42,6 +42,6 @@ jobs:
           key: ${{secrets.SSH_KEY}}
           script: |
             cd ~/proxy
-            source .env
+            source .env_proxy
             docker-compose -f docker-compose-caddy.yml down
             docker-compose -f docker-compose-caddy.yml up -d

--- a/docker-compose-backend.yml
+++ b/docker-compose-backend.yml
@@ -1,10 +1,6 @@
 services:
     green:
         container_name: csereal_server_green
-        build:
-            context: ./
-            args:
-                PROFILE: ${PROFILE}
         ports:
             - 8080:8080
         volumes:
@@ -22,4 +18,4 @@ services:
         extra_hosts:
             - host.docker.internal:host-gateway
         restart: always
-        image: ghcr.io/wafflestudio/csereal-server/server_image:latest
+        image: "ghcr.io/wafflestudio/csereal-server/server_image:${PROFILE}"


### PR DESCRIPTION
## CICD: env 파일 분리, 서버 docker image tag 분리

### 한줄 요약
- 각 service의 .env 파일을 분리하여 배포 순서에 따른 문제 발생 가능성을 제거하였습니다.
- prod 환경과 dev 환경의 docker image를 태그를 통해 분리하여 관리, rollback이 용이하도록 하였습니다.

PR 요약해주세요

### 상세 설명

c255786 CICD: Seperate docker image tag of prod, dev, rename env
cc1bf78 CICD: Change env name of db
2ed8ddb CICD: Change env name of proxy

