### PR TITLE
Feat: Staff 수정 API 추가

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/common/config/OpenApiConfig.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/config/OpenApiConfig.kt
@@ -13,6 +13,7 @@ class OpenApiConfig {
         val info = Info()
             .title("컴퓨터공학부 홈페이지 백엔드 API")
             .description("컴퓨터공학부 홈페이지 백엔드 API 명세서입니다.")
+            .version("1")
 
         return OpenAPI()
             .components(Components())

--- a/src/main/kotlin/com/wafflestudio/csereal/common/enums/LanguageType.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/enums/LanguageType.kt
@@ -5,6 +5,7 @@ import com.wafflestudio.csereal.common.CserealException
 enum class LanguageType {
     KO, EN;
 
+    // TODO: Define custom deserializer, serializer
     companion object {
         fun makeStringToLanguageType(language: String): LanguageType {
             try {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/api/StaffController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/api/StaffController.kt
@@ -1,10 +1,13 @@
 package com.wafflestudio.csereal.core.member.api
 
 import com.wafflestudio.csereal.common.aop.AuthenticatedStaff
+import com.wafflestudio.csereal.core.member.api.req.CreateStaffReqBody
+import com.wafflestudio.csereal.core.member.api.req.ModifyStaffReqBody
 import com.wafflestudio.csereal.core.member.dto.SimpleStaffDto
 import com.wafflestudio.csereal.core.member.dto.StaffDto
 import com.wafflestudio.csereal.core.member.service.StaffService
-import org.springframework.context.annotation.Profile
+import io.swagger.v3.oas.annotations.Parameter
+import jakarta.validation.constraints.Positive
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
@@ -18,14 +21,16 @@ class StaffController(
     @AuthenticatedStaff
     @PostMapping
     fun createStaff(
-        @RequestPart("request") createStaffRequest: StaffDto,
-        @RequestPart("mainImage") mainImage: MultipartFile?
-    ): ResponseEntity<StaffDto> {
-        return ResponseEntity.ok(staffService.createStaff(createStaffRequest, mainImage))
-    }
+        @RequestPart("request") createStaffRequest: CreateStaffReqBody,
+        @RequestPart("image") image: MultipartFile?
+    ): StaffDto =
+        staffService.createStaff(createStaffRequest, image)
 
     @GetMapping("/{staffId}")
-    fun getStaff(@PathVariable staffId: Long): ResponseEntity<StaffDto> {
+    fun getStaff(
+        @PathVariable @Positive
+        staffId: Long
+    ): ResponseEntity<StaffDto> {
         return ResponseEntity.ok(staffService.getStaff(staffId))
     }
 
@@ -36,36 +41,26 @@ class StaffController(
         return ResponseEntity.ok(staffService.getAllStaff(language))
     }
 
+    // swagger explanation
     @AuthenticatedStaff
+    @PutMapping("/{staffId}")
     fun updateStaff(
-        @PathVariable staffId: Long,
-        @RequestPart("request") updateStaffRequest: StaffDto,
-        @RequestPart("mainImage") mainImage: MultipartFile?
-    ): ResponseEntity<StaffDto> {
-        return ResponseEntity.ok(staffService.updateStaff(staffId, updateStaffRequest, mainImage))
-    }
+        @PathVariable @Positive
+        staffId: Long,
+        @RequestPart("request") modifyStaffReq: ModifyStaffReqBody,
+        @Parameter(description = "image 교체할 경우 업로드. Request Body의 removeImage 관계없이 변경됨.")
+        @RequestPart("newImage")
+        newImage: MultipartFile?
+    ): StaffDto =
+        staffService.updateStaff(staffId, modifyStaffReq, newImage)
 
     @AuthenticatedStaff
     @DeleteMapping("/{staffId}")
-    fun deleteStaff(@PathVariable staffId: Long): ResponseEntity<Any> {
+    fun deleteStaff(
+        @PathVariable @Positive
+        staffId: Long
+    ): ResponseEntity<Any> {
         staffService.deleteStaff(staffId)
         return ResponseEntity.ok().build()
-    }
-
-    @Profile("!prod")
-    @PostMapping("/migrate")
-    fun migrateStaff(
-        @RequestBody requestList: List<StaffDto>
-    ): ResponseEntity<List<StaffDto>> {
-        return ResponseEntity.ok(staffService.migrateStaff(requestList))
-    }
-
-    @Profile("!prod")
-    @PatchMapping("/migrateImage/{staffId}")
-    fun migrateStaffImage(
-        @PathVariable staffId: Long,
-        @RequestPart("mainImage") mainImage: MultipartFile
-    ): ResponseEntity<StaffDto> {
-        return ResponseEntity.ok(staffService.migrateStaffImage(staffId, mainImage))
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/api/req/CreateStaffReqBody.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/api/req/CreateStaffReqBody.kt
@@ -1,0 +1,11 @@
+package com.wafflestudio.csereal.core.member.api.req
+
+data class CreateStaffReqBody(
+    val language: String,
+    val name: String,
+    val role: String,
+    val office: String,
+    val phone: String,
+    val email: String,
+    val tasks: List<String>
+)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/api/req/ModifyStaffReqBody.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/api/req/ModifyStaffReqBody.kt
@@ -1,0 +1,12 @@
+package com.wafflestudio.csereal.core.member.api.req
+
+data class ModifyStaffReqBody(
+    val language: String,
+    val name: String,
+    val role: String,
+    val office: String,
+    val phone: String,
+    val email: String,
+    val tasks: List<String>,
+    val removeImage: Boolean
+)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/database/MemberSearchEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/database/MemberSearchEntity.kt
@@ -9,7 +9,7 @@ class MemberSearchEntity(
     @Column(columnDefinition = "TEXT")
     var content: String,
 
-    val language: LanguageType,
+    var language: LanguageType,
 
     @OneToOne
     @JoinColumn(name = "professor_id")
@@ -91,10 +91,12 @@ class MemberSearchEntity(
     }
 
     fun update(professor: ProfessorEntity) {
+        this.language = professor.language
         this.content = createContent(professor)
     }
 
     fun update(staff: StaffEntity) {
+        this.language = staff.language
         this.content = createContent(staff)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/dto/StaffDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/dto/StaffDto.kt
@@ -1,12 +1,10 @@
 package com.wafflestudio.csereal.core.member.dto
 
-import com.fasterxml.jackson.annotation.JsonInclude
 import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.member.database.StaffEntity
 
 data class StaffDto(
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    var id: Long? = null,
+    var id: Long,
     val language: String,
     val name: String,
     val role: String,
@@ -14,8 +12,7 @@ data class StaffDto(
     val phone: String,
     val email: String,
     val tasks: List<String>,
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    val imageURL: String? = null
+    val imageURL: String?
 ) {
     companion object {
         fun of(staffEntity: StaffEntity, imageURL: String?): StaffDto {

--- a/src/test/kotlin/com/wafflestudio/csereal/core/member/service/StaffServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/member/service/StaffServiceTest.kt
@@ -1,9 +1,10 @@
 package com.wafflestudio.csereal.core.member.service
 
 import com.wafflestudio.csereal.common.enums.LanguageType
+import com.wafflestudio.csereal.core.member.api.req.CreateStaffReqBody
+import com.wafflestudio.csereal.core.member.api.req.ModifyStaffReqBody
 import com.wafflestudio.csereal.core.member.database.MemberSearchRepository
 import com.wafflestudio.csereal.core.member.database.StaffRepository
-import com.wafflestudio.csereal.core.member.dto.StaffDto
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.extensions.spring.SpringTestExtension
 import io.kotest.extensions.spring.SpringTestLifecycleMode
@@ -29,7 +30,7 @@ class StaffServiceTest(
     }
 
     Given("이미지 없는 행정직원을 생성하려고 할 떄") {
-        val staffDto = StaffDto(
+        val createStaffReq = CreateStaffReqBody(
             language = "ko",
             name = "name",
             role = "role",
@@ -40,7 +41,7 @@ class StaffServiceTest(
         )
 
         When("행정직원을 생성하면") {
-            val createdStaffDto = staffService.createStaff(staffDto, null)
+            val createdStaffDto = staffService.createStaff(createStaffReq, null)
 
             Then("행정직원이 생성된다") {
                 staffRepository.count() shouldBe 1
@@ -48,13 +49,13 @@ class StaffServiceTest(
             }
 
             Then("행정직원의 정보가 일치한다") {
-                val staffEntity = staffRepository.findByIdOrNull(createdStaffDto.id!!)!!
-                staffEntity.name shouldBe staffDto.name
-                staffEntity.role shouldBe staffDto.role
-                staffEntity.office shouldBe staffDto.office
-                staffEntity.phone shouldBe staffDto.phone
-                staffEntity.email shouldBe staffDto.email
-                staffEntity.tasks.map { it.name } shouldBe staffDto.tasks
+                val staffEntity = staffRepository.findByIdOrNull(createdStaffDto.id)!!
+                staffEntity.name shouldBe createStaffReq.name
+                staffEntity.role shouldBe createStaffReq.role
+                staffEntity.office shouldBe createStaffReq.office
+                staffEntity.phone shouldBe createStaffReq.phone
+                staffEntity.email shouldBe createStaffReq.email
+                staffEntity.tasks.map { it.name } shouldBe createStaffReq.tasks
             }
 
             Then("검색 정보가 생성된다") {
@@ -79,7 +80,7 @@ class StaffServiceTest(
     }
 
     Given("이미지 없는 행정직원을 수정할 때") {
-        val staffDto = StaffDto(
+        val createStaffReq = CreateStaffReqBody(
             language = "ko",
             name = "name",
             role = "role",
@@ -88,37 +89,37 @@ class StaffServiceTest(
             email = "email",
             tasks = listOf("task1", "task2")
         )
-
-        val createdStaffDto = staffService.createStaff(staffDto, null)
+        val createdStaffDto = staffService.createStaff(createStaffReq, null)
 
         When("행정직원을 수정하면") {
-            val updateStaffDto = StaffDto(
+            val modifyStaffReq = ModifyStaffReqBody(
                 language = "ko",
                 name = "name2",
                 role = "role2",
                 office = "office2",
                 phone = "phone2",
                 email = "email2",
-                tasks = listOf("task1", "task3", "task4")
+                tasks = listOf("task1", "task3", "task4"),
+                removeImage = false
             )
 
-            val updatedStaffDto = staffService.updateStaff(createdStaffDto.id!!, updateStaffDto, null)
+            val updatedStaffDto = staffService.updateStaff(createdStaffDto.id, modifyStaffReq, null)
 
             Then("행정직원의 정보가 일치한다") {
                 staffRepository.count() shouldBe 1
-                val staffEntity = staffRepository.findByIdOrNull(updatedStaffDto.id!!)!!
-                staffEntity.name shouldBe updateStaffDto.name
-                staffEntity.role shouldBe updateStaffDto.role
-                staffEntity.office shouldBe updateStaffDto.office
-                staffEntity.phone shouldBe updateStaffDto.phone
-                staffEntity.email shouldBe updateStaffDto.email
-                staffEntity.tasks.map { it.name } shouldBe updateStaffDto.tasks
+                val staffEntity = staffRepository.findByIdOrNull(updatedStaffDto.id)!!
+                staffEntity.name shouldBe modifyStaffReq.name
+                staffEntity.role shouldBe modifyStaffReq.role
+                staffEntity.office shouldBe modifyStaffReq.office
+                staffEntity.phone shouldBe modifyStaffReq.phone
+                staffEntity.email shouldBe modifyStaffReq.email
+                staffEntity.tasks.map { it.name } shouldBe modifyStaffReq.tasks
             }
 
             Then("검색 정보가 수정된다") {
                 memberSearchRepository.count() shouldBe 1
 
-                val staffEntity = staffRepository.findByIdOrNull(updatedStaffDto.id!!)!!
+                val staffEntity = staffRepository.findByIdOrNull(updatedStaffDto.id)!!
                 val memberSearch = staffEntity.memberSearch!!
 
                 memberSearch.content shouldBe """


### PR DESCRIPTION
## Feat: Staff 수정 API 추가

### 한줄 요약
- 사용하지 않고 로직이 불완전했던 staff 수정 api를 수정하여 적용했습니다.
    - 수정 시 파일과 검색을 위한 인덱스 역시 수정되도록 함.
    - response로 사용하는 dto와 request body를 분리.

### TODO
Professor에 대한 같은 작업.
