### PR TITLE
feat: 공지글 고정 & 메인 만료기간 추가

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/CserealApplication.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/CserealApplication.kt
@@ -4,10 +4,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 import org.springframework.scheduling.annotation.EnableAsync
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @EnableJpaAuditing
 @SpringBootApplication
 @EnableAsync
+@EnableScheduling
 class CserealApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeEntity.kt
@@ -7,6 +7,7 @@ import com.wafflestudio.csereal.core.notice.dto.NoticeDto
 import com.wafflestudio.csereal.core.resource.attachment.database.AttachmentEntity
 import com.wafflestudio.csereal.core.user.database.UserEntity
 import jakarta.persistence.*
+import java.time.LocalDate
 
 @Entity(name = "notice")
 class NoticeEntity(
@@ -23,8 +24,12 @@ class NoticeEntity(
     var plainTextDescription: String,
 
     var isPrivate: Boolean,
+
     var isPinned: Boolean,
+    var pinnedUntil: LocalDate? = null,
+
     var isImportant: Boolean,
+    var importantUntil: LocalDate? = null,
 
     @OneToMany(mappedBy = "notice", cascade = [CascadeType.ALL])
     var noticeTags: MutableSet<NoticeTagEntity> = mutableSetOf(),
@@ -49,7 +54,13 @@ class NoticeEntity(
         this.titleForMain = updateNoticeRequest.titleForMain
         this.description = updateNoticeRequest.description
         this.isPrivate = updateNoticeRequest.isPrivate
+
+        // Pin related fields (prioritize isPinned flag)
         this.isPinned = updateNoticeRequest.isPinned
+        this.pinnedUntil = if (updateNoticeRequest.isPinned) updateNoticeRequest.pinnedUntil else null
+
+        // Important related fields (prioritize isImportant flag)
         this.isImportant = updateNoticeRequest.isImportant
+        this.importantUntil = if (updateNoticeRequest.isImportant) updateNoticeRequest.importantUntil else null
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
@@ -36,11 +36,23 @@ interface NoticeRepository : JpaRepository<NoticeEntity, Long>, CustomNoticeRepo
     fun findAllIds(): List<Long>
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("UPDATE notice n SET n.isPinned = false, n.pinnedUntil = null WHERE n.isPinned = true AND n.pinnedUntil < :currentDate")
+    @Query(
+        """
+        UPDATE notice n 
+        SET n.isPinned = false, n.pinnedUntil = null 
+        WHERE n.isPinned = true AND n.pinnedUntil < :currentDate
+    """
+    )
     fun updateExpiredPinnedStatus(@Param("currentDate") currentDate: LocalDate): Int
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("UPDATE notice n SET n.isImportant = false, n.importantUntil = null WHERE n.isImportant = true AND n.importantUntil < :currentDate")
+    @Query(
+        """
+        UPDATE notice n 
+        SET n.isImportant = false, n.importantUntil = null 
+        WHERE n.isImportant = true AND n.importantUntil < :currentDate
+    """
+    )
     fun updateExpiredImportantStatus(@Param("currentDate") currentDate: LocalDate): Int
 }
 
@@ -218,7 +230,11 @@ class NoticeRepositoryImpl(
             ).orderBy(
                 noticeEntity.createdAt.desc()
             ).let {
-                if (cnt != null) { it.limit(cnt.toLong()) } else it
+                if (cnt != null) {
+                    it.limit(cnt.toLong())
+                } else {
+                    it
+                }
             }
             .fetch()
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeRepository.kt
@@ -16,9 +16,12 @@ import com.wafflestudio.csereal.core.notice.dto.NoticeTotalSearchElement
 import com.wafflestudio.csereal.core.notice.dto.NoticeTotalSearchResponse
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Component
 import java.time.LocalDateTime
+import java.time.LocalDate
 
 interface NoticeRepository : JpaRepository<NoticeEntity, Long>, CustomNoticeRepository {
     fun findFirstByIsDeletedFalseAndIsPrivateFalseAndCreatedAtLessThanOrderByCreatedAtDesc(
@@ -31,6 +34,14 @@ interface NoticeRepository : JpaRepository<NoticeEntity, Long>, CustomNoticeRepo
 
     @Query("SELECT n.id FROM notice n")
     fun findAllIds(): List<Long>
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE notice n SET n.isPinned = false, n.pinnedUntil = null WHERE n.isPinned = true AND n.pinnedUntil < :currentDate")
+    fun updateExpiredPinnedStatus(@Param("currentDate") currentDate: LocalDate): Int
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE notice n SET n.isImportant = false, n.importantUntil = null WHERE n.isImportant = true AND n.importantUntil < :currentDate")
+    fun updateExpiredImportantStatus(@Param("currentDate") currentDate: LocalDate): Int
 }
 
 interface CustomNoticeRepository {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/NoticeDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/NoticeDto.kt
@@ -5,13 +5,14 @@ import com.wafflestudio.csereal.core.resource.attachment.dto.AttachmentResponse
 import java.time.LocalDateTime
 import java.time.LocalDate
 
+// TODO: split between dto, response, request data classes
 data class NoticeDto(
     val id: Long,
     val title: String,
     val titleForMain: String?,
     val description: String,
     val author: String?,
-    val tags: List<String>,
+    val tags: List<String>, // TODO: make nullable
     val createdAt: LocalDateTime?,
     val modifiedAt: LocalDateTime?,
     val isPrivate: Boolean,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/NoticeDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/dto/NoticeDto.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.csereal.core.notice.dto
 import com.wafflestudio.csereal.core.notice.database.NoticeEntity
 import com.wafflestudio.csereal.core.resource.attachment.dto.AttachmentResponse
 import java.time.LocalDateTime
+import java.time.LocalDate
 
 data class NoticeDto(
     val id: Long,
@@ -15,7 +16,9 @@ data class NoticeDto(
     val modifiedAt: LocalDateTime?,
     val isPrivate: Boolean,
     val isPinned: Boolean,
+    val pinnedUntil: LocalDate?,
     val isImportant: Boolean,
+    val importantUntil: LocalDate?,
     val prevId: Long?,
     val prevTitle: String?,
     val nextId: Long?,
@@ -42,7 +45,9 @@ data class NoticeDto(
                 modifiedAt = this.modifiedAt,
                 isPrivate = this.isPrivate,
                 isPinned = this.isPinned,
+                pinnedUntil = this.pinnedUntil,
                 isImportant = this.isImportant,
+                importantUntil = this.importantUntil,
                 prevId = prevNotice?.id,
                 prevTitle = prevNotice?.title,
                 nextId = nextNotice?.id,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/scheduler/NoticeScheduler.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/scheduler/NoticeScheduler.kt
@@ -24,7 +24,10 @@ class NoticeScheduler(
     fun updateNoticeExpirationStatus() {
         val currentDate = LocalDate.now(ZoneId.of("Asia/Seoul"))
         // This task updates notices expired *before* the start of today (currentDate KST).
-        logger.info("[updateNoticeExpirationStatus] Running scheduled task to update notices expired before: {}", currentDate)
+        logger.info(
+            "[updateNoticeExpirationStatus] Running scheduled task to update notices expired before: {}",
+            currentDate
+        )
 
         try {
             val updatedPinnedCount = noticeRepository.updateExpiredPinnedStatus(currentDate)
@@ -32,10 +35,16 @@ class NoticeScheduler(
 
             val updatedImportantCount = noticeRepository.updateExpiredImportantStatus(currentDate)
             logger.info("[updateNoticeExpirationStatus] Marked {} notices as not important.", updatedImportantCount)
-
         } catch (e: Exception) {
-            logger.error("[updateNoticeExpirationStatus] Error occurred during notice expiration update for date {}.", currentDate, e)
+            logger.error(
+                "[updateNoticeExpirationStatus] Error occurred during notice expiration update for date {}.",
+                currentDate,
+                e
+            )
         }
-         logger.info("[updateNoticeExpirationStatus] Finished scheduled task for notices expired before: {}", currentDate)
+        logger.info(
+            "[updateNoticeExpirationStatus] Finished scheduled task for notices expired before: {}",
+            currentDate
+        )
     }
-} 
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/scheduler/NoticeScheduler.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/scheduler/NoticeScheduler.kt
@@ -1,0 +1,41 @@
+package com.wafflestudio.csereal.core.notice.scheduler
+
+import com.wafflestudio.csereal.core.notice.database.NoticeRepository
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.ZoneId
+
+@Component
+class NoticeScheduler(
+    private val noticeRepository: NoticeRepository
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    /**
+     * Scheduled task to update the status of notices whose pin or importance period has expired.
+     * Runs every day at 1:00 AM KST.
+     */
+    @Scheduled(cron = "0 0 1 * * *", zone = "Asia/Seoul")
+    @Transactional
+    fun updateNoticeExpirationStatus() {
+        val currentDate = LocalDate.now(ZoneId.of("Asia/Seoul"))
+        // This task updates notices expired *before* the start of today (currentDate KST).
+        logger.info("[updateNoticeExpirationStatus] Running scheduled task to update notices expired before: {}", currentDate)
+
+        try {
+            val updatedPinnedCount = noticeRepository.updateExpiredPinnedStatus(currentDate)
+            logger.info("[updateNoticeExpirationStatus] Unpinned {} notices.", updatedPinnedCount)
+
+            val updatedImportantCount = noticeRepository.updateExpiredImportantStatus(currentDate)
+            logger.info("[updateNoticeExpirationStatus] Marked {} notices as not important.", updatedImportantCount)
+
+        } catch (e: Exception) {
+            logger.error("[updateNoticeExpirationStatus] Error occurred during notice expiration update for date {}.", currentDate, e)
+        }
+         logger.info("[updateNoticeExpirationStatus] Finished scheduled task for notices expired before: {}", currentDate)
+    }
+} 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
@@ -13,6 +13,7 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
+import java.time.LocalDate
 
 interface NoticeService {
     fun searchNotice(
@@ -101,7 +102,9 @@ class NoticeServiceImpl(
             plainTextDescription = cleanTextFromHtml(request.description),
             isPrivate = request.isPrivate,
             isPinned = request.isPinned,
+            pinnedUntil = if (request.isPinned) request.pinnedUntil else null,
             isImportant = request.isImportant,
+            importantUntil = if (request.isImportant) request.importantUntil else null,
             author = user
         )
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeService.kt
@@ -13,7 +13,6 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
-import java.time.LocalDate
 
 interface NoticeService {
     fun searchNotice(

--- a/src/main/resources/db/migration/V9__add_notice_expiration_dates.sql
+++ b/src/main/resources/db/migration/V9__add_notice_expiration_dates.sql
@@ -1,0 +1,4 @@
+-- Add columns for pinned and important expiration dates to the notice table
+ALTER TABLE notice
+    ADD COLUMN `pinned_until` DATE NULL DEFAULT NULL COMMENT 'Pin expiration date',
+    ADD COLUMN `important_until` DATE NULL DEFAULT NULL COMMENT 'Importance expiration date'; 

--- a/src/test/kotlin/com/wafflestudio/csereal/core/notice/scheduler/NoticeSchedulerTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/notice/scheduler/NoticeSchedulerTest.kt
@@ -1,0 +1,130 @@
+package com.wafflestudio.csereal.core.notice.scheduler
+
+import com.wafflestudio.csereal.core.notice.database.NoticeEntity
+import com.wafflestudio.csereal.core.notice.database.NoticeRepository
+import com.wafflestudio.csereal.core.user.database.UserEntity
+import com.wafflestudio.csereal.core.user.database.UserRepository
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.kotest.matchers.shouldBe
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.ZoneId
+
+@SpringBootTest
+@Transactional
+class NoticeSchedulerTest(
+    private val noticeScheduler: NoticeScheduler,
+    private val noticeRepository: NoticeRepository,
+    private val userRepository: UserRepository
+) : BehaviorSpec() {
+
+    override fun extensions() = listOf(SpringExtension)
+
+    private lateinit var user: UserEntity
+    private val KST: ZoneId = ZoneId.of("Asia/Seoul")
+    private val today: LocalDate = LocalDate.now(KST)
+    private val yesterday: LocalDate = today.minusDays(1)
+    private val tomorrow: LocalDate = today.plusDays(1)
+
+    init {
+        // Setup: Create a user first
+        beforeSpec {
+            user = userRepository.save(UserEntity("username", "name", "email", "studentId"))
+        }
+
+        // Cleanup
+        afterSpec {
+            noticeRepository.deleteAll()
+            userRepository.deleteAll()
+        }
+
+        Given("Various notices with different expiration dates are present") {
+            // Create test notices
+            val noticeExpiredPinned = createTestNotice("Expired Pinned", isPinned = true, pinnedUntil = yesterday)
+            val noticeExpiredImportant = createTestNotice("Expired Important", isImportant = true, importantUntil = yesterday)
+            val noticeTodayPinned = createTestNotice("Today Pinned", isPinned = true, pinnedUntil = today)
+            val noticeTodayImportant = createTestNotice("Today Important", isImportant = true, importantUntil = today)
+            val noticeFuturePinned = createTestNotice("Future Pinned", isPinned = true, pinnedUntil = tomorrow)
+            val noticeFutureImportant = createTestNotice("Future Important", isImportant = true, importantUntil = tomorrow)
+            val noticePermanentPinned = createTestNotice("Permanent Pinned", isPinned = true, pinnedUntil = null)
+            val noticePermanentImportant = createTestNotice("Permanent Important", isImportant = true, importantUntil = null)
+            val noticeNotPinnedOrImportant = createTestNotice("Not Pinned or Important", isPinned = false, isImportant = false)
+
+            When("The updateNoticeExpirationStatus scheduler task runs") {
+                noticeScheduler.updateNoticeExpirationStatus()
+
+                Then("Notices with expiration date before today should be updated") {
+                    val updatedExpiredPinned = noticeRepository.findByIdOrNull(noticeExpiredPinned.id)!!
+                    updatedExpiredPinned.isPinned shouldBe false
+                    updatedExpiredPinned.pinnedUntil shouldBe null
+
+                    val updatedExpiredImportant = noticeRepository.findByIdOrNull(noticeExpiredImportant.id)!!
+                    updatedExpiredImportant.isImportant shouldBe false
+                    updatedExpiredImportant.importantUntil shouldBe null
+                }
+
+                Then("Notices with expiration date today or later, or no expiration date, should remain unchanged") {
+                    // Today
+                    val updatedTodayPinned = noticeRepository.findByIdOrNull(noticeTodayPinned.id)!!
+                    updatedTodayPinned.isPinned shouldBe true
+                    updatedTodayPinned.pinnedUntil shouldBe today
+
+                    val updatedTodayImportant = noticeRepository.findByIdOrNull(noticeTodayImportant.id)!!
+                    updatedTodayImportant.isImportant shouldBe true
+                    updatedTodayImportant.importantUntil shouldBe today
+
+                    // Future
+                    val updatedFuturePinned = noticeRepository.findByIdOrNull(noticeFuturePinned.id)!!
+                    updatedFuturePinned.isPinned shouldBe true
+                    updatedFuturePinned.pinnedUntil shouldBe tomorrow
+
+                    val updatedFutureImportant = noticeRepository.findByIdOrNull(noticeFutureImportant.id)!!
+                    updatedFutureImportant.isImportant shouldBe true
+                    updatedFutureImportant.importantUntil shouldBe tomorrow
+
+                    // Permanent
+                    val updatedPermanentPinned = noticeRepository.findByIdOrNull(noticePermanentPinned.id)!!
+                    updatedPermanentPinned.isPinned shouldBe true
+                    updatedPermanentPinned.pinnedUntil shouldBe null
+
+                    val updatedPermanentImportant = noticeRepository.findByIdOrNull(noticePermanentImportant.id)!!
+                    updatedPermanentImportant.isImportant shouldBe true
+                    updatedPermanentImportant.importantUntil shouldBe null
+
+                    // Neither
+                    val updatedNotPinnedOrImportant = noticeRepository.findByIdOrNull(noticeNotPinnedOrImportant.id)!!
+                    updatedNotPinnedOrImportant.isPinned shouldBe false
+                    updatedNotPinnedOrImportant.pinnedUntil shouldBe null
+                    updatedNotPinnedOrImportant.isImportant shouldBe false
+                    updatedNotPinnedOrImportant.importantUntil shouldBe null
+                }
+            }
+        }
+    }
+
+    private fun createTestNotice(
+        title: String,
+        isPinned: Boolean = false,
+        pinnedUntil: LocalDate? = null,
+        isImportant: Boolean = false,
+        importantUntil: LocalDate? = null
+    ): NoticeEntity {
+        return noticeRepository.save(
+            NoticeEntity(
+                title = title,
+                titleForMain = null,
+                description = "Test description for $title",
+                plainTextDescription = "Test description for $title",
+                isPrivate = false,
+                isPinned = isPinned,
+                pinnedUntil = pinnedUntil,
+                isImportant = isImportant,
+                importantUntil = importantUntil,
+                author = user
+            )
+        )
+    }
+} 

--- a/src/test/kotlin/com/wafflestudio/csereal/core/notice/scheduler/NoticeSchedulerTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/notice/scheduler/NoticeSchedulerTest.kt
@@ -43,32 +43,59 @@ class NoticeSchedulerTest(
 
         Given("Various notices with different expiration dates are present") {
             // Create test notices
-            val noticeExpiredPinned = createTestNotice("Expired Pinned", isPinned = true, pinnedUntil = yesterday)
+            val noticeExpiredPinned = createTestNotice(
+                title = "Expired Pinned",
+                isPinned = true,
+                pinnedUntil = yesterday
+            )
+
             val noticeExpiredImportant = createTestNotice(
-                "Expired Important",
+                title = "Expired Important",
                 isImportant = true,
                 importantUntil = yesterday
             )
-            val noticeTodayPinned = createTestNotice("Today Pinned", isPinned = true, pinnedUntil = today)
-            val noticeTodayImportant = createTestNotice("Today Important", isImportant = true, importantUntil = today)
-            val noticeFuturePinned = createTestNotice("Future Pinned", isPinned = true, pinnedUntil = tomorrow)
+
+            val noticeTodayPinned = createTestNotice(
+                title = "Today Pinned",
+                isPinned = true,
+                pinnedUntil = today
+            )
+
+            val noticeTodayImportant = createTestNotice(
+                title = "Today Important",
+                isImportant = true,
+                importantUntil = today
+            )
+
+            val noticeFuturePinned = createTestNotice(
+                title = "Future Pinned",
+                isPinned = true,
+                pinnedUntil = tomorrow
+            )
+
             val noticeFutureImportant = createTestNotice(
-                "Future Important",
+                title = "Future Important",
                 isImportant = true,
                 importantUntil = tomorrow
             )
-            val noticePermanentPinned = createTestNotice("Permanent Pinned", isPinned = true, pinnedUntil = null)
+
+            val noticePermanentPinned = createTestNotice(
+                title = "Permanent Pinned",
+                isPinned = true,
+                pinnedUntil = null
+            )
+
             val noticePermanentImportant = createTestNotice(
-                "Permanent Important",
+                title = "Permanent Important",
                 isImportant = true,
                 importantUntil = null
             )
+
             val noticeNotPinnedOrImportant = createTestNotice(
-                "Not Pinned or Important",
+                title = "Not Pinned or Important",
                 isPinned = false,
                 isImportant = false
             )
-
             When("The updateNoticeExpirationStatus scheduler task runs") {
                 noticeScheduler.updateNoticeExpirationStatus()
 

--- a/src/test/kotlin/com/wafflestudio/csereal/core/notice/scheduler/NoticeSchedulerTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/notice/scheduler/NoticeSchedulerTest.kt
@@ -44,14 +44,30 @@ class NoticeSchedulerTest(
         Given("Various notices with different expiration dates are present") {
             // Create test notices
             val noticeExpiredPinned = createTestNotice("Expired Pinned", isPinned = true, pinnedUntil = yesterday)
-            val noticeExpiredImportant = createTestNotice("Expired Important", isImportant = true, importantUntil = yesterday)
+            val noticeExpiredImportant = createTestNotice(
+                "Expired Important",
+                isImportant = true,
+                importantUntil = yesterday
+            )
             val noticeTodayPinned = createTestNotice("Today Pinned", isPinned = true, pinnedUntil = today)
             val noticeTodayImportant = createTestNotice("Today Important", isImportant = true, importantUntil = today)
             val noticeFuturePinned = createTestNotice("Future Pinned", isPinned = true, pinnedUntil = tomorrow)
-            val noticeFutureImportant = createTestNotice("Future Important", isImportant = true, importantUntil = tomorrow)
+            val noticeFutureImportant = createTestNotice(
+                "Future Important",
+                isImportant = true,
+                importantUntil = tomorrow
+            )
             val noticePermanentPinned = createTestNotice("Permanent Pinned", isPinned = true, pinnedUntil = null)
-            val noticePermanentImportant = createTestNotice("Permanent Important", isImportant = true, importantUntil = null)
-            val noticeNotPinnedOrImportant = createTestNotice("Not Pinned or Important", isPinned = false, isImportant = false)
+            val noticePermanentImportant = createTestNotice(
+                "Permanent Important",
+                isImportant = true,
+                importantUntil = null
+            )
+            val noticeNotPinnedOrImportant = createTestNotice(
+                "Not Pinned or Important",
+                isPinned = false,
+                isImportant = false
+            )
 
             When("The updateNoticeExpirationStatus scheduler task runs") {
                 noticeScheduler.updateNoticeExpirationStatus()
@@ -127,4 +143,4 @@ class NoticeSchedulerTest(
             )
         )
     }
-} 
+}

--- a/src/test/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeServiceTest.kt
@@ -49,7 +49,7 @@ class NoticeServiceTest(
                 prevTitle = null,
                 nextId = null,
                 nextTitle = null,
-                attachments = null,
+                attachments = null
             )
 
             When("공지사항을 생성하면") {

--- a/src/test/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/notice/service/NoticeServiceTest.kt
@@ -42,12 +42,14 @@ class NoticeServiceTest(
                 modifiedAt = null,
                 isPrivate = false,
                 isPinned = false,
+                pinnedUntil = null,
                 isImportant = false,
+                importantUntil = null,
                 prevId = null,
                 prevTitle = null,
                 nextId = null,
                 nextTitle = null,
-                attachments = null
+                attachments = null,
             )
 
             When("공지사항을 생성하면") {


### PR DESCRIPTION
## 설명

기존의 공지사항 고정(`isPinned`) 및 중요(`isImportant`) 표시는 영구적이었습니다. 운영상 특정 기간 동안만 해당 상태를 유지해야 하는 요구사항을 충족하기 위해, 고정 및 중요 상태에 만료 기한을 설정하는 기능을 추가합니다.

## 주요 변경 사항

1.  **데이터베이스 및 모델 변경:**
    *   `notice` 테이블 및 `NoticeEntity`에 만료 날짜를 저장하기 위한 `pinned_until` (DATE, nullable), `important_until` (DATE, nullable) 컬럼/필드를 추가했습니다. (Flyway 마이그레이션 `V9`)
    *   `NoticeDto`에도 해당 `LocalDate?` 타입 필드를 추가하여 API 요청 및 응답에 포함될 수 있도록 했습니다.

2.  **생성/수정 로직 변경:**
    *   `NoticeService`의 공지 생성(`createNotice`) 및 수정(`NoticeEntity.update`) 로직을 수정하여 `isPinned`/`isImportant` 플래그와 함께 만료 날짜(`pinnedUntil`/`importantUntil`)를 설정할 수 있도록 했습니다.
    *   사용자 요청 시 `isPinned`/`isImportant` 플래그가 우선시됩니다. (예: `isPinned=false`로 요청 시 `pinnedUntil` 값은 무시되고 `null`로 저장됨)

3.  **자동 만료 처리 (스케줄러):**
    *   매일 새벽 1시(KST)에 실행되는 `NoticeScheduler`를 추가했습니다.
    *   이 스케줄러는 `NoticeRepository`의 배치 업데이트 메서드를 호출하여, 만료일(`pinnedUntil`, `importantUntil`)이 지난 공지사항의 `isPinned`/`isImportant` 상태를 `false`로, 해당 만료 날짜 필드를 `null`로 자동 업데이트합니다.
    *   `NoticeRepository`에 관련 JPQL 배치 업데이트 쿼리(`updateExpiredPinnedStatus`, `updateExpiredImportantStatus`)를 추가했습니다.
    *   `CserealApplication`에 `@EnableScheduling`을 추가하여 스케줄링 기능을 활성화했습니다.

4.  **테스트 추가:**
    *   `NoticeScheduler`의 만료 처리 로직이 올바르게 동작하는지 검증하는 통합 테스트(`NoticeSchedulerTest`)를 추가했습니다.

## 참고

*   이번 변경은 하위 호환성을 유지하며, 기존 API 사용 방식에는 영향을 주지 않습니다.
*   만료 날짜 필드(`pinnedUntil`, `importantUntil`)는 선택 사항입니다. 설정하지 않으면 기존처럼 영구적으로 고정/중요 상태가 유지됩니다.
