### PR TITLE
Feat: 안전한 파일 제거 method 추가

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/service/NewsService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/service/NewsService.kt
@@ -143,7 +143,7 @@ class NewsServiceImpl(
             mainImageService.uploadMainImage(news, newMainImage)
         }
 
-        attachmentService.deleteAttachments(request.deleteIds)
+        attachmentService.deleteAttachmentsDeprecated(request.deleteIds)
 
         if (newAttachments != null) {
             attachmentService.uploadAllAttachments(news, newAttachments)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
@@ -142,7 +142,7 @@ class NoticeServiceImpl(
 
         notice.update(request)
 
-        attachmentService.deleteAttachments(request.deleteIds)
+        attachmentService.deleteAttachmentsDeprecated(request.deleteIds)
 
         if (newAttachments != null) {
             attachmentService.uploadAllAttachments(notice, newAttachments)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/service/ResearchService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/service/ResearchService.kt
@@ -289,7 +289,7 @@ class ResearchServiceImpl(
 
         // update pdf
         if (request.pdfModified) {
-            labEntity.pdf?.let { attachmentService.deleteAttachment(it) }
+            labEntity.pdf?.let { attachmentService.deleteAttachmentDeprecated(it) }
 
             pdf?.let {
                 val attachmentDto = attachmentService.uploadAttachmentInLabEntity(labEntity, it)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/common/event/FileDeleteEvent.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/common/event/FileDeleteEvent.kt
@@ -1,0 +1,5 @@
+package com.wafflestudio.csereal.core.resource.common.event
+
+data class FileDeleteEvent(
+    val filename: String
+)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/common/service/CommonFileService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/common/service/CommonFileService.kt
@@ -1,0 +1,27 @@
+package com.wafflestudio.csereal.core.resource.common.service
+
+import com.wafflestudio.csereal.core.resource.common.event.FileDeleteEvent
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+import java.io.File
+
+interface CommonFileService {
+    fun removeFile(fileDeleteEvent: FileDeleteEvent)
+}
+
+@Service
+class CommonFileServiceImpl() : CommonFileService {
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    override fun removeFile(fileDeleteEvent: FileDeleteEvent) {
+        val file = File(fileDeleteEvent.filename)
+        if (file.exists()) {
+            if (!file.delete()) {
+                log.warn("${file.path} is not deleted.")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/service/SeminarService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/service/SeminarService.kt
@@ -118,7 +118,7 @@ class SeminarServiceImpl(
             mainImageService.uploadMainImage(seminar, newMainImage)
         }
 
-        attachmentService.deleteAttachments(request.deleteIds)
+        attachmentService.deleteAttachmentsDeprecated(request.deleteIds)
 
         if (newAttachments != null) {
             attachmentService.uploadAllAttachments(seminar, newAttachments)


### PR DESCRIPTION
## Feat: 안전한 파일 제거 method 추가

### 한줄 요약
- MainImage, Attachment에 대하여 transaction이 완료했을 경우만 파일을 제거하는 method를 추가하였습니다.

### 상세 설명
- `CommonFileService.removeFile`이 transaction이 commit되었을 경우 event를 listen하여 주어진 경로의 파일을 제거합니다.

17a02c9 Feat: Create file delete event.
998be6c Feat: Create File Delete Event Listener, only delete file when transaction commit.
eeb765d Feat: Add remove entity method which publish file delete event.


### TODO
기존 deprecated된 파일 safe delete 방식 제거.