### PR TITLE
Feat: Main API에서 중요 공지 갯수 optional하게 전달하도록 수정

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/api/MainController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/api/MainController.kt
@@ -15,12 +15,11 @@ class MainController(
 ) {
     @GetMapping
     fun readMain(
-        @RequestParam(required = false, defaultValue = "3")
+        @RequestParam(required = false)
         @Positive
-        importantCnt: Int
-    ): MainResponse {
-        return mainService.readMain(importantCnt)
-    }
+        importantCnt: Int?
+    ): MainResponse =
+        mainService.readMain(importantCnt)
 
     @GetMapping("/search/refresh")
     fun refreshSearches() {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/service/MainService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/service/MainService.kt
@@ -14,9 +14,9 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 interface MainService {
-    fun readMain(importantCnt: Int): MainResponse
+    fun readMain(importantCnt: Int?): MainResponse
     fun refreshSearch()
-    fun readMainImportant(cnt: Int): List<MainImportantResponse>
+    fun readMainImportant(cnt: Int? = null): List<MainImportantResponse>
 }
 
 @Service
@@ -28,7 +28,7 @@ class MainServiceImpl(
     private val newsRepository: NewsRepository
 ) : MainService {
     @Transactional(readOnly = true)
-    override fun readMain(importantCnt: Int): MainResponse {
+    override fun readMain(importantCnt: Int?): MainResponse {
         val slides = mainRepository.readMainSlide()
 
         val noticeTotal = mainRepository.readMainNoticeTotal()
@@ -43,13 +43,15 @@ class MainServiceImpl(
     }
 
     @Transactional(readOnly = true)
-    override fun readMainImportant(cnt: Int): List<MainImportantResponse> =
+    override fun readMainImportant(cnt: Int?): List<MainImportantResponse> =
         mutableListOf<MainImportantResponse>().apply {
             addAll(noticeRepository.findImportantNotice(cnt))
             addAll(seminarRepository.findImportantSeminar(cnt))
             addAll(newsRepository.findImportantNews(cnt))
             sortByDescending { it.createdAt }
-        }.take(cnt)
+        }.let {
+            if (cnt != null) it.take(cnt) else it
+        }
 
     override fun refreshSearch() {
         eventPublisher.publishEvent(RefreshSearchEvent())

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsRepository.kt
@@ -58,7 +58,7 @@ interface CustomNewsRepository {
     ): NewsTotalSearchDto
 
     fun readAllSlides(pageNum: Long, pageSize: Int): AdminSlidesResponse
-    fun findImportantNews(cnt: Int): List<MainImportantResponse>
+    fun findImportantNews(cnt: Int? = null): List<MainImportantResponse>
 }
 
 @Repository
@@ -240,7 +240,7 @@ class NewsRepositoryImpl(
         )
     }
 
-    override fun findImportantNews(cnt: Int): List<MainImportantResponse> =
+    override fun findImportantNews(cnt: Int?): List<MainImportantResponse> =
         queryFactory.select(
             Projections.constructor(
                 MainImportantResponse::class.java,
@@ -258,6 +258,8 @@ class NewsRepositoryImpl(
                 newsEntity.isDeleted.isFalse()
             ).orderBy(
                 newsEntity.createdAt.desc()
-            ).limit(cnt.toLong())
+            ).let {
+                if (cnt != null) it.limit(cnt.toLong()) else it
+            }
             .fetch()
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
@@ -45,7 +45,7 @@ interface CustomNoticeRepository {
 
     fun totalSearchNotice(keyword: String, number: Int, stringLength: Int, isStaff: Boolean): NoticeTotalSearchResponse
 
-    fun findImportantNotice(cnt: Int): List<MainImportantResponse>
+    fun findImportantNotice(cnt: Int? = null): List<MainImportantResponse>
 }
 
 @Component
@@ -188,7 +188,7 @@ class NoticeRepositoryImpl(
         return NoticeSearchResponse(total, noticeSearchDtoList)
     }
 
-    override fun findImportantNotice(cnt: Int): List<MainImportantResponse> =
+    override fun findImportantNotice(cnt: Int?): List<MainImportantResponse> =
         queryFactory.select(
             Projections.constructor(
                 MainImportantResponse::class.java,
@@ -206,6 +206,8 @@ class NoticeRepositoryImpl(
                 noticeEntity.isDeleted.isFalse()
             ).orderBy(
                 noticeEntity.createdAt.desc()
-            ).limit(cnt.toLong())
+            ).let {
+                if (cnt != null) { it.limit(cnt.toLong()) } else it
+            }
             .fetch()
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarRepository.kt
@@ -40,7 +40,7 @@ interface CustomSeminarRepository {
         isStaff: Boolean
     ): SeminarSearchResponse
 
-    fun findImportantSeminar(cnt: Int): List<MainImportantResponse>
+    fun findImportantSeminar(cnt: Int? = null): List<MainImportantResponse>
 }
 
 @Component
@@ -137,7 +137,7 @@ class SeminarRepositoryImpl(
         return SeminarSearchResponse(total, seminarSearchDtoList)
     }
 
-    override fun findImportantSeminar(cnt: Int): List<MainImportantResponse> =
+    override fun findImportantSeminar(cnt: Int?): List<MainImportantResponse> =
         queryFactory.select(
             Projections.constructor(
                 MainImportantResponse::class.java,
@@ -155,6 +155,8 @@ class SeminarRepositoryImpl(
                 seminarEntity.isPrivate.isFalse()
             ).orderBy(
                 seminarEntity.createdAt.desc()
-            ).limit(cnt.toLong())
+            ).let {
+                if (cnt != null) it.limit(cnt.toLong()) else it
+            }
             .fetch()
 }


### PR DESCRIPTION
## Feat: Main API에서 중요 공지 갯수 optional하게 전달하도록 수정

### 한줄 요약
Main API에서 `importantCnt` 쿼리 파라미터를 선택적으로 전달할 수 있도록 수정하였습니다. (전달하지 않을 경우 모든 중요 공지 전달)

