### PR TITLE
update api for single html page

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/api/AcademicsController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/api/AcademicsController.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.csereal.core.academics.api
 
 import com.wafflestudio.csereal.common.aop.AuthenticatedStaff
 import com.wafflestudio.csereal.common.enums.LanguageType
+import com.wafflestudio.csereal.core.academics.api.req.UpdateGuideReq
 import com.wafflestudio.csereal.core.academics.dto.*
 import com.wafflestudio.csereal.core.academics.service.AcademicsService
 import com.wafflestudio.csereal.core.academics.dto.ScholarshipDto
@@ -40,6 +41,15 @@ class AcademicsController(
     ): ResponseEntity<GuidePageResponse> {
         return ResponseEntity.ok(academicsService.readGuide(language, studentType))
     }
+
+    @AuthenticatedStaff
+    @PutMapping("/{studentType}/guide")
+    fun updateGuide(
+        @RequestParam(required = false, defaultValue = "ko") language: String,
+        @PathVariable studentType: String,
+        @RequestPart request: UpdateGuideReq,
+        @RequestPart newAttachments: List<MultipartFile>?
+    ) = academicsService.updateGuide(language, studentType, request, newAttachments)
 
     @GetMapping("/undergraduate/general-studies-requirements")
     fun readGeneralStudiesRequirements(

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/api/AcademicsController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/api/AcademicsController.kt
@@ -2,7 +2,7 @@ package com.wafflestudio.csereal.core.academics.api
 
 import com.wafflestudio.csereal.common.aop.AuthenticatedStaff
 import com.wafflestudio.csereal.common.enums.LanguageType
-import com.wafflestudio.csereal.core.academics.api.req.UpdateGuideReq
+import com.wafflestudio.csereal.core.academics.api.req.UpdateSingleReq
 import com.wafflestudio.csereal.core.academics.dto.*
 import com.wafflestudio.csereal.core.academics.service.AcademicsService
 import com.wafflestudio.csereal.core.academics.dto.ScholarshipDto
@@ -47,7 +47,7 @@ class AcademicsController(
     fun updateGuide(
         @RequestParam(required = false, defaultValue = "ko") language: String,
         @PathVariable studentType: String,
-        @RequestPart request: UpdateGuideReq,
+        @RequestPart request: UpdateSingleReq,
         @RequestPart newAttachments: List<MultipartFile>?
     ) = academicsService.updateGuide(language, studentType, request, newAttachments)
 
@@ -104,6 +104,14 @@ class AcademicsController(
     ): ResponseEntity<DegreeRequirementsPageResponse> {
         return ResponseEntity.ok(academicsService.readDegreeRequirements(language))
     }
+
+    @AuthenticatedStaff
+    @PutMapping("/undergraduate/degree-requirements")
+    fun updateDegreeRequirements(
+        @RequestParam(required = false, defaultValue = "ko") language: String,
+        @RequestPart request: UpdateSingleReq,
+        @RequestPart newAttachments: List<MultipartFile>?
+    ) = academicsService.updateDegreeRequirements(language, request, newAttachments)
 
     @AuthenticatedStaff
     @PostMapping("/{studentType}/scholarshipDetail")

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/api/req/UpdateGuideReq.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/api/req/UpdateGuideReq.kt
@@ -1,0 +1,6 @@
+package com.wafflestudio.csereal.core.academics.api.req
+
+data class UpdateGuideReq(
+    val description: String,
+    val deleteIds: List<Long>
+)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/api/req/UpdateSingleReq.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/api/req/UpdateSingleReq.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.academics.api.req
 
-data class UpdateGuideReq(
+data class UpdateSingleReq(
     val description: String,
     val deleteIds: List<Long>
 )

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/service/AcademicsService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/service/AcademicsService.kt
@@ -126,8 +126,13 @@ class AcademicsServiceImpl(
                 enumStudentType,
                 AcademicsPostType.GUIDE
             )
+
         academicsEntity.description = request.description
-        attachmentService.deleteAttachmentsDeprecated(request.deleteIds)
+        academicsEntity.academicsSearch?.update(academicsEntity) ?: let {
+            academicsEntity.academicsSearch = AcademicsSearchEntity.create(academicsEntity)
+        }
+
+        attachmentService.deleteAttachments(request.deleteIds)
         if (newAttachments != null) {
             attachmentService.uploadAllAttachments(academicsEntity, newAttachments)
         }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/service/AcademicsService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/service/AcademicsService.kt
@@ -2,7 +2,7 @@ package com.wafflestudio.csereal.core.academics.service
 
 import com.wafflestudio.csereal.common.CserealException
 import com.wafflestudio.csereal.common.enums.LanguageType
-import com.wafflestudio.csereal.core.academics.api.req.UpdateGuideReq
+import com.wafflestudio.csereal.core.academics.api.req.UpdateSingleReq
 import com.wafflestudio.csereal.core.academics.database.*
 import com.wafflestudio.csereal.core.academics.dto.*
 import com.wafflestudio.csereal.core.resource.attachment.service.AttachmentService
@@ -30,6 +30,7 @@ interface AcademicsService {
 
     fun readGeneralStudiesRequirements(language: String): GeneralStudiesRequirementsPageResponse
     fun readDegreeRequirements(language: String): DegreeRequirementsPageResponse
+    fun updateDegreeRequirements(language: String, request: UpdateSingleReq, newAttachments: List<MultipartFile>?)
     fun createCourse(
         studentType: String,
         request: CourseDto,
@@ -48,7 +49,7 @@ interface AcademicsService {
     fun updateGuide(
         language: String,
         studentType: String,
-        request: UpdateGuideReq,
+        request: UpdateSingleReq,
         newAttachments: List<MultipartFile>?
     )
 }
@@ -114,7 +115,7 @@ class AcademicsServiceImpl(
     override fun updateGuide(
         language: String,
         studentType: String,
-        request: UpdateGuideReq,
+        request: UpdateSingleReq,
         newAttachments: List<MultipartFile>?
     ) {
         val languageType = LanguageType.makeStringToLanguageType(language)
@@ -195,6 +196,32 @@ class AcademicsServiceImpl(
 
         val attachments = attachmentService.createAttachmentResponses(academicsEntity.attachments)
         return DegreeRequirementsPageResponse.of(academicsEntity, attachments)
+    }
+
+    @Transactional
+    override fun updateDegreeRequirements(
+        language: String,
+        request: UpdateSingleReq,
+        newAttachments: List<MultipartFile>?
+    ) {
+        val enumLanguageType = LanguageType.makeStringToLanguageType(language)
+
+        val academicsEntity =
+            academicsRepository.findByLanguageAndStudentTypeAndPostType(
+                enumLanguageType,
+                AcademicsStudentType.UNDERGRADUATE,
+                AcademicsPostType.DEGREE_REQUIREMENTS
+            )
+
+        academicsEntity.description = request.description
+        academicsEntity.academicsSearch?.update(academicsEntity) ?: let {
+            academicsEntity.academicsSearch = AcademicsSearchEntity.create(academicsEntity)
+        }
+
+        attachmentService.deleteAttachments(request.deleteIds)
+        if (newAttachments != null) {
+            attachmentService.uploadAllAttachments(academicsEntity, newAttachments)
+        }
     }
 
     @Transactional

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/service/AttachmentService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/service/AttachmentService.kt
@@ -35,10 +35,12 @@ interface AttachmentService {
         contentEntityType: AttachmentContentEntityType,
         requestAttachments: List<MultipartFile>
     ): List<AttachmentDto>
+
     fun createOneAttachmentResponse(attachment: AttachmentEntity?): AttachmentResponse?
     fun createAttachmentResponses(attachments: List<AttachmentEntity>?): List<AttachmentResponse>
 
     fun deleteAttachment(attachment: AttachmentEntity)
+    fun deleteAttachments(ids: List<Long>?)
     fun deleteAttachmentsDeprecated(ids: List<Long>?)
     fun deleteAttachmentDeprecated(attachment: AttachmentEntity)
 }
@@ -172,6 +174,17 @@ class AttachmentServiceImpl(
         val fileDirectory = path + attachment.filename
         attachmentRepository.delete(attachment)
         eventPublisher.publishEvent(FileDeleteEvent(fileDirectory))
+    }
+
+    @Transactional
+    override fun deleteAttachments(ids: List<Long>?) {
+        if (ids != null) {
+            for (id in ids) {
+                val attachment = attachmentRepository.findByIdOrNull(id)
+                    ?: throw CserealException.Csereal404("id:${id}인 첨부파일을 찾을 수 없습니다.")
+                deleteAttachment(attachment)
+            }
+        }
     }
 
     private fun connectAttachmentToEntity(contentEntity: AttachmentContentEntityType, attachment: AttachmentEntity) {


### PR DESCRIPTION
## 학사 및 교과 수정 api

### 한줄 요약

학부 안내, 대학원 안내, 졸업 규정 페이지를 위한 수정 api + deleteAttachments 추가

### 상세 설명

[30f494a01f91ffd11192c12087afa542776dc6cd]: 안내 페이지

[681682e7ad8f079f7a940ec528fde721a5bc43e2]: search entity 수정

[74bd48bd99b8c307588ef97f86386169cb9b1655]: 졸업 규정

### TODO

나머지 학사 및 교과 페이지를 위한 update api