### PR TITLE
Refactor: 공지 태그 FOREIGN -> INTERNATIONAL

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/api/NoticeController.kt
@@ -28,8 +28,8 @@ class NoticeController(
     fun searchNotice(
         @RequestParam(required = false) tag: List<String>?,
         @RequestParam(required = false) keyword: String?,
-        @RequestParam(required = false) pageNum: Int?,
-        @RequestParam(required = false, defaultValue = "20") pageSize: Int,
+        @RequestParam(required = false) @Positive pageNum: Int?,
+        @RequestParam(required = false, defaultValue = "20") @Positive pageSize: Int,
         @RequestParam(required = false, defaultValue = "DATE") sortBy: String,
         authentication: Authentication?
     ): ResponseEntity<NoticeSearchResponse> {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/TagInNoticeEnum.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/TagInNoticeEnum.kt
@@ -9,7 +9,7 @@ enum class TagInNoticeEnum(val krName: String) {
     OUTER_EVENTS_PROGRAMS("외부행사/프로그램"), FOREIGN("foreign");
 
     companion object {
-        private val lookupMap: Map<String, TagInNoticeEnum> = values().associateBy(TagInNoticeEnum::krName)
+        private val lookupMap: Map<String, TagInNoticeEnum> = entries.associateBy(TagInNoticeEnum::krName)
 
         fun getTagEnum(t: String): TagInNoticeEnum {
             return lookupMap[t] ?: throw CserealException.Csereal404("태그를 찾을 수 없습니다: $t")

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/TagInNoticeEnum.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/TagInNoticeEnum.kt
@@ -6,7 +6,7 @@ enum class TagInNoticeEnum(val krName: String) {
     CLASS("수업"), SCHOLARSHIP("장학"), UNDERGRADUATE("학사(학부)"), GRADUATE("학사(대학원)"),
     MINOR("다전공/전과"), REGISTRATIONS("등록/복학/휴학/재입학"), ADMISSIONS("입학"), GRADUATIONS("졸업"),
     RECRUIT("채용정보"), STUDENT_EXCHANGE("교환학생/유학"), INNER_EVENTS_PROGRAMS("내부행사/프로그램"),
-    OUTER_EVENTS_PROGRAMS("외부행사/프로그램"), FOREIGN("foreign");
+    OUTER_EVENTS_PROGRAMS("외부행사/프로그램"), INTERNATIONAL("international");
 
     companion object {
         private val lookupMap: Map<String, TagInNoticeEnum> = entries.associateBy(TagInNoticeEnum::krName)


### PR DESCRIPTION
## 제목
Refactor: 공지 태그 FOREIGN -> INTERNATIONAL

f97609d Feat: Add validation for notice search pagesize, pagenum.
ff9eb34 Refactor: Refactor Enum.values() to Enum.entries
147e744  Refactor: Change FOREIGN -> INTERNATIONAL

### TODO
- 추후 krName도 database에 저장하도록 수정.
