### PR TITLE
Feat: 첨부파일만 존재하는 Council에 대한 Entity, Dto 정의

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/council/api/v2/CouncilController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/council/api/v2/CouncilController.kt
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/v2/council")
-class CouncilController (
+class CouncilController(
     private val councilService: CouncilService
 ) {
     // ...

--- a/src/main/kotlin/com/wafflestudio/csereal/core/council/api/v2/CouncilController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/council/api/v2/CouncilController.kt
@@ -1,0 +1,13 @@
+package com.wafflestudio.csereal.core.council.api.v2
+
+import com.wafflestudio.csereal.core.council.service.CouncilService
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v2/council")
+class CouncilController (
+    private val councilService: CouncilService
+) {
+    // ...
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/council/database/CouncilEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/council/database/CouncilEntity.kt
@@ -24,7 +24,7 @@ class CouncilEntity(
     val dataType: CouncilDataType,
 
     @OneToMany(mappedBy = "council")
-    val attachments: MutableSet<AttachmentEntity> = mutableSetOf(),
+    val attachments: MutableSet<AttachmentEntity> = mutableSetOf()
 ) : BaseTimeEntity(), AttachmentContentEntityType {
     override fun bringAttachments(): List<AttachmentEntity> {
         return attachments.toList()

--- a/src/main/kotlin/com/wafflestudio/csereal/core/council/database/CouncilEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/council/database/CouncilEntity.kt
@@ -2,11 +2,12 @@ package com.wafflestudio.csereal.core.council.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
 import com.wafflestudio.csereal.common.controller.AttachmentContentEntityType
+import com.wafflestudio.csereal.core.council.dto.CouncilDto
+import com.wafflestudio.csereal.core.council.type.CouncilType.CouncilDataType
+import com.wafflestudio.csereal.core.council.type.CouncilType.CouncilType
 import com.wafflestudio.csereal.core.resource.attachment.database.AttachmentEntity
-import jakarta.persistence.Entity
-import jakarta.persistence.Index
-import jakarta.persistence.OneToMany
-import jakarta.persistence.Table
+import com.wafflestudio.csereal.core.resource.attachment.dto.AttachmentResponse
+import jakarta.persistence.*
 
 @Entity(name = "council")
 @Table(
@@ -15,16 +16,35 @@ import jakarta.persistence.Table
     ]
 )
 class CouncilEntity(
-    // ...
-) : BaseTimeEntity() {
-    // ...
     val type: String,
     val subType: String? = null,
+
+    @Column(columnDefinition = "VARCHAR(255)")
+    @Enumerated(EnumType.STRING)
+    val dataType: CouncilDataType,
 
     @OneToMany(mappedBy = "council")
     val attachments: MutableSet<AttachmentEntity> = mutableSetOf(),
 ) : BaseTimeEntity(), AttachmentContentEntityType {
     override fun bringAttachments(): List<AttachmentEntity> {
         return attachments.toList()
+    }
+
+    // TODO: Check type's data type when create
+
+    fun toDto(attachmentResponseMapper: (List<AttachmentEntity>) -> List<AttachmentResponse>): CouncilDto {
+        val type = CouncilType.fromString(this.type, this.subType)
+
+        return when (type.dataType()) {
+            CouncilDataType.ATTACHMENT -> CouncilDto.CouncilAttachmentDto(
+                id = id,
+                type = type,
+                createdAt = createdAt,
+                modifiedAt = modifiedAt,
+                attachments = attachmentResponseMapper(this.attachments.toList())
+            )
+
+            else -> TODO("IMPLEMENT")
+        }
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/council/database/CouncilEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/council/database/CouncilEntity.kt
@@ -1,11 +1,30 @@
 package com.wafflestudio.csereal.core.council.database
 
 import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.controller.AttachmentContentEntityType
+import com.wafflestudio.csereal.core.resource.attachment.database.AttachmentEntity
 import jakarta.persistence.Entity
+import jakarta.persistence.Index
+import jakarta.persistence.OneToMany
+import jakarta.persistence.Table
 
 @Entity(name = "council")
+@Table(
+    indexes = [
+        Index(columnList = "type, sub_type")
+    ]
+)
 class CouncilEntity(
     // ...
 ) : BaseTimeEntity() {
     // ...
+    val type: String,
+    val subType: String? = null,
+
+    @OneToMany(mappedBy = "council")
+    val attachments: MutableSet<AttachmentEntity> = mutableSetOf(),
+) : BaseTimeEntity(), AttachmentContentEntityType {
+    override fun bringAttachments(): List<AttachmentEntity> {
+        return attachments.toList()
+    }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/council/database/CouncilEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/council/database/CouncilEntity.kt
@@ -4,7 +4,8 @@ import com.wafflestudio.csereal.common.config.BaseTimeEntity
 import jakarta.persistence.Entity
 
 @Entity(name = "council")
-class CouncilEntity (
+class CouncilEntity(
     // ...
-): BaseTimeEntity() {
+) : BaseTimeEntity() {
+    // ...
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/council/database/CouncilEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/council/database/CouncilEntity.kt
@@ -1,0 +1,10 @@
+package com.wafflestudio.csereal.core.council.database
+
+import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import jakarta.persistence.Entity
+
+@Entity(name = "council")
+class CouncilEntity (
+    // ...
+): BaseTimeEntity() {
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/council/database/CouncilRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/council/database/CouncilRepository.kt
@@ -1,0 +1,7 @@
+package com.wafflestudio.csereal.core.council.database
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CouncilRepository: JpaRepository<CouncilEntity, Long> {
+    // ...
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/council/database/CouncilRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/council/database/CouncilRepository.kt
@@ -2,6 +2,6 @@ package com.wafflestudio.csereal.core.council.database
 
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface CouncilRepository: JpaRepository<CouncilEntity, Long> {
+interface CouncilRepository : JpaRepository<CouncilEntity, Long> {
     // ...
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/council/dto/CouncilDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/council/dto/CouncilDto.kt
@@ -5,6 +5,6 @@ import java.time.LocalDateTime
 data class CouncilDto(
     val id: Long,
     val createdAt: LocalDateTime?,
-    val modifiedAt: LocalDateTime?,
+    val modifiedAt: LocalDateTime?
     // ...
 )

--- a/src/main/kotlin/com/wafflestudio/csereal/core/council/dto/CouncilDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/council/dto/CouncilDto.kt
@@ -1,7 +1,6 @@
 package com.wafflestudio.csereal.core.council.dto
 
 import com.wafflestudio.csereal.core.council.type.CouncilType.CouncilDataType
-import com.wafflestudio.csereal.core.council.type.CouncilType.CouncilSubType
 import com.wafflestudio.csereal.core.council.type.CouncilType.CouncilType
 import com.wafflestudio.csereal.core.resource.attachment.dto.AttachmentResponse
 import java.time.LocalDateTime
@@ -28,7 +27,7 @@ sealed class CouncilDto(
 }
 
 sealed class CouncilCreateDto(
-    open val type: CouncilType,
+    open val type: CouncilType
 ) {
     data class CouncilAttachmentCreateDto(
         override val type: CouncilType,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/council/dto/CouncilDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/council/dto/CouncilDto.kt
@@ -1,10 +1,43 @@
 package com.wafflestudio.csereal.core.council.dto
 
+import com.wafflestudio.csereal.core.council.type.CouncilType.CouncilDataType
+import com.wafflestudio.csereal.core.council.type.CouncilType.CouncilSubType
+import com.wafflestudio.csereal.core.council.type.CouncilType.CouncilType
+import com.wafflestudio.csereal.core.resource.attachment.dto.AttachmentResponse
 import java.time.LocalDateTime
 
-data class CouncilDto(
-    val id: Long,
-    val createdAt: LocalDateTime?,
-    val modifiedAt: LocalDateTime?
-    // ...
-)
+sealed class CouncilDto(
+    open val id: Long,
+    open val type: CouncilType,
+    open val createdAt: LocalDateTime?,
+    open val modifiedAt: LocalDateTime?
+) {
+    data class CouncilAttachmentDto(
+        override val id: Long,
+        override val type: CouncilType,
+        override val createdAt: LocalDateTime?,
+        override val modifiedAt: LocalDateTime?,
+        val attachments: List<AttachmentResponse>
+    ) : CouncilDto(id, type, createdAt, modifiedAt) {
+        init {
+            require(type.dataType() == CouncilDataType.ATTACHMENT)
+        }
+    }
+
+    // TODO: Create CouncilContentDto, CouncilContentAttachmentDto
+}
+
+sealed class CouncilCreateDto(
+    open val type: CouncilType,
+) {
+    data class CouncilAttachmentCreateDto(
+        override val type: CouncilType,
+        val attachments: List<Long>
+    ) : CouncilCreateDto(type) {
+        init {
+            require(type.dataType() == CouncilDataType.ATTACHMENT)
+        }
+    }
+
+    // TODO: Create CouncilContentCreateDto, CouncilContentAttachmentCreateDto
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/council/dto/CouncilDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/council/dto/CouncilDto.kt
@@ -1,0 +1,10 @@
+package com.wafflestudio.csereal.core.council.dto
+
+import java.time.LocalDateTime
+
+data class CouncilDto(
+    val id: Long,
+    val createdAt: LocalDateTime?,
+    val modifiedAt: LocalDateTime?,
+    // ...
+)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/council/service/CouncilService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/council/service/CouncilService.kt
@@ -4,7 +4,7 @@ import com.wafflestudio.csereal.core.council.database.CouncilRepository
 import org.springframework.stereotype.Service
 
 @Service
-class CouncilService (
+class CouncilService(
     private val councilRepository: CouncilRepository
 ) {
     // ...

--- a/src/main/kotlin/com/wafflestudio/csereal/core/council/service/CouncilService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/council/service/CouncilService.kt
@@ -1,0 +1,11 @@
+package com.wafflestudio.csereal.core.council.service
+
+import com.wafflestudio.csereal.core.council.database.CouncilRepository
+import org.springframework.stereotype.Service
+
+@Service
+class CouncilService (
+    private val councilRepository: CouncilRepository
+) {
+    // ...
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/council/type/CouncilType/CouncilType.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/council/type/CouncilType/CouncilType.kt
@@ -1,0 +1,84 @@
+package com.wafflestudio.csereal.core.council.type.CouncilType
+
+import com.wafflestudio.csereal.common.CserealException
+
+private const val MEETING_MINUTE = "MEETING_MINUTE"
+private const val RULE = "RULE"
+private const val CONSTITUTION = "CONSTITUTION"
+private const val BYLAW = "BYLAW"
+
+sealed class CouncilType {
+    abstract fun typeValue(): String
+    abstract fun dataType(): CouncilDataType
+
+    companion object {
+        fun fromString(type: String, subType: String?): CouncilType {
+            return if (subType != null) {
+                when (type) {
+                    MEETING_MINUTE -> MeetingMinute.fromString(subType)
+                    RULE -> Rule.fromString(subType)
+                    else -> throw CserealException.Csereal400("잘못된 council 타입이 주어졌습니다.")
+                }
+            } else {
+                when (type) {
+                    else -> throw CserealException.Csereal400("잘못된 council 타입이 주어졌습니다.")
+                }
+            }
+        }
+    }
+
+    data class MeetingMinute( // 회의록
+        val year: Int,
+        val index: Int
+    ) : CouncilType(), CouncilSubType {
+        override fun typeValue(): String = MEETING_MINUTE
+        override fun subTypeValue(): String = "$year-$index"
+        override fun dataType(): CouncilDataType = CouncilDataType.ATTACHMENT
+
+        companion object {
+            fun fromString(value: String): MeetingMinute {
+                try {
+                    val (year, index) = value.split("-").map { it.toInt() }
+                    return MeetingMinute(year, index)
+                } catch (e: Exception) {
+                    throw CserealException.Csereal400("잘못된 council 타입이 주어졌습니다.")
+                }
+            }
+        }
+    }
+
+    sealed class Rule( // 규정
+    ) : CouncilType(), CouncilSubType {
+        object Constitution : Rule() { // 회칙
+            override fun typeValue(): String = RULE
+            override fun subTypeValue(): String = CONSTITUTION
+            override fun dataType(): CouncilDataType = CouncilDataType.ATTACHMENT
+        }
+
+        object Bylaw : Rule() { // 세칙
+            override fun typeValue(): String = RULE
+            override fun subTypeValue(): String = BYLAW
+            override fun dataType(): CouncilDataType = CouncilDataType.ATTACHMENT
+        }
+
+        companion object {
+            fun fromString(value: String): Rule {
+                return when (value) {
+                    CONSTITUTION -> Constitution
+                    BYLAW -> Bylaw
+                    else -> throw CserealException.Csereal400("잘못된 council 타입이 주어졌습니다.")
+                }
+            }
+        }
+    }
+}
+
+interface CouncilSubType {
+    fun subTypeValue(): String
+}
+
+enum class CouncilDataType {
+    ATTACHMENT,
+    CONTENT,
+    ATTACHMENT_CONTENT,
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/council/type/CouncilType/CouncilType.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/council/type/CouncilType/CouncilType.kt
@@ -80,5 +80,5 @@ interface CouncilSubType {
 enum class CouncilDataType {
     ATTACHMENT,
     CONTENT,
-    ATTACHMENT_CONTENT,
+    ATTACHMENT_CONTENT
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/database/AttachmentEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/database/AttachmentEntity.kt
@@ -5,6 +5,7 @@ import com.wafflestudio.csereal.core.about.database.AboutEntity
 import com.wafflestudio.csereal.core.academics.database.AcademicsEntity
 import com.wafflestudio.csereal.core.academics.database.CourseEntity
 import com.wafflestudio.csereal.core.academics.database.ScholarshipEntity
+import com.wafflestudio.csereal.core.council.database.CouncilEntity
 import com.wafflestudio.csereal.core.news.database.NewsEntity
 import com.wafflestudio.csereal.core.notice.database.NoticeEntity
 import com.wafflestudio.csereal.core.research.database.LabEntity
@@ -49,7 +50,12 @@ class AttachmentEntity(
     @JoinColumn(name = "lab_id")
     var lab: LabEntity? = null,
 
+    // TODO: delete unused column
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "scholarship_id")
-    var scholarship: ScholarshipEntity? = null
+    var scholarship: ScholarshipEntity? = null,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "council_id")
+    var council: CouncilEntity? = null
 ) : BaseTimeEntity()

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/service/AttachmentService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/service/AttachmentService.kt
@@ -115,6 +115,7 @@ class AttachmentServiceImpl(
         return attachmentsList
     }
 
+    // TODO: move method out from service to entity
     @Transactional
     override fun createOneAttachmentResponse(attachment: AttachmentEntity?): AttachmentResponse? {
         var attachmentDto: AttachmentResponse? = null
@@ -132,6 +133,7 @@ class AttachmentServiceImpl(
         return attachmentDto
     }
 
+    // TODO: move method out from service to entity
     @Transactional
     override fun createAttachmentResponses(attachments: List<AttachmentEntity>?): List<AttachmentResponse> {
         val list = mutableListOf<AttachmentResponse>()


### PR DESCRIPTION
## 구조
- 기본적으로 2 가지의 Type이 존재
   - CouncilType: 어떤 내용인지를 나타내는 정보
       - 내부 구체적인 추가 정보는 subType으로 지정
   - CouncilDataType: 어떤 형식인지를 나타내는 정보

- Entity에 type, subtype, datatype을 저장하여 해당 분류를 기록

(뭔가 많이 복잡한거 같긴 해서, 그냥 회의록을 별도의 테이블로 분리해버릴지 고민중. 의견 부탁드립니당.)