### PR TITLE
Fix: notice keyword가 없을 시 오류 발생 수정

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.csereal.core.notice.database
 
 import com.querydsl.core.BooleanBuilder
 import com.querydsl.core.types.Projections
+import com.querydsl.core.types.dsl.Expressions
 import com.querydsl.jpa.impl.JPAQueryFactory
 import com.wafflestudio.csereal.common.enums.ContentSearchSortType
 import com.wafflestudio.csereal.common.repository.CommonRepository
@@ -142,7 +143,8 @@ class NoticeRepositoryImpl(
                 noticeEntity.isPinned,
                 noticeEntity.attachments.isNotEmpty,
                 noticeEntity.isPrivate,
-                scoreOrNull
+                // if scoreOrNull is null, put 0.0
+                scoreOrNull ?: Expressions.numberTemplate(Double::class.javaObjectType, "0.0")
             )
         ).from(noticeEntity)
             .leftJoin(noticeTagEntity).on(noticeTagEntity.notice.eq(noticeEntity))

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/NoticeSearchDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/NoticeSearchDto.kt
@@ -19,7 +19,7 @@ data class NoticeSearchDto(
         isPinned: Boolean,
         hasAttachment: Boolean,
         isPrivate: Boolean,
-        score: Double?
+        score: Double
     ) : this(id, title, createdAt, isPinned, hasAttachment, isPrivate)
 
     constructor(entity: NoticeEntity, hasAttachment: Boolean) : this(


### PR DESCRIPTION
## Fix: notice keyword가 없을 시 오류 발생 수정

### 한줄 요약

- keyword가 없을 시 score 칸에 "0.0"을 주어서 (의미 없는 값) 오류 해결

