### PR TITLE
Feat: 신입교수초빙 수정 API 생성

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/recruit/api/RecruitController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/recruit/api/RecruitController.kt
@@ -23,7 +23,7 @@ class RecruitController(
     @PutMapping(consumes = ["multipart/form-data"])
     fun upsertRecruitPage(
         @RequestPart("request") modifyRecruitReqBody: ModifyRecruitReqBody,
-        @RequestPart("newMainImage") newMainImage: MultipartFile?,
+        @RequestPart("newMainImage") newMainImage: MultipartFile?
     ): RecruitPage {
         return recruitService.upsertRecruitPage(modifyRecruitReqBody, newMainImage)
     }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/recruit/api/RecruitController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/recruit/api/RecruitController.kt
@@ -1,11 +1,12 @@
 package com.wafflestudio.csereal.core.recruit.api
 
+import com.wafflestudio.csereal.common.aop.AuthenticatedStaff
+import com.wafflestudio.csereal.core.recruit.api.req.ModifyRecruitReqBody
 import com.wafflestudio.csereal.core.recruit.dto.RecruitPage
 import com.wafflestudio.csereal.core.recruit.service.RecruitService
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
+import org.springframework.web.multipart.MultipartFile
 
 @RequestMapping("/api/v1/recruit")
 @RestController
@@ -16,5 +17,14 @@ class RecruitController(
     @GetMapping
     fun getRecruitPage(): ResponseEntity<RecruitPage> {
         return ResponseEntity.ok(recruitService.getRecruitPage())
+    }
+
+    @AuthenticatedStaff
+    @PutMapping(consumes = ["multipart/form-data"])
+    fun upsertRecruitPage(
+        @RequestPart("request") modifyRecruitReqBody: ModifyRecruitReqBody,
+        @RequestPart("newMainImage") newMainImage: MultipartFile?,
+    ): RecruitPage {
+        return recruitService.upsertRecruitPage(modifyRecruitReqBody, newMainImage)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/recruit/api/req/ModifyRecruitReqBody.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/recruit/api/req/ModifyRecruitReqBody.kt
@@ -1,8 +1,7 @@
 package com.wafflestudio.csereal.core.recruit.api.req
 
 data class ModifyRecruitReqBody(
-    val latestRecruitTitle: String,
-    val latestRecruitUrl: String,
+    val title: String,
     val description: String,
     val removeImage: Boolean
 )

--- a/src/main/kotlin/com/wafflestudio/csereal/core/recruit/api/req/ModifyRecruitReqBody.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/recruit/api/req/ModifyRecruitReqBody.kt
@@ -4,5 +4,5 @@ data class ModifyRecruitReqBody(
     val latestRecruitTitle: String,
     val latestRecruitUrl: String,
     val description: String,
-    val removeImage: Boolean,
+    val removeImage: Boolean
 )

--- a/src/main/kotlin/com/wafflestudio/csereal/core/recruit/api/req/ModifyRecruitReqBody.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/recruit/api/req/ModifyRecruitReqBody.kt
@@ -1,0 +1,8 @@
+package com.wafflestudio.csereal.core.recruit.api.req
+
+data class ModifyRecruitReqBody(
+    val latestRecruitTitle: String,
+    val latestRecruitUrl: String,
+    val description: String,
+    val removeImage: Boolean,
+)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/recruit/database/RecruitEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/recruit/database/RecruitEntity.kt
@@ -16,7 +16,7 @@ class RecruitEntity(
     var description: String,
 
     @OneToOne
-    var mainImage: MainImageEntity? = null,
+    var mainImage: MainImageEntity? = null
 ) : BaseTimeEntity(), MainImageContentEntityType {
     override fun bringMainImage(): MainImageEntity? = mainImage
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/recruit/database/RecruitEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/recruit/database/RecruitEntity.kt
@@ -9,8 +9,7 @@ import jakarta.persistence.OneToOne
 
 @Entity(name = "recruit")
 class RecruitEntity(
-    var latestRecruitTitle: String,
-    var latestRecruitUrl: String,
+    var title: String,
 
     @Column(columnDefinition = "text")
     var description: String,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/recruit/database/RecruitEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/recruit/database/RecruitEntity.kt
@@ -1,14 +1,22 @@
 package com.wafflestudio.csereal.core.recruit.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.controller.MainImageContentEntityType
+import com.wafflestudio.csereal.core.resource.mainImage.database.MainImageEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.OneToOne
 
 @Entity(name = "recruit")
 class RecruitEntity(
-    val latestRecruitTitle: String,
-    val latestRecruitUrl: String,
+    var latestRecruitTitle: String,
+    var latestRecruitUrl: String,
 
     @Column(columnDefinition = "text")
-    val description: String
-) : BaseTimeEntity()
+    var description: String,
+
+    @OneToOne
+    var mainImage: MainImageEntity? = null,
+) : BaseTimeEntity(), MainImageContentEntityType {
+    override fun bringMainImage(): MainImageEntity? = mainImage
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/recruit/dto/RecruitPage.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/recruit/dto/RecruitPage.kt
@@ -3,22 +3,23 @@ package com.wafflestudio.csereal.core.recruit.dto
 import com.wafflestudio.csereal.core.recruit.database.RecruitEntity
 
 data class RecruitPage(
-    val latestRecruitTitle: String,
-    val latestRecruitUrl: String,
+    val title: String,
     val description: String,
     val mainImageUrl: String?
 ) {
     companion object {
-        private val emptyPage = RecruitPage("", "", "", null)
+        private val emptyPage = RecruitPage("", "", null)
+
         fun empty() = emptyPage
 
-        fun of(recruitEntity: RecruitEntity, mainImageUrl: String?): RecruitPage {
-            return RecruitPage(
-                latestRecruitTitle = recruitEntity.latestRecruitTitle,
-                latestRecruitUrl = recruitEntity.latestRecruitUrl,
+        fun of(
+            recruitEntity: RecruitEntity,
+            mainImageUrl: String?
+        ): RecruitPage =
+            RecruitPage(
+                title = recruitEntity.title,
                 description = recruitEntity.description,
                 mainImageUrl = mainImageUrl
             )
-        }
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/recruit/dto/RecruitPage.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/recruit/dto/RecruitPage.kt
@@ -5,14 +5,19 @@ import com.wafflestudio.csereal.core.recruit.database.RecruitEntity
 data class RecruitPage(
     val latestRecruitTitle: String,
     val latestRecruitUrl: String,
-    val description: String
+    val description: String,
+    val mainImageUrl: String?,
 ) {
     companion object {
-        fun of(recruitEntity: RecruitEntity): RecruitPage {
+        private val emptyPage = RecruitPage("", "", "", null)
+        fun empty() = emptyPage
+
+        fun of(recruitEntity: RecruitEntity, mainImageUrl: String?): RecruitPage {
             return RecruitPage(
                 latestRecruitTitle = recruitEntity.latestRecruitTitle,
                 latestRecruitUrl = recruitEntity.latestRecruitUrl,
-                description = recruitEntity.description
+                description = recruitEntity.description,
+                mainImageUrl = mainImageUrl,
             )
         }
     }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/recruit/dto/RecruitPage.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/recruit/dto/RecruitPage.kt
@@ -6,7 +6,7 @@ data class RecruitPage(
     val latestRecruitTitle: String,
     val latestRecruitUrl: String,
     val description: String,
-    val mainImageUrl: String?,
+    val mainImageUrl: String?
 ) {
     companion object {
         private val emptyPage = RecruitPage("", "", "", null)
@@ -17,7 +17,7 @@ data class RecruitPage(
                 latestRecruitTitle = recruitEntity.latestRecruitTitle,
                 latestRecruitUrl = recruitEntity.latestRecruitUrl,
                 description = recruitEntity.description,
-                mainImageUrl = mainImageUrl,
+                mainImageUrl = mainImageUrl
             )
         }
     }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/recruit/service/RecruitService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/recruit/service/RecruitService.kt
@@ -39,16 +39,14 @@ class RecruitServiceImpl(
         val modifiedRecruitEntity = when (oldRecruitEntities.size) {
             0 -> modifyRecruitReqBody.let {
                 RecruitEntity(
-                    it.latestRecruitTitle,
-                    it.latestRecruitUrl,
+                    it.title,
                     it.description
                 )
             }
 
             1 -> oldRecruitEntities.first().apply {
                 modifyRecruitReqBody.let {
-                    latestRecruitTitle = it.latestRecruitTitle
-                    latestRecruitUrl = it.latestRecruitUrl
+                    title = it.title
                     description = it.description
                 }
             }
@@ -64,8 +62,7 @@ class RecruitServiceImpl(
             }.first().apply {
                 // modify first
                 modifyRecruitReqBody.let {
-                    latestRecruitTitle = it.latestRecruitTitle
-                    latestRecruitUrl = it.latestRecruitUrl
+                    title = it.title
                     description = it.description
                 }
             }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/recruit/service/RecruitService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/recruit/service/RecruitService.kt
@@ -18,7 +18,7 @@ interface RecruitService {
 @Transactional
 class RecruitServiceImpl(
     private val recruitRepository: RecruitRepository,
-    private val mainImageService: MainImageService,
+    private val mainImageService: MainImageService
 ) : RecruitService {
 
     @Transactional(readOnly = true)
@@ -41,10 +41,9 @@ class RecruitServiceImpl(
                 RecruitEntity(
                     it.latestRecruitTitle,
                     it.latestRecruitUrl,
-                    it.description,
+                    it.description
                 )
             }
-
 
             1 -> oldRecruitEntities.first().apply {
                 modifyRecruitReqBody.let {
@@ -53,7 +52,6 @@ class RecruitServiceImpl(
                     description = it.description
                 }
             }
-
 
             else -> oldRecruitEntities.also { entities ->
                 // remove leftovers
@@ -73,8 +71,8 @@ class RecruitServiceImpl(
             }
         }
 
-        if (modifiedRecruitEntity.mainImage != null
-            && (newMainImage != null || modifyRecruitReqBody.removeImage)
+        if (modifiedRecruitEntity.mainImage != null &&
+            (newMainImage != null || modifyRecruitReqBody.removeImage)
         ) {
             mainImageService.removeImage(modifiedRecruitEntity.mainImage!!)
             modifiedRecruitEntity.mainImage = null

--- a/src/main/kotlin/com/wafflestudio/csereal/core/recruit/service/RecruitService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/recruit/service/RecruitService.kt
@@ -17,7 +17,9 @@ class RecruitServiceImpl(
 
     @Transactional(readOnly = true)
     override fun getRecruitPage(): RecruitPage {
-        val recruit = recruitRepository.findAll()[0]
-        return RecruitPage.of(recruit)
+        // return empty page if not exists
+        return recruitRepository.findAll().firstOrNull()
+            ?.let { RecruitPage.of(it, mainImageService.createImageURL(it.mainImage)) }
+            ?: RecruitPage.empty()
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/recruit/service/RecruitService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/recruit/service/RecruitService.kt
@@ -1,18 +1,24 @@
 package com.wafflestudio.csereal.core.recruit.service
 
+import com.wafflestudio.csereal.core.recruit.api.req.ModifyRecruitReqBody
+import com.wafflestudio.csereal.core.recruit.database.RecruitEntity
 import com.wafflestudio.csereal.core.recruit.database.RecruitRepository
 import com.wafflestudio.csereal.core.recruit.dto.RecruitPage
+import com.wafflestudio.csereal.core.resource.mainImage.service.MainImageService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.multipart.MultipartFile
 
 interface RecruitService {
     fun getRecruitPage(): RecruitPage
+    fun upsertRecruitPage(modifyRecruitReqBody: ModifyRecruitReqBody, newMainImage: MultipartFile?): RecruitPage
 }
 
 @Service
 @Transactional
 class RecruitServiceImpl(
-    private val recruitRepository: RecruitRepository
+    private val recruitRepository: RecruitRepository,
+    private val mainImageService: MainImageService,
 ) : RecruitService {
 
     @Transactional(readOnly = true)
@@ -21,5 +27,64 @@ class RecruitServiceImpl(
         return recruitRepository.findAll().firstOrNull()
             ?.let { RecruitPage.of(it, mainImageService.createImageURL(it.mainImage)) }
             ?: RecruitPage.empty()
+    }
+
+    @Transactional
+    override fun upsertRecruitPage(
+        modifyRecruitReqBody: ModifyRecruitReqBody,
+        newMainImage: MultipartFile?
+    ): RecruitPage {
+        val oldRecruitEntities = recruitRepository.findAll()
+
+        val modifiedRecruitEntity = when (oldRecruitEntities.size) {
+            0 -> modifyRecruitReqBody.let {
+                RecruitEntity(
+                    it.latestRecruitTitle,
+                    it.latestRecruitUrl,
+                    it.description,
+                )
+            }
+
+
+            1 -> oldRecruitEntities.first().apply {
+                modifyRecruitReqBody.let {
+                    latestRecruitTitle = it.latestRecruitTitle
+                    latestRecruitUrl = it.latestRecruitUrl
+                    description = it.description
+                }
+            }
+
+
+            else -> oldRecruitEntities.also { entities ->
+                // remove leftovers
+                entities.subList(1, entities.size).let {
+                    it.mapNotNull(RecruitEntity::mainImage)
+                        .forEach(mainImageService::removeImage)
+
+                    recruitRepository.deleteAll(it)
+                }
+            }.first().apply {
+                // modify first
+                modifyRecruitReqBody.let {
+                    latestRecruitTitle = it.latestRecruitTitle
+                    latestRecruitUrl = it.latestRecruitUrl
+                    description = it.description
+                }
+            }
+        }
+
+        if (modifiedRecruitEntity.mainImage != null
+            && (newMainImage != null || modifyRecruitReqBody.removeImage)
+        ) {
+            mainImageService.removeImage(modifiedRecruitEntity.mainImage!!)
+            modifiedRecruitEntity.mainImage = null
+        }
+        newMainImage?.let { mainImageService.uploadMainImage(modifiedRecruitEntity, it) }
+
+        return modifiedRecruitEntity.let {
+            recruitRepository.save(it)
+        }.let {
+            RecruitPage.of(it, mainImageService.createImageURL(it.mainImage))
+        }
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/mainImage/service/MainImageService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/mainImage/service/MainImageService.kt
@@ -7,6 +7,7 @@ import com.wafflestudio.csereal.core.about.database.AboutEntity
 import com.wafflestudio.csereal.core.member.database.ProfessorEntity
 import com.wafflestudio.csereal.core.member.database.StaffEntity
 import com.wafflestudio.csereal.core.news.database.NewsEntity
+import com.wafflestudio.csereal.core.recruit.database.RecruitEntity
 import com.wafflestudio.csereal.core.research.database.ResearchEntity
 import com.wafflestudio.csereal.core.resource.common.event.FileDeleteEvent
 import com.wafflestudio.csereal.core.resource.mainImage.database.MainImageRepository
@@ -120,6 +121,10 @@ class MainImageServiceImpl(
             }
 
             is ResearchEntity -> {
+                contentEntity.mainImage = mainImage
+            }
+
+            is RecruitEntity -> {
                 contentEntity.mainImage = mainImage
             }
 


### PR DESCRIPTION
## Feat: 신입교수초빙 수정 API 생성

- GET 시 db에 존재하지 않는 경우 비어있는 dto 반환하도록 수정
- PUT API를 통해 신입교수초빙 페이지 수정할 수 있도록 추가
    - 내부에서는 하나의 db record를 upsert함.
- RecruitEntity에 mainImage 추가
