### PR TITLE
Feat: Main 화면 중요 항목 갯수 전달 가능하도록 API 수정 (기본 3개)

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/api/MainController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/api/MainController.kt
@@ -2,8 +2,10 @@ package com.wafflestudio.csereal.core.main.api
 
 import com.wafflestudio.csereal.core.main.dto.MainResponse
 import com.wafflestudio.csereal.core.main.service.MainService
+import jakarta.validation.constraints.Positive
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RequestMapping("/api/v1")
@@ -12,8 +14,12 @@ class MainController(
     private val mainService: MainService
 ) {
     @GetMapping
-    fun readMain(): MainResponse {
-        return mainService.readMain()
+    fun readMain(
+        @RequestParam(required = false, defaultValue = "3")
+        @Positive
+        importantCnt: Int
+    ): MainResponse {
+        return mainService.readMain(importantCnt)
     }
 
     @GetMapping("/search/refresh")

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/dto/MainImportantResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/dto/MainImportantResponse.kt
@@ -8,4 +8,19 @@ data class MainImportantResponse(
     val description: String,
     val createdAt: LocalDateTime?,
     val category: String
-)
+) {
+    constructor(
+        id: Long,
+        titleForMain: String?,
+        title: String,
+        description: String,
+        createdAt: LocalDateTime?,
+        category: String
+    ) : this(
+        id = id,
+        title = titleForMain ?: title,
+        description = description,
+        createdAt = createdAt,
+        category = category
+    )
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/service/MainService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/service/MainService.kt
@@ -1,26 +1,34 @@
 package com.wafflestudio.csereal.core.main.service
 
 import com.wafflestudio.csereal.core.main.database.MainRepository
+import com.wafflestudio.csereal.core.main.dto.MainImportantResponse
 import com.wafflestudio.csereal.core.main.dto.MainResponse
 import com.wafflestudio.csereal.core.main.dto.NoticesResponse
 import com.wafflestudio.csereal.core.main.event.RefreshSearchEvent
+import com.wafflestudio.csereal.core.news.database.NewsRepository
+import com.wafflestudio.csereal.core.notice.database.NoticeRepository
 import com.wafflestudio.csereal.core.notice.database.TagInNoticeEnum
+import com.wafflestudio.csereal.core.seminar.database.SeminarRepository
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 interface MainService {
-    fun readMain(): MainResponse
+    fun readMain(importantCnt: Int): MainResponse
     fun refreshSearch()
+    fun readMainImportant(cnt: Int): List<MainImportantResponse>
 }
 
 @Service
 class MainServiceImpl(
     private val mainRepository: MainRepository,
-    private val eventPublisher: ApplicationEventPublisher
+    private val eventPublisher: ApplicationEventPublisher,
+    private val noticeRepository: NoticeRepository,
+    private val seminarRepository: SeminarRepository,
+    private val newsRepository: NewsRepository
 ) : MainService {
     @Transactional(readOnly = true)
-    override fun readMain(): MainResponse {
+    override fun readMain(importantCnt: Int): MainResponse {
         val slides = mainRepository.readMainSlide()
 
         val noticeTotal = mainRepository.readMainNoticeTotal()
@@ -29,10 +37,19 @@ class MainServiceImpl(
         val noticeGraduate = mainRepository.readMainNoticeTag(TagInNoticeEnum.GRADUATE)
         val notices = NoticesResponse(noticeTotal, noticeScholarship, noticeUndergraduate, noticeGraduate)
 
-        val importants = mainRepository.readMainImportant()
+        val importants = readMainImportant(importantCnt)
 
         return MainResponse(slides, notices, importants)
     }
+
+    @Transactional(readOnly = true)
+    override fun readMainImportant(cnt: Int): List<MainImportantResponse> =
+        mutableListOf<MainImportantResponse>().apply {
+            addAll(noticeRepository.findImportantNotice(cnt))
+            addAll(seminarRepository.findImportantSeminar(cnt))
+            addAll(newsRepository.findImportantNews(cnt))
+            sortByDescending { it.createdAt }
+        }.take(cnt)
 
     override fun refreshSearch() {
         eventPublisher.publishEvent(RefreshSearchEvent())


### PR DESCRIPTION
## Feat: Main 화면 중요 항목 갯수 전달 가능하도록 API 수정 (기본 3개)

### 상세 설명
b7576fd Feat: Add `findImportantNotice` method with count to `NoticeRepository`
7db4f9c Feat: Add `findImportantSeminar` method with count to `SeminarRepository`
a31381d Feat: Add `findImportantNews` method with count to `NewsRepository`
6867b2b Refactor: Remove readMainImportant method (to move to `MainService`)
df42d9b Feat: Add constructor for query projection.
7f10c91 Feat: Moved `readMainImportant` from MainRepository, add `importantCnt` for `readMain` method.
8f24854 Feat: Add `importantCnt` query param (with default 3) to `readMain`.

### Issue
#283 

### TODO
추후 Refactoring 통해 MainRepository 전체 제거.