### PR TITLE
feat: id list api for seo

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/api/NewsController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/api/NewsController.kt
@@ -123,4 +123,9 @@ class NewsController(
         newsService.enrollTag(tagName["name"]!!)
         return ResponseEntity<String>("등록되었습니다. (tagName: ${tagName["name"]})", HttpStatus.OK)
     }
+
+    @GetMapping("/ids")
+    fun getAllIds(): ResponseEntity<List<Long>> {
+        return ResponseEntity.ok(newsService.getAllIds())
+    }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsRepository.kt
@@ -19,6 +19,7 @@ import com.wafflestudio.csereal.core.resource.mainImage.database.QMainImageEntit
 import com.wafflestudio.csereal.core.resource.mainImage.service.MainImageService
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import java.time.LocalDateTime
 
@@ -32,6 +33,9 @@ interface NewsRepository : JpaRepository<NewsEntity, Long>, CustomNewsRepository
     fun findFirstByIsDeletedFalseAndIsPrivateFalseAndCreatedAtGreaterThanOrderByCreatedAtAsc(
         timestamp: LocalDateTime
     ): NewsEntity?
+
+    @Query("SELECT n.id FROM news n")
+    fun findAllIds(): List<Long>
 }
 
 interface CustomNewsRepository {
@@ -121,6 +125,7 @@ class NewsRepositoryImpl(
             sortBy == ContentSearchSortType.DATE || keyword.isNullOrEmpty() -> newsEntityQuery.orderBy(
                 newsEntity.createdAt.desc()
             )
+
             else /* sortBy == RELEVANCE */ -> newsEntityQuery
         }.fetch()
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/service/NewsService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/service/NewsService.kt
@@ -39,6 +39,7 @@ interface NewsService {
     fun searchTotalNews(keyword: String, number: Int, amount: Int, isStaff: Boolean): NewsTotalSearchDto
     fun readAllSlides(pageNum: Long, pageSize: Int): AdminSlidesResponse
     fun unSlideManyNews(request: List<Long>)
+    fun getAllIds(): List<Long>
 }
 
 @Service
@@ -195,6 +196,11 @@ class NewsServiceImpl(
             val news = getNewsEntityByIdOrThrow(newsId)
             news.isSlide = false
         }
+    }
+
+    @Transactional(readOnly = true)
+    override fun getAllIds(): List<Long> {
+        return newsRepository.findAllIds()
     }
 
     fun getNewsEntityByIdOrThrow(newsId: Long): NewsEntity {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
@@ -135,4 +135,9 @@ class NoticeController(
         noticeService.enrollTag(tagName["name"]!!)
         return ResponseEntity<String>("등록되었습니다. (tagName: ${tagName["name"]})", HttpStatus.OK)
     }
+
+    @GetMapping("/ids")
+    fun getAllIds(): ResponseEntity<List<Long>> {
+        return ResponseEntity.ok(noticeService.getAllIds())
+    }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
@@ -15,6 +15,7 @@ import com.wafflestudio.csereal.core.notice.dto.NoticeTotalSearchElement
 import com.wafflestudio.csereal.core.notice.dto.NoticeTotalSearchResponse
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Component
 import java.time.LocalDateTime
 
@@ -29,6 +30,9 @@ interface NoticeRepository : JpaRepository<NoticeEntity, Long>, CustomNoticeRepo
     fun findFirstByIsDeletedFalseAndIsPrivateFalseAndCreatedAtGreaterThanOrderByCreatedAtAsc(
         timestamp: LocalDateTime
     ): NoticeEntity?
+
+    @Query("SELECT n.id FROM notice n")
+    fun findAllIds(): List<Long>
 }
 
 interface CustomNoticeRepository {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
@@ -40,6 +40,7 @@ interface NoticeService {
     fun unpinManyNotices(idList: List<Long>)
     fun deleteManyNotices(idList: List<Long>)
     fun enrollTag(tagName: String)
+    fun getAllIds(): List<Long>
 }
 
 @Service
@@ -199,5 +200,10 @@ class NoticeServiceImpl(
             name = TagInNoticeEnum.getTagEnum(tagName)
         )
         tagInNoticeRepository.save(newTag)
+    }
+
+    @Transactional(readOnly = true)
+    override fun getAllIds(): List<Long> {
+        return noticeRepository.findAllIds()
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/api/SeminarController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/api/SeminarController.kt
@@ -96,4 +96,9 @@ class SeminarController(
     ) {
         seminarService.deleteSeminar(seminarId)
     }
+
+    @GetMapping("/ids")
+    fun getAllIds(): ResponseEntity<List<Long>> {
+        return ResponseEntity.ok(seminarService.getAllIds())
+    }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarRepository.kt
@@ -11,6 +11,7 @@ import com.wafflestudio.csereal.core.seminar.dto.SeminarSearchDto
 import com.wafflestudio.csereal.core.seminar.dto.SeminarSearchResponse
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Component
 import java.time.LocalDateTime
 
@@ -24,6 +25,9 @@ interface SeminarRepository : JpaRepository<SeminarEntity, Long>, CustomSeminarR
     fun findFirstByIsDeletedFalseAndIsPrivateFalseAndCreatedAtGreaterThanOrderByCreatedAtAsc(
         timestamp: LocalDateTime
     ): SeminarEntity?
+
+    @Query("SELECT s.id FROM seminar s")
+    fun findAllIds(): List<Long>
 }
 
 interface CustomSeminarRepository {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/service/SeminarService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/service/SeminarService.kt
@@ -33,6 +33,7 @@ interface SeminarService {
     ): SeminarDto
 
     fun deleteSeminar(seminarId: Long)
+    fun getAllIds(): List<Long>
 }
 
 @Service
@@ -135,5 +136,10 @@ class SeminarServiceImpl(
             ?: throw CserealException.Csereal404("존재하지 않는 세미나입니다.(seminarId=$seminarId")
 
         seminar.isDeleted = true
+    }
+
+    @Transactional(readOnly = true)
+    override fun getAllIds(): List<Long> {
+        return seminarRepository.findAllIds()
     }
 }


### PR DESCRIPTION
## id 목록 받아오기

### 한줄 요약

공지,세미나,새소식 세부 게시글도 포털 검색결과에 뜨게 하기 위해서 id 목록 받아오는 api 가 필요하다고 합니다.
