### PR TITLE
Feat/local server docker compose

### DIFF
--- a/docker-compose-local-full.yml
+++ b/docker-compose-local-full.yml
@@ -1,0 +1,36 @@
+services:
+    db:
+        image: mysql:8.0
+        cap_add:
+            - SYS_NICE
+        environment:
+            - MYSQL_DATABASE=csereal
+            - MYSQL_ROOT_PASSWORD=password
+        ports:
+            - '3306:3306'
+        volumes:
+            - ./db:/var/lib/mysql
+            - ./db_config:/etc/mysql/conf.d
+        networks:
+            - my-network
+
+    my_server:
+        image: my_server_image:1.0
+        environment:
+            - SPRING_DATASOURCE_URL=jdbc:mysql://db:3306/csereal?useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul
+            - SPRING_DATASOURCE_USERNAME=root
+            - SPRING_DATASOURCE_PASSWORD=password
+        build:
+            context: .
+        ports:
+            - '8080:8080'
+        depends_on:
+            - db
+        restart: on-failure
+        networks:
+            - my-network
+volumes:
+    db:
+        driver: local
+networks:
+    my-network:

--- a/docker-compose-local-full.yml
+++ b/docker-compose-local-full.yml
@@ -9,7 +9,7 @@ services:
         ports:
             - '3306:3306'
         volumes:
-            - ./db:/var/lib/mysql
+            - db:/var/lib/mysql
             - ./db_config:/etc/mysql/conf.d
         networks:
             - my-network


### PR DESCRIPTION
## 로컬 서버 배포 compose 파일 생성

### 한줄 요약

로컬에서 db와 서버를 도커로 한번에 배포할 수 있는 compose파일을 만들었습니다

### 상세 설명

[2fdbfee]: docker-compose-local-full.yml 추가

로컬 서버 배포

```
./gradlew clean bootJar
docker build --build-arg PROFILE=local -t my_server_image:1.0 .
docker-compose -f docker-compose-local-full.yml up -d
```
-> http://localhost:8080/ 이용 가능

로컬 서버 끄기
```
docker-compose -f docker-compose-local-full.yml down
```

## TODO

테스트에 활용할 수 있는 기본 데이터를 자동으로 많이 넣어주는 코드도 만들어볼 예정입니다