### PR TITLE
fix: replace operators to space in mysql full text search

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/common/repository/CommonRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/repository/CommonRepository.kt
@@ -197,7 +197,7 @@ class CommonRepositoryImpl : CommonRepository {
         replaceOperatorsToSpace(keyword)
     )
 
-    val operatorRegex = """[+-<>'"@]""".toRegex()
+    val operatorRegex = """[+\-<>'"@()~*]""".toRegex()
 
     // Currently, we do not want user to search with operators, or having sql error by using @ operator.
     // So we replace all operators to space.

--- a/src/main/kotlin/com/wafflestudio/csereal/common/repository/CommonRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/repository/CommonRepository.kt
@@ -24,6 +24,7 @@ interface CommonRepository {
         field4: Any,
         field5: Any
     ): NumberTemplate<Double>
+
     fun searchFullSextupleTextTemplate(
         keyword: String,
         field1: Any,
@@ -33,6 +34,7 @@ interface CommonRepository {
         field5: Any,
         field6: Any
     ): NumberTemplate<Double>
+
     fun searchFullSeptupleTextTemplate(
         keyword: String,
         field1: Any,
@@ -43,6 +45,7 @@ interface CommonRepository {
         field6: Any,
         field7: Any
     ): NumberTemplate<Double>
+
     fun searchFullOctupleTextTemplate(
         keyword: String,
         field1: Any,
@@ -65,7 +68,7 @@ class CommonRepositoryImpl : CommonRepository {
         Double::class.javaObjectType,
         "function('match',{0},{1})",
         field,
-        keyword
+        replaceOperatorsToSpace(keyword)
     )
 
     override fun searchFullDoubleTextTemplate(
@@ -77,7 +80,7 @@ class CommonRepositoryImpl : CommonRepository {
         "function('match2',{0},{1},{2})",
         field1,
         field2,
-        keyword
+        replaceOperatorsToSpace(keyword)
     )
 
     override fun searchFullTripleTextTemplate(
@@ -91,7 +94,7 @@ class CommonRepositoryImpl : CommonRepository {
         field1,
         field2,
         field3,
-        keyword
+        replaceOperatorsToSpace(keyword)
     )
 
     override fun searchFullQuadrapleTextTemplate(
@@ -107,7 +110,7 @@ class CommonRepositoryImpl : CommonRepository {
         field2,
         field3,
         field4,
-        keyword
+        replaceOperatorsToSpace(keyword)
     )
 
     override fun searchFullQuintupleTextTemplate(
@@ -125,7 +128,7 @@ class CommonRepositoryImpl : CommonRepository {
         field3,
         field4,
         field5,
-        keyword
+        replaceOperatorsToSpace(keyword)
     )
 
     override fun searchFullSextupleTextTemplate(
@@ -145,7 +148,7 @@ class CommonRepositoryImpl : CommonRepository {
         field4,
         field5,
         field6,
-        keyword
+        replaceOperatorsToSpace(keyword)
     )
 
     override fun searchFullSeptupleTextTemplate(
@@ -167,7 +170,7 @@ class CommonRepositoryImpl : CommonRepository {
         field5,
         field6,
         field7,
-        keyword
+        replaceOperatorsToSpace(keyword)
     )
 
     override fun searchFullOctupleTextTemplate(
@@ -191,6 +194,14 @@ class CommonRepositoryImpl : CommonRepository {
         field6,
         field7,
         field8,
-        keyword
+        replaceOperatorsToSpace(keyword)
     )
+
+    val operatorRegex = """[+-<>'"@]""".toRegex()
+
+    // Currently, we do not want user to search with operators, or having sql error by using @ operator.
+    // So we replace all operators to space.
+    // This should be changed if we want to support operators or advanced search in the future.
+    private inline fun replaceOperatorsToSpace(keyword: String): String =
+        operatorRegex.replace(keyword, " ")
 }


### PR DESCRIPTION
## fix: replace operators to space in mysql full text search

### 한줄 요약

- full text 시 keyword로 넣어주는 값에 연산자를 공백으로 변환한 후 전달하도록 수정하였습니다.

### 변경 이유
- 검색 시 `@`를 입력하는 경우 sql 오류 발생 (해당 연산자는 뒤에 숫자가 반드시 붙어야 함)
- 현재 고급 검색을 지원하고 있지 않으므로, `@`를 포함한 연산자를 공백으로 변환 후 query를 하도록 수정함.

### Reference
- https://dev.mysql.com/doc/refman/8.4/en/fulltext-boolean.html
