### PR TITLE
fix: readDegreeRequirements response 행정실 요구사항에 맞게 수정

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/dto/DegreeRequirementsPageResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/dto/DegreeRequirementsPageResponse.kt
@@ -1,16 +1,17 @@
 package com.wafflestudio.csereal.core.academics.dto
 
 import com.wafflestudio.csereal.core.academics.database.AcademicsEntity
+import com.wafflestudio.csereal.core.resource.attachment.dto.AttachmentResponse
 
 class DegreeRequirementsPageResponse(
     val description: String,
-    val yearList: List<DegreeRequirementsDto>
+    val attachments: List<AttachmentResponse>
 ) {
     companion object {
-        fun of(entity: AcademicsEntity, yearList: List<DegreeRequirementsDto>) = entity.run {
+        fun of(entity: AcademicsEntity, attachments: List<AttachmentResponse>) = entity.run {
             DegreeRequirementsPageResponse(
                 description = this.description,
-                yearList = yearList
+                attachments = attachments
             )
         }
     }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/service/AcademicsService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/service/AcademicsService.kt
@@ -166,25 +166,6 @@ class AcademicsServiceImpl(
     @Transactional(readOnly = true)
     override fun readDegreeRequirements(language: String): DegreeRequirementsPageResponse {
         val enumLanguageType = LanguageType.makeStringToLanguageType(language)
-        /*
-        val academicsEntity =
-            academicsRepository.findByLanguageAndStudentTypeAndPostType(
-                enumLanguageType,
-                AcademicsStudentType.UNDERGRADUATE,
-                AcademicsPostType.DEGREE_REQUIREMENTS
-            )
-
-        val attachments =
-            academicsRepository.findByLanguageAndStudentTypeAndPostType(
-                enumLanguageType,
-                AcademicsStudentType.UNDERGRADUATE,
-                AcademicsPostType.DEGREE_REQUIREMENTS
-            ).attachments.map {
-                val attachmentResponse =
-                    attachmentService.createAttachmentResponses(it)
-            }
-
-         */
 
         val academicsEntity =
             academicsRepository.findByLanguageAndStudentTypeAndPostType(

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/service/AcademicsService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/service/AcademicsService.kt
@@ -166,6 +166,7 @@ class AcademicsServiceImpl(
     @Transactional(readOnly = true)
     override fun readDegreeRequirements(language: String): DegreeRequirementsPageResponse {
         val enumLanguageType = LanguageType.makeStringToLanguageType(language)
+        /*
         val academicsEntity =
             academicsRepository.findByLanguageAndStudentTypeAndPostType(
                 enumLanguageType,
@@ -173,17 +174,27 @@ class AcademicsServiceImpl(
                 AcademicsPostType.DEGREE_REQUIREMENTS
             )
 
-        val yearList =
-            academicsRepository.findAllByLanguageAndStudentTypeAndPostTypeOrderByYearDesc(
+        val attachments =
+            academicsRepository.findByLanguageAndStudentTypeAndPostType(
                 enumLanguageType,
                 AcademicsStudentType.UNDERGRADUATE,
-                AcademicsPostType.DEGREE_REQUIREMENTS_YEAR_LIST
-            ).map {
-                val attachments = attachmentService.createAttachmentResponses(it.attachments)
-                DegreeRequirementsDto.of(it, attachments)
+                AcademicsPostType.DEGREE_REQUIREMENTS
+            ).attachments.map {
+                val attachmentResponse =
+                    attachmentService.createAttachmentResponses(it)
             }
 
-        return DegreeRequirementsPageResponse.of(academicsEntity, yearList)
+         */
+
+        val academicsEntity =
+            academicsRepository.findByLanguageAndStudentTypeAndPostType(
+                enumLanguageType,
+                AcademicsStudentType.UNDERGRADUATE,
+                AcademicsPostType.DEGREE_REQUIREMENTS
+            )
+
+        val attachments = attachmentService.createAttachmentResponses(academicsEntity.attachments)
+        return DegreeRequirementsPageResponse.of(academicsEntity, attachments)
     }
 
     @Transactional


### PR DESCRIPTION
## 제목
fix: readDegreeRequirements response 행정실 요구사항에 맞게 수정

### 한줄 요약
readDegreeRequirements의 response를 행정실 요구사항에 맞게 수정하였습니다

### 상세 설명

[3f63ac336c6c0d4ba2413d300ffef7540f2e6072]: Description의 내용을 바꾸고, 연도별 항목이 아니라 4개의 pdf를 달아놓도록 해달라고 해서 yearList을 attachments로 바꿨습니다. 로컬 서버에서 한 결과 슬랙에 올려놓은 형식대로 잘 변경되었습니다. 실제 develop 머지는 프론트에서도 해당 response로 하는게 괜찮다고 한 이후에 이뤄질 예정입니다.

