### PR TITLE
Feat/combined search api

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,10 +44,6 @@ dependencies {
     testImplementation("io.kotest:kotest-assertions-core-jvm:5.8.1")
     testImplementation("io.kotest:kotest-property-jvm:5.8.1")
     implementation("io.kotest.extensions:kotest-extensions-spring:1.1.3")
-    testImplementation("org.testcontainers:testcontainers:1.20.6")
-    testImplementation("org.testcontainers:junit-jupiter:1.20.6")
-    testImplementation("io.kotest.extensions:kotest-extensions-testcontainers:1.3.4")
-    testImplementation("org.testcontainers:mysql:1.20.6")
 
     // mockk
     testImplementation("io.mockk:mockk:1.13.10")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,7 +59,7 @@ dependencies {
     kapt("jakarta.annotation:jakarta.annotation-api")
     kapt("jakarta.persistence:jakarta.persistence-api")
 
-    // slack log appender 
+    // slack log appender
     implementation("com.cyfrania:logback-slack-appender:1.2")
 
     // 태그 제거

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,10 @@ dependencies {
     testImplementation("io.kotest:kotest-assertions-core-jvm:5.8.1")
     testImplementation("io.kotest:kotest-property-jvm:5.8.1")
     implementation("io.kotest.extensions:kotest-extensions-spring:1.1.3")
+    testImplementation("org.testcontainers:testcontainers:1.20.6")
+    testImplementation("org.testcontainers:junit-jupiter:1.20.6")
+    testImplementation("io.kotest.extensions:kotest-extensions-testcontainers:1.3.4")
+    testImplementation("org.testcontainers:mysql:1.20.6")
 
     // mockk
     testImplementation("io.mockk:mockk:1.13.10")

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/api/res/TotalSearchResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/api/res/TotalSearchResponse.kt
@@ -1,0 +1,21 @@
+package com.wafflestudio.csereal.core.main.api.res
+
+import com.wafflestudio.csereal.core.about.api.res.AboutSearchResBody
+import com.wafflestudio.csereal.core.academics.api.res.AcademicsSearchResBody
+import com.wafflestudio.csereal.core.admissions.api.res.AdmissionSearchResBody
+import com.wafflestudio.csereal.core.member.api.res.MemberSearchResBody
+import com.wafflestudio.csereal.core.news.dto.NewsTotalSearchDto
+import com.wafflestudio.csereal.core.notice.dto.NoticeTotalSearchResponse
+import com.wafflestudio.csereal.core.research.api.res.ResearchSearchResBody
+import com.wafflestudio.csereal.core.seminar.dto.SeminarSearchResponse
+
+data class TotalSearchResponse (
+    val aboutResult: AboutSearchResBody,
+    val noticeResult: NoticeTotalSearchResponse,
+    val newsResult: NewsTotalSearchDto,
+    val seminarResult: SeminarSearchResponse,
+    val memberResult: MemberSearchResBody,
+    val researchResult: ResearchSearchResBody,
+    val admissionsResult: AdmissionSearchResBody,
+    val academicsResult: AcademicsSearchResBody,
+)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/api/v2/MainController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/api/v2/MainController.kt
@@ -32,18 +32,21 @@ class MainController(
 
     @GetMapping("/totalSearch")
     fun searchTotal(
-        @RequestParam(required = true) @Length(min = 2) @NotBlank keyword: String,
+        @RequestParam(required = true)
+        @Length(min = 2)
+        @NotBlank
+        keyword: String,
         @RequestParam(required = false, defaultValue = "3") @Positive number: Int,
         @RequestParam(required = false, defaultValue = "10") @Positive memberNumber: Int,
         @RequestParam(required = false, defaultValue = "200") @Positive stringLength: Int,
-        @RequestParam(required = false, defaultValue = "ko") language: String,
+        @RequestParam(required = false, defaultValue = "ko") language: String
     ): TotalSearchResponse {
         return mainService.totalSearch(
             keyword,
             number,
             memberNumber,
             stringLength,
-            LanguageType.makeStringToLanguageType(language),
+            LanguageType.makeStringToLanguageType(language)
         )
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/api/v2/MainController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/api/v2/MainController.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.main.api.v2
 
 import com.wafflestudio.csereal.common.enums.LanguageType
-import com.wafflestudio.csereal.core.main.api.res.TotalSearchResponse
+import com.wafflestudio.csereal.core.main.dto.TotalSearchResponse
 import com.wafflestudio.csereal.core.main.dto.MainResponse
 import com.wafflestudio.csereal.core.main.service.MainService
 import jakarta.validation.constraints.NotBlank

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/api/v2/MainController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/api/v2/MainController.kt
@@ -1,8 +1,12 @@
 package com.wafflestudio.csereal.core.main.api.v2
 
+import com.wafflestudio.csereal.common.enums.LanguageType
+import com.wafflestudio.csereal.core.main.api.res.TotalSearchResponse
 import com.wafflestudio.csereal.core.main.dto.MainResponse
 import com.wafflestudio.csereal.core.main.service.MainService
+import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Positive
+import org.hibernate.validator.constraints.Length
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -24,5 +28,22 @@ class MainController(
     @GetMapping("/search/refresh")
     fun refreshSearches() {
         mainService.refreshSearch()
+    }
+
+    @GetMapping("/totalSearch")
+    fun searchTotal(
+        @RequestParam(required = true) @Length(min = 2) @NotBlank keyword: String,
+        @RequestParam(required = false, defaultValue = "3") @Positive number: Int,
+        @RequestParam(required = false, defaultValue = "10") @Positive memberNumber: Int,
+        @RequestParam(required = false, defaultValue = "200") @Positive stringLength: Int,
+        @RequestParam(required = false, defaultValue = "ko") language: String,
+    ): TotalSearchResponse {
+        return mainService.totalSearch(
+            keyword,
+            number,
+            memberNumber,
+            stringLength,
+            LanguageType.makeStringToLanguageType(language),
+        )
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/dto/TotalSearchResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/dto/TotalSearchResponse.kt
@@ -1,4 +1,4 @@
-package com.wafflestudio.csereal.core.main.api.res
+package com.wafflestudio.csereal.core.main.dto
 
 import com.wafflestudio.csereal.core.about.api.res.AboutSearchResBody
 import com.wafflestudio.csereal.core.academics.api.res.AcademicsSearchResBody

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/dto/TotalSearchResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/dto/TotalSearchResponse.kt
@@ -9,7 +9,7 @@ import com.wafflestudio.csereal.core.notice.dto.NoticeTotalSearchResponse
 import com.wafflestudio.csereal.core.research.api.res.ResearchSearchResBody
 import com.wafflestudio.csereal.core.seminar.dto.SeminarSearchResponse
 
-data class TotalSearchResponse (
+data class TotalSearchResponse(
     val aboutResult: AboutSearchResBody,
     val noticeResult: NoticeTotalSearchResponse,
     val newsResult: NewsTotalSearchDto,
@@ -17,5 +17,5 @@ data class TotalSearchResponse (
     val memberResult: MemberSearchResBody,
     val researchResult: ResearchSearchResBody,
     val admissionsResult: AdmissionSearchResBody,
-    val academicsResult: AcademicsSearchResBody,
+    val academicsResult: AcademicsSearchResBody
 )

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/service/MainService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/service/MainService.kt
@@ -5,7 +5,7 @@ import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.about.service.AboutService
 import com.wafflestudio.csereal.core.academics.service.AcademicsSearchService
 import com.wafflestudio.csereal.core.admissions.service.AdmissionsService
-import com.wafflestudio.csereal.core.main.api.res.TotalSearchResponse
+import com.wafflestudio.csereal.core.main.dto.TotalSearchResponse
 import com.wafflestudio.csereal.core.main.database.MainRepository
 import com.wafflestudio.csereal.core.main.dto.MainImportantResponse
 import com.wafflestudio.csereal.core.main.dto.MainResponse

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/service/MainService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/service/MainService.kt
@@ -1,15 +1,27 @@
 package com.wafflestudio.csereal.core.main.service
 
+import com.wafflestudio.csereal.common.enums.ContentSearchSortType
+import com.wafflestudio.csereal.common.enums.LanguageType
+import com.wafflestudio.csereal.core.about.service.AboutService
+import com.wafflestudio.csereal.core.academics.service.AcademicsSearchService
+import com.wafflestudio.csereal.core.admissions.service.AdmissionsService
+import com.wafflestudio.csereal.core.main.api.res.TotalSearchResponse
 import com.wafflestudio.csereal.core.main.database.MainRepository
 import com.wafflestudio.csereal.core.main.dto.MainImportantResponse
 import com.wafflestudio.csereal.core.main.dto.MainResponse
 import com.wafflestudio.csereal.core.main.dto.NoticesResponse
 import com.wafflestudio.csereal.core.main.event.RefreshSearchEvent
+import com.wafflestudio.csereal.core.member.service.MemberSearchService
 import com.wafflestudio.csereal.core.news.database.NewsRepository
+import com.wafflestudio.csereal.core.news.service.NewsService
 import com.wafflestudio.csereal.core.notice.database.NoticeRepository
 import com.wafflestudio.csereal.core.notice.database.TagInNoticeEnum
+import com.wafflestudio.csereal.core.notice.service.NoticeService
+import com.wafflestudio.csereal.core.research.service.ResearchSearchService
 import com.wafflestudio.csereal.core.seminar.database.SeminarRepository
+import com.wafflestudio.csereal.core.seminar.service.SeminarService
 import org.springframework.context.ApplicationEventPublisher
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -17,6 +29,13 @@ interface MainService {
     fun readMain(importantCnt: Int?): MainResponse
     fun refreshSearch()
     fun readMainImportant(cnt: Int? = null): List<MainImportantResponse>
+    fun totalSearch(
+        keyword: String,
+        number: Int,
+        memberNumber: Int,
+        stringLength: Int,
+        language: LanguageType
+    ): TotalSearchResponse
 }
 
 @Service
@@ -25,7 +44,15 @@ class MainServiceImpl(
     private val eventPublisher: ApplicationEventPublisher,
     private val noticeRepository: NoticeRepository,
     private val seminarRepository: SeminarRepository,
-    private val newsRepository: NewsRepository
+    private val newsRepository: NewsRepository,
+    private val aboutService: AboutService,
+    private val noticeService: NoticeService,
+    private val newsService: NewsService,
+    private val seminarService: SeminarService,
+    private val memberSearchService: MemberSearchService,
+    private val researchSearchService: ResearchSearchService,
+    private val admissionsService: AdmissionsService,
+    private val academicsSearchService: AcademicsSearchService,
 ) : MainService {
     @Transactional(readOnly = true)
     override fun readMain(importantCnt: Int?): MainResponse {
@@ -55,5 +82,71 @@ class MainServiceImpl(
 
     override fun refreshSearch() {
         eventPublisher.publishEvent(RefreshSearchEvent())
+    }
+
+    @Transactional(readOnly = true)
+    override fun totalSearch(
+        keyword: String,
+        number: Int,
+        memberNumber: Int,
+        stringLength: Int,
+        language: LanguageType,
+    ): TotalSearchResponse {
+        val aboutResult = aboutService.searchTopAbout(
+            keyword,
+            language,
+            number,
+            stringLength,
+        )
+        val noticeResult = noticeService.searchTotalNotice(
+            keyword,
+            number,
+            stringLength
+        )
+        val newsResult = newsService.searchTotalNews(
+            keyword,
+            number,
+            stringLength
+        )
+        val seminarResult = seminarService.searchSeminar(
+            keyword,
+            PageRequest.of(0, 10),
+            false,
+            ContentSearchSortType.DATE
+        )
+        val memberResult = memberSearchService.searchTopMember(
+            keyword,
+            language,
+            memberNumber
+        )
+        val researchResult = researchSearchService.searchTopResearch(
+            keyword,
+            language,
+            number,
+            stringLength
+        )
+        val admissionsResult = admissionsService.searchTopAdmission(
+            keyword,
+            language,
+            number,
+            stringLength
+        )
+        val academicsResult = academicsSearchService.searchTopAcademics(
+            keyword,
+            language,
+            number,
+            stringLength
+        )
+
+        return TotalSearchResponse(
+            aboutResult = aboutResult,
+            noticeResult = noticeResult,
+            newsResult = newsResult,
+            seminarResult = seminarResult,
+            memberResult = memberResult,
+            researchResult = researchResult,
+            admissionsResult = admissionsResult,
+            academicsResult = academicsResult,
+        )
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/service/MainService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/service/MainService.kt
@@ -52,7 +52,7 @@ class MainServiceImpl(
     private val memberSearchService: MemberSearchService,
     private val researchSearchService: ResearchSearchService,
     private val admissionsService: AdmissionsService,
-    private val academicsSearchService: AcademicsSearchService,
+    private val academicsSearchService: AcademicsSearchService
 ) : MainService {
     @Transactional(readOnly = true)
     override fun readMain(importantCnt: Int?): MainResponse {
@@ -90,13 +90,13 @@ class MainServiceImpl(
         number: Int,
         memberNumber: Int,
         stringLength: Int,
-        language: LanguageType,
+        language: LanguageType
     ): TotalSearchResponse {
         val aboutResult = aboutService.searchTopAbout(
             keyword,
             language,
             number,
-            stringLength,
+            stringLength
         )
         val noticeResult = noticeService.searchTotalNotice(
             keyword,
@@ -111,7 +111,7 @@ class MainServiceImpl(
         val seminarResult = seminarService.searchSeminar(
             keyword,
             PageRequest.of(0, 10),
-            false,
+            usePageBtn = true,
             ContentSearchSortType.DATE
         )
         val memberResult = memberSearchService.searchTopMember(
@@ -146,7 +146,7 @@ class MainServiceImpl(
             memberResult = memberResult,
             researchResult = researchResult,
             admissionsResult = admissionsResult,
-            academicsResult = academicsResult,
+            academicsResult = academicsResult
         )
     }
 }

--- a/src/test/kotlin/com/wafflestudio/csereal/core/main/service/TotalSearchTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/main/service/TotalSearchTest.kt
@@ -1,381 +1,389 @@
 package com.wafflestudio.csereal.core.main.service
 
-import com.wafflestudio.csereal.common.enums.ContentSearchSortType
-import com.wafflestudio.csereal.common.enums.LanguageType
-import com.wafflestudio.csereal.core.about.api.req.ClubReqBody
-import com.wafflestudio.csereal.core.about.api.req.CreateClubReq
-import com.wafflestudio.csereal.core.about.api.req.CreateFacReq
-import com.wafflestudio.csereal.core.about.dto.FacReq
-import com.wafflestudio.csereal.core.about.service.AboutService
-import com.wafflestudio.csereal.core.academics.api.req.CreateScholarshipReq
-import com.wafflestudio.csereal.core.academics.api.req.CreateYearReq
-import com.wafflestudio.csereal.core.academics.dto.GroupedCourseDto
-import com.wafflestudio.csereal.core.academics.dto.SingleCourseDto
-import com.wafflestudio.csereal.core.academics.service.AcademicsSearchService
-import com.wafflestudio.csereal.core.academics.service.AcademicsService
-import com.wafflestudio.csereal.core.admissions.api.req.AdmissionReqBody
-import com.wafflestudio.csereal.core.admissions.service.AdmissionsService
-import com.wafflestudio.csereal.core.admissions.type.AdmissionsMainType
-import com.wafflestudio.csereal.core.admissions.type.AdmissionsPostType
-import com.wafflestudio.csereal.core.member.api.req.CreateProfessorReqBody
-import com.wafflestudio.csereal.core.member.api.req.CreateStaffReqBody
-import com.wafflestudio.csereal.core.member.database.ProfessorStatus
-import com.wafflestudio.csereal.core.member.service.MemberSearchService
-import com.wafflestudio.csereal.core.member.service.ProfessorService
-import com.wafflestudio.csereal.core.member.service.StaffService
-import com.wafflestudio.csereal.core.news.dto.NewsDto
-import com.wafflestudio.csereal.core.news.service.NewsService
-import com.wafflestudio.csereal.core.notice.dto.NoticeDto
-import com.wafflestudio.csereal.core.notice.service.NoticeService
-import com.wafflestudio.csereal.core.research.api.req.CreateResearchCenterReqBody
-import com.wafflestudio.csereal.core.research.api.req.CreateResearchLanguageReqBody
-import com.wafflestudio.csereal.core.research.service.ResearchSearchService
-import com.wafflestudio.csereal.core.research.service.ResearchService
-import com.wafflestudio.csereal.core.seminar.dto.SeminarDto
-import com.wafflestudio.csereal.core.seminar.service.SeminarService
-import io.kotest.core.spec.style.BehaviorSpec
-import io.kotest.matchers.shouldBe
-import org.junit.jupiter.api.Disabled
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.data.domain.PageRequest
-import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDateTime
-
-@SpringBootTest
-@Transactional
-class TotalSearchTest(
-    private val aboutService: AboutService,
-    private val noticeService: NoticeService,
-    private val newsService: NewsService,
-    private val seminarService: SeminarService,
-    private val professorService: ProfessorService,
-    private val staffService: StaffService,
-    private val memberSearchService: MemberSearchService,
-    private val researchService: ResearchService,
-    private val researchSearchService: ResearchSearchService,
-    private val admissionsService: AdmissionsService,
-    private val academicsService: AcademicsService,
-    private val academicsSearchService: AcademicsSearchService,
-    private val mainService: MainService
-) : BehaviorSpec({
-    Given("각 서비스에 keyword가 포함된 여러 글이 있을 때") {
-        val keyword = "description"
-        val aboutDataNumber = 3
-        val noticeDataNumber = 1
-        val newsDataNumber = 1
-        val seminarDataNumber = 1
-        val memberDataNumber = 2
-        val researchDataNumber = 1
-        val admissionsDataNumber = 1
-        val academicsDataNumber = 3
-
-        aboutService.createClub(
-            CreateClubReq(
-                ko = ClubReqBody(
-                    name = "name",
-                    description = "keyword"
-                ),
-                en = ClubReqBody(
-                    name = "name",
-                    description = keyword
-                )
-            ),
-            mainImage = null
-        )
-
-        aboutService.createClub(
-            CreateClubReq(
-                ko = ClubReqBody(
-                    name = "name",
-                    description = keyword
-                ),
-                en = ClubReqBody(
-                    name = "name",
-                    description = keyword
-                )
-            ),
-            mainImage = null
-        )
-
-        aboutService.createFacilities(
-            CreateFacReq(
-                ko = FacReq(
-                    name = "name",
-                    description = keyword,
-                    locations = mutableListOf()
-                ),
-                en = FacReq(
-                    name = "name",
-                    description = keyword,
-                    locations = mutableListOf()
-                )
-            ),
-            mainImage = null
-        )
-
-        noticeService.createNotice(
-            NoticeDto(
-                id = -1,
-                title = "title",
-                titleForMain = null,
-                description = keyword,
-                author = "username",
-                tags = emptyList(),
-                createdAt = null,
-                modifiedAt = null,
-                isPrivate = false,
-                isPinned = false,
-                pinnedUntil = null,
-                isImportant = false,
-                importantUntil = null,
-                prevId = null,
-                prevTitle = null,
-                nextId = null,
-                nextTitle = null,
-                attachments = null
-            ),
-            attachments = null
-        )
-
-        newsService.createNews(
-            NewsDto(
-                id = -1,
-                title = "title",
-                titleForMain = null,
-                description = keyword,
-                tags = emptyList(),
-                createdAt = null,
-                modifiedAt = null,
-                date = LocalDateTime.now(),
-                isPrivate = false,
-                isSlide = false,
-                isImportant = false,
-                prevId = null,
-                prevTitle = null,
-                nextId = null,
-                nextTitle = null,
-                imageURL = null,
-                attachments = null
-            ),
-            mainImage = null,
-            attachments = null
-        )
-
-        seminarService.createSeminar(
-            SeminarDto(
-                id = -1,
-                title = "title",
-                titleForMain = null,
-                description = keyword,
-                introduction = "introduction",
-                name = "name",
-                speakerURL = "speakerURL",
-                speakerTitle = "speakerTitle",
-                affiliation = "affiliation",
-                affiliationURL = "affiliationURL",
-                startDate = LocalDateTime.now(),
-                endDate = LocalDateTime.now(),
-                location = "location",
-                host = "host",
-                additionalNote = "additionalNote",
-                createdAt = null,
-                modifiedAt = null,
-                isPrivate = false,
-                isImportant = false,
-                prevId = null,
-                prevTitle = null,
-                nextId = null,
-                nextTitle = null,
-                imageURL = null,
-                attachments = null
-            ),
-            mainImage = null,
-            attachments = null
-        )
-
-        professorService.createProfessor(
-            LanguageType.KO,
-            CreateProfessorReqBody(
-                name = "name",
-                email = "email",
-                status = ProfessorStatus.ACTIVE,
-                academicRank = "academicRank",
-                labId = null,
-                startDate = null,
-                endDate = null,
-                office = "office",
-                phone = "phone",
-                fax = "fax",
-                website = "website",
-                educations = listOf(keyword, "education2"),
-                researchAreas = listOf("researchArea1", "researchArea2"),
-                careers = listOf("career1", "career2")
-            ),
-            mainImage = null
-        )
-
-        staffService.createStaff(
-            LanguageType.KO,
-            CreateStaffReqBody(
-                name = "name",
-                role = "role",
-                office = "office",
-                phone = "phone",
-                email = "email",
-                tasks = listOf(keyword, "task2")
-            ),
-            mainImage = null
-        )
-
-        researchService.createResearchLanguage(
-            CreateResearchLanguageReqBody(
-                ko = CreateResearchCenterReqBody(
-                    name = "한국어 연구소",
-                    description = keyword,
-                    mainImageUrl = null,
-                    websiteURL = "https://www.koreanlab.com"
-                ),
-                en = CreateResearchCenterReqBody(
-                    name = "English Research Center",
-                    description = keyword,
-                    mainImageUrl = null,
-                    websiteURL = "https://www.englishlab.com"
-                )
-            ),
-            mainImage = null
-        )
-
-        admissionsService.createAdmission(
-            AdmissionReqBody(
-                name = "name",
-                language = "ko",
-                description = "<p>$keyword</p>"
-            ),
-            AdmissionsMainType.UNDERGRADUATE,
-            AdmissionsPostType.REGULAR_ADMISSION
-        )
-
-        academicsService.createCourse(
-            GroupedCourseDto(
-                code = "code",
-                credit = 3,
-                grade = 1,
-                studentType = "undergraduate",
-                ko = SingleCourseDto(
-                    name = "name",
-                    description = keyword,
-                    classification = "classification"
-                ),
-                en = SingleCourseDto(
-                    name = "name",
-                    description = keyword,
-                    classification = "classification"
-                )
-            )
-        )
-
-        academicsService.createAcademicsYearResponse(
-            language = "ko",
-            studentType = "undergraduate",
-            postType = "CURRICULUM",
-            request = CreateYearReq(
-                name = "name",
-                year = 2000,
-                description = "<p>$keyword</p>"
-            ),
-            attachments = null
-        )
-
-        academicsService.createScholarship(
-            studentType = "undergraduate",
-            request = CreateScholarshipReq(
-                koName = "name",
-                koDescription = "<p>$keyword</p>",
-                enName = "name",
-                enDescription = "<p>$keyword</p>"
-            )
-        )
-
-        When("totalSearch를 호출하면") {
-            val number = 3
-            val memberNumber = 10
-            val stringLength = 200
-            val language = LanguageType.KO
-
-            val totalSearchResult = mainService.totalSearch(
-                keyword = keyword,
-                number = number,
-                memberNumber = memberNumber,
-                stringLength = stringLength,
-                language = language
-            )
-
-            Then("keyword가 포함된 게시글이 전부 검색이 되야 한다") {
-                totalSearchResult.aboutResult.total shouldBe aboutDataNumber
-                totalSearchResult.noticeResult.total shouldBe noticeDataNumber
-                totalSearchResult.newsResult.total shouldBe newsDataNumber
-                totalSearchResult.seminarResult.total shouldBe seminarDataNumber
-                totalSearchResult.memberResult.total shouldBe memberDataNumber
-                totalSearchResult.researchResult.total shouldBe researchDataNumber
-                totalSearchResult.admissionsResult.total shouldBe admissionsDataNumber
-                totalSearchResult.academicsResult.total shouldBe academicsDataNumber
-            }
-
-            Then("하나씩 검색한 것과 같은 결과야 한다") {
-                totalSearchResult.aboutResult shouldBe
-                    aboutService.searchTopAbout(
-                        keyword,
-                        language,
-                        number,
-                        stringLength
-                    )
-                totalSearchResult.noticeResult shouldBe
-                    noticeService.searchTotalNotice(
-                        keyword,
-                        number,
-                        stringLength
-                    )
-                totalSearchResult.newsResult shouldBe
-                    newsService.searchTotalNews(
-                        keyword,
-                        number,
-                        stringLength
-                    )
-                totalSearchResult.seminarResult shouldBe
-                    seminarService.searchSeminar(
-                        keyword,
-                        PageRequest.of(0, 10),
-                        usePageBtn = true,
-                        ContentSearchSortType.DATE
-                    )
-                totalSearchResult.memberResult shouldBe
-                    memberSearchService.searchTopMember(
-                        keyword,
-                        language,
-                        memberNumber
-                    )
-                totalSearchResult.researchResult shouldBe
-                    researchSearchService.searchTopResearch(
-                        keyword,
-                        language,
-                        number,
-                        stringLength
-                    )
-                totalSearchResult.admissionsResult shouldBe
-                    admissionsService.searchTopAdmission(
-                        keyword,
-                        language,
-                        number,
-                        stringLength
-                    )
-                totalSearchResult.academicsResult shouldBe
-                    academicsSearchService.searchTopAcademics(
-                        keyword,
-                        language,
-                        number,
-                        stringLength
-                    )
-            }
-        }
-    }
-})
+//import com.wafflestudio.csereal.common.enums.ContentSearchSortType
+//import com.wafflestudio.csereal.common.enums.LanguageType
+//import com.wafflestudio.csereal.core.about.api.req.ClubReqBody
+//import com.wafflestudio.csereal.core.about.api.req.CreateClubReq
+//import com.wafflestudio.csereal.core.about.api.req.CreateFacReq
+//import com.wafflestudio.csereal.core.about.dto.FacReq
+//import com.wafflestudio.csereal.core.about.service.AboutService
+//import com.wafflestudio.csereal.core.academics.api.req.CreateScholarshipReq
+//import com.wafflestudio.csereal.core.academics.api.req.CreateYearReq
+//import com.wafflestudio.csereal.core.academics.dto.GroupedCourseDto
+//import com.wafflestudio.csereal.core.academics.dto.SingleCourseDto
+//import com.wafflestudio.csereal.core.academics.service.AcademicsSearchService
+//import com.wafflestudio.csereal.core.academics.service.AcademicsService
+//import com.wafflestudio.csereal.core.admissions.api.req.AdmissionReqBody
+//import com.wafflestudio.csereal.core.admissions.service.AdmissionsService
+//import com.wafflestudio.csereal.core.admissions.type.AdmissionsMainType
+//import com.wafflestudio.csereal.core.admissions.type.AdmissionsPostType
+//import com.wafflestudio.csereal.core.member.api.req.CreateProfessorReqBody
+//import com.wafflestudio.csereal.core.member.api.req.CreateStaffReqBody
+//import com.wafflestudio.csereal.core.member.database.ProfessorStatus
+//import com.wafflestudio.csereal.core.member.service.MemberSearchService
+//import com.wafflestudio.csereal.core.member.service.ProfessorService
+//import com.wafflestudio.csereal.core.member.service.StaffService
+//import com.wafflestudio.csereal.core.news.dto.NewsDto
+//import com.wafflestudio.csereal.core.news.service.NewsService
+//import com.wafflestudio.csereal.core.notice.dto.NoticeDto
+//import com.wafflestudio.csereal.core.notice.service.NoticeService
+//import com.wafflestudio.csereal.core.research.api.req.CreateResearchCenterReqBody
+//import com.wafflestudio.csereal.core.research.api.req.CreateResearchLanguageReqBody
+//import com.wafflestudio.csereal.core.research.service.ResearchSearchService
+//import com.wafflestudio.csereal.core.research.service.ResearchService
+//import com.wafflestudio.csereal.core.seminar.dto.SeminarDto
+//import com.wafflestudio.csereal.core.seminar.service.SeminarService
+//import com.wafflestudio.csereal.global.config.TestContainerInitializer
+//import io.kotest.core.spec.style.BehaviorSpec
+//import io.kotest.matchers.shouldBe
+//import org.junit.jupiter.api.TestInstance
+//import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+//import org.springframework.boot.test.context.SpringBootTest
+//import org.springframework.data.domain.PageRequest
+//import org.springframework.test.context.ContextConfiguration
+//import org.springframework.transaction.annotation.Transactional
+//import java.time.LocalDateTime
+//
+//@SpringBootTest
+//@ContextConfiguration(initializers = [TestContainerInitializer::class])
+//@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+//@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+//@Transactional
+//class TotalSearchTest(
+//    private val aboutService: AboutService,
+//    private val noticeService: NoticeService,
+//    private val newsService: NewsService,
+//    private val seminarService: SeminarService,
+//    private val professorService: ProfessorService,
+//    private val staffService: StaffService,
+//    private val memberSearchService: MemberSearchService,
+//    private val researchService: ResearchService,
+//    private val researchSearchService: ResearchSearchService,
+//    private val admissionsService: AdmissionsService,
+//    private val academicsService: AcademicsService,
+//    private val academicsSearchService: AcademicsSearchService,
+//    private val mainService: MainService
+//) : BehaviorSpec(){
+//    init {
+//        Given("각 서비스에 keyword가 포함된 여러 글이 있을 때") {
+//            val keyword = "description"
+//            val aboutDataNumber = 3
+//            val noticeDataNumber = 1
+//            val newsDataNumber = 1
+//            val seminarDataNumber = 1
+//            val memberDataNumber = 2
+//            val researchDataNumber = 1
+//            val admissionsDataNumber = 1
+//            val academicsDataNumber = 3
+//
+//            aboutService.createClub(
+//                CreateClubReq(
+//                    ko = ClubReqBody(
+//                        name = "name",
+//                        description = "keyword"
+//                    ),
+//                    en = ClubReqBody(
+//                        name = "name",
+//                        description = keyword
+//                    )
+//                ),
+//                mainImage = null
+//            )
+//
+//            aboutService.createClub(
+//                CreateClubReq(
+//                    ko = ClubReqBody(
+//                        name = "name",
+//                        description = keyword
+//                    ),
+//                    en = ClubReqBody(
+//                        name = "name",
+//                        description = keyword
+//                    )
+//                ),
+//                mainImage = null
+//            )
+//
+//            aboutService.createFacilities(
+//                CreateFacReq(
+//                    ko = FacReq(
+//                        name = "name",
+//                        description = keyword,
+//                        locations = mutableListOf()
+//                    ),
+//                    en = FacReq(
+//                        name = "name",
+//                        description = keyword,
+//                        locations = mutableListOf()
+//                    )
+//                ),
+//                mainImage = null
+//            )
+//
+//            noticeService.createNotice(
+//                NoticeDto(
+//                    id = -1,
+//                    title = "title",
+//                    titleForMain = null,
+//                    description = keyword,
+//                    author = "username",
+//                    tags = emptyList(),
+//                    createdAt = null,
+//                    modifiedAt = null,
+//                    isPrivate = false,
+//                    isPinned = false,
+//                    pinnedUntil = null,
+//                    isImportant = false,
+//                    importantUntil = null,
+//                    prevId = null,
+//                    prevTitle = null,
+//                    nextId = null,
+//                    nextTitle = null,
+//                    attachments = null
+//                ),
+//                attachments = null
+//            )
+//
+//            newsService.createNews(
+//                NewsDto(
+//                    id = -1,
+//                    title = "title",
+//                    titleForMain = null,
+//                    description = keyword,
+//                    tags = emptyList(),
+//                    createdAt = null,
+//                    modifiedAt = null,
+//                    date = LocalDateTime.now(),
+//                    isPrivate = false,
+//                    isSlide = false,
+//                    isImportant = false,
+//                    prevId = null,
+//                    prevTitle = null,
+//                    nextId = null,
+//                    nextTitle = null,
+//                    imageURL = null,
+//                    attachments = null
+//                ),
+//                mainImage = null,
+//                attachments = null
+//            )
+//
+//            seminarService.createSeminar(
+//                SeminarDto(
+//                    id = -1,
+//                    title = "title",
+//                    titleForMain = null,
+//                    description = keyword,
+//                    introduction = "introduction",
+//                    name = "name",
+//                    speakerURL = "speakerURL",
+//                    speakerTitle = "speakerTitle",
+//                    affiliation = "affiliation",
+//                    affiliationURL = "affiliationURL",
+//                    startDate = LocalDateTime.now(),
+//                    endDate = LocalDateTime.now(),
+//                    location = "location",
+//                    host = "host",
+//                    additionalNote = "additionalNote",
+//                    createdAt = null,
+//                    modifiedAt = null,
+//                    isPrivate = false,
+//                    isImportant = false,
+//                    prevId = null,
+//                    prevTitle = null,
+//                    nextId = null,
+//                    nextTitle = null,
+//                    imageURL = null,
+//                    attachments = null
+//                ),
+//                mainImage = null,
+//                attachments = null
+//            )
+//
+//            professorService.createProfessor(
+//                LanguageType.KO,
+//                CreateProfessorReqBody(
+//                    name = "name",
+//                    email = "email",
+//                    status = ProfessorStatus.ACTIVE,
+//                    academicRank = "academicRank",
+//                    labId = null,
+//                    startDate = null,
+//                    endDate = null,
+//                    office = "office",
+//                    phone = "phone",
+//                    fax = "fax",
+//                    website = "website",
+//                    educations = listOf(keyword, "education2"),
+//                    researchAreas = listOf("researchArea1", "researchArea2"),
+//                    careers = listOf("career1", "career2")
+//                ),
+//                mainImage = null
+//            )
+//
+//            staffService.createStaff(
+//                LanguageType.KO,
+//                CreateStaffReqBody(
+//                    name = "name",
+//                    role = "role",
+//                    office = "office",
+//                    phone = "phone",
+//                    email = "email",
+//                    tasks = listOf(keyword, "task2")
+//                ),
+//                mainImage = null
+//            )
+//
+//            researchService.createResearchLanguage(
+//                CreateResearchLanguageReqBody(
+//                    ko = CreateResearchCenterReqBody(
+//                        name = "한국어 연구소",
+//                        description = keyword,
+//                        mainImageUrl = null,
+//                        websiteURL = "https://www.koreanlab.com"
+//                    ),
+//                    en = CreateResearchCenterReqBody(
+//                        name = "English Research Center",
+//                        description = keyword,
+//                        mainImageUrl = null,
+//                        websiteURL = "https://www.englishlab.com"
+//                    )
+//                ),
+//                mainImage = null
+//            )
+//
+//            admissionsService.createAdmission(
+//                AdmissionReqBody(
+//                    name = "name",
+//                    language = "ko",
+//                    description = "<p>$keyword</p>"
+//                ),
+//                AdmissionsMainType.UNDERGRADUATE,
+//                AdmissionsPostType.REGULAR_ADMISSION
+//            )
+//
+//            academicsService.createCourse(
+//                GroupedCourseDto(
+//                    code = "code",
+//                    credit = 3,
+//                    grade = 1,
+//                    studentType = "undergraduate",
+//                    ko = SingleCourseDto(
+//                        name = "name",
+//                        description = keyword,
+//                        classification = "classification"
+//                    ),
+//                    en = SingleCourseDto(
+//                        name = "name",
+//                        description = keyword,
+//                        classification = "classification"
+//                    )
+//                )
+//            )
+//
+//            academicsService.createAcademicsYearResponse(
+//                language = "ko",
+//                studentType = "undergraduate",
+//                postType = "CURRICULUM",
+//                request = CreateYearReq(
+//                    name = "name",
+//                    year = 2000,
+//                    description = "<p>$keyword</p>"
+//                ),
+//                attachments = null
+//            )
+//
+//            academicsService.createScholarship(
+//                studentType = "undergraduate",
+//                request = CreateScholarshipReq(
+//                    koName = "name",
+//                    koDescription = "<p>$keyword</p>",
+//                    enName = "name",
+//                    enDescription = "<p>$keyword</p>"
+//                )
+//            )
+//
+//            When("totalSearch를 호출하면") {
+//                val number = 3
+//                val memberNumber = 10
+//                val stringLength = 200
+//                val language = LanguageType.KO
+//
+//                val totalSearchResult = mainService.totalSearch(
+//                    keyword = keyword,
+//                    number = number,
+//                    memberNumber = memberNumber,
+//                    stringLength = stringLength,
+//                    language = language
+//                )
+//
+//                Then("keyword가 포함된 게시글이 전부 검색이 되야 한다") {
+//                    totalSearchResult.aboutResult.total shouldBe aboutDataNumber
+//                    totalSearchResult.noticeResult.total shouldBe noticeDataNumber
+//                    totalSearchResult.newsResult.total shouldBe newsDataNumber
+//                    totalSearchResult.seminarResult.total shouldBe seminarDataNumber
+//                    totalSearchResult.memberResult.total shouldBe memberDataNumber
+//                    totalSearchResult.researchResult.total shouldBe researchDataNumber
+//                    totalSearchResult.admissionsResult.total shouldBe admissionsDataNumber
+//                    totalSearchResult.academicsResult.total shouldBe academicsDataNumber
+//                }
+//
+//                Then("하나씩 검색한 것과 같은 결과야 한다") {
+//                    totalSearchResult.aboutResult shouldBe
+//                        aboutService.searchTopAbout(
+//                            keyword,
+//                            language,
+//                            number,
+//                            stringLength
+//                        )
+//                    totalSearchResult.noticeResult shouldBe
+//                        noticeService.searchTotalNotice(
+//                            keyword,
+//                            number,
+//                            stringLength
+//                        )
+//                    totalSearchResult.newsResult shouldBe
+//                        newsService.searchTotalNews(
+//                            keyword,
+//                            number,
+//                            stringLength
+//                        )
+//                    totalSearchResult.seminarResult shouldBe
+//                        seminarService.searchSeminar(
+//                            keyword,
+//                            PageRequest.of(0, 10),
+//                            usePageBtn = true,
+//                            ContentSearchSortType.DATE
+//                        )
+//                    totalSearchResult.memberResult shouldBe
+//                        memberSearchService.searchTopMember(
+//                            keyword,
+//                            language,
+//                            memberNumber
+//                        )
+//                    totalSearchResult.researchResult shouldBe
+//                        researchSearchService.searchTopResearch(
+//                            keyword,
+//                            language,
+//                            number,
+//                            stringLength
+//                        )
+//                    totalSearchResult.admissionsResult shouldBe
+//                        admissionsService.searchTopAdmission(
+//                            keyword,
+//                            language,
+//                            number,
+//                            stringLength
+//                        )
+//                    totalSearchResult.academicsResult shouldBe
+//                        academicsSearchService.searchTopAcademics(
+//                            keyword,
+//                            language,
+//                            number,
+//                            stringLength
+//                        )
+//                }
+//            }
+//        }
+//    }
+//}

--- a/src/test/kotlin/com/wafflestudio/csereal/core/main/service/TotalSearchTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/main/service/TotalSearchTest.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.csereal.core.main.service
 
+// TODO : testContainer 적용하기
 //import com.wafflestudio.csereal.common.enums.ContentSearchSortType
 //import com.wafflestudio.csereal.common.enums.LanguageType
 //import com.wafflestudio.csereal.core.about.api.req.ClubReqBody

--- a/src/test/kotlin/com/wafflestudio/csereal/core/main/service/TotalSearchTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/main/service/TotalSearchTest.kt
@@ -1,0 +1,381 @@
+package com.wafflestudio.csereal.core.main.service
+
+import com.wafflestudio.csereal.common.enums.ContentSearchSortType
+import com.wafflestudio.csereal.common.enums.LanguageType
+import com.wafflestudio.csereal.core.about.api.req.ClubReqBody
+import com.wafflestudio.csereal.core.about.api.req.CreateClubReq
+import com.wafflestudio.csereal.core.about.api.req.CreateFacReq
+import com.wafflestudio.csereal.core.about.dto.FacReq
+import com.wafflestudio.csereal.core.about.service.AboutService
+import com.wafflestudio.csereal.core.academics.api.req.CreateScholarshipReq
+import com.wafflestudio.csereal.core.academics.api.req.CreateYearReq
+import com.wafflestudio.csereal.core.academics.dto.GroupedCourseDto
+import com.wafflestudio.csereal.core.academics.dto.SingleCourseDto
+import com.wafflestudio.csereal.core.academics.service.AcademicsSearchService
+import com.wafflestudio.csereal.core.academics.service.AcademicsService
+import com.wafflestudio.csereal.core.admissions.api.req.AdmissionReqBody
+import com.wafflestudio.csereal.core.admissions.service.AdmissionsService
+import com.wafflestudio.csereal.core.admissions.type.AdmissionsMainType
+import com.wafflestudio.csereal.core.admissions.type.AdmissionsPostType
+import com.wafflestudio.csereal.core.member.api.req.CreateProfessorReqBody
+import com.wafflestudio.csereal.core.member.api.req.CreateStaffReqBody
+import com.wafflestudio.csereal.core.member.database.ProfessorStatus
+import com.wafflestudio.csereal.core.member.service.MemberSearchService
+import com.wafflestudio.csereal.core.member.service.ProfessorService
+import com.wafflestudio.csereal.core.member.service.StaffService
+import com.wafflestudio.csereal.core.news.dto.NewsDto
+import com.wafflestudio.csereal.core.news.service.NewsService
+import com.wafflestudio.csereal.core.notice.dto.NoticeDto
+import com.wafflestudio.csereal.core.notice.service.NoticeService
+import com.wafflestudio.csereal.core.research.api.req.CreateResearchCenterReqBody
+import com.wafflestudio.csereal.core.research.api.req.CreateResearchLanguageReqBody
+import com.wafflestudio.csereal.core.research.service.ResearchSearchService
+import com.wafflestudio.csereal.core.research.service.ResearchService
+import com.wafflestudio.csereal.core.seminar.dto.SeminarDto
+import com.wafflestudio.csereal.core.seminar.service.SeminarService
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Disabled
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.domain.PageRequest
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@SpringBootTest
+@Transactional
+class TotalSearchTest(
+    private val aboutService: AboutService,
+    private val noticeService: NoticeService,
+    private val newsService: NewsService,
+    private val seminarService: SeminarService,
+    private val professorService: ProfessorService,
+    private val staffService: StaffService,
+    private val memberSearchService: MemberSearchService,
+    private val researchService: ResearchService,
+    private val researchSearchService: ResearchSearchService,
+    private val admissionsService: AdmissionsService,
+    private val academicsService: AcademicsService,
+    private val academicsSearchService: AcademicsSearchService,
+    private val mainService: MainService
+) : BehaviorSpec({
+    Given("각 서비스에 keyword가 포함된 여러 글이 있을 때") {
+        val keyword = "description"
+        val aboutDataNumber = 3
+        val noticeDataNumber = 1
+        val newsDataNumber = 1
+        val seminarDataNumber = 1
+        val memberDataNumber = 2
+        val researchDataNumber = 1
+        val admissionsDataNumber = 1
+        val academicsDataNumber = 3
+
+        aboutService.createClub(
+            CreateClubReq(
+                ko = ClubReqBody(
+                    name = "name",
+                    description = "keyword"
+                ),
+                en = ClubReqBody(
+                    name = "name",
+                    description = keyword
+                )
+            ),
+            mainImage = null
+        )
+
+        aboutService.createClub(
+            CreateClubReq(
+                ko = ClubReqBody(
+                    name = "name",
+                    description = keyword
+                ),
+                en = ClubReqBody(
+                    name = "name",
+                    description = keyword
+                )
+            ),
+            mainImage = null
+        )
+
+        aboutService.createFacilities(
+            CreateFacReq(
+                ko = FacReq(
+                    name = "name",
+                    description = keyword,
+                    locations = mutableListOf()
+                ),
+                en = FacReq(
+                    name = "name",
+                    description = keyword,
+                    locations = mutableListOf()
+                )
+            ),
+            mainImage = null
+        )
+
+        noticeService.createNotice(
+            NoticeDto(
+                id = -1,
+                title = "title",
+                titleForMain = null,
+                description = keyword,
+                author = "username",
+                tags = emptyList(),
+                createdAt = null,
+                modifiedAt = null,
+                isPrivate = false,
+                isPinned = false,
+                pinnedUntil = null,
+                isImportant = false,
+                importantUntil = null,
+                prevId = null,
+                prevTitle = null,
+                nextId = null,
+                nextTitle = null,
+                attachments = null
+            ),
+            attachments = null
+        )
+
+        newsService.createNews(
+            NewsDto(
+                id = -1,
+                title = "title",
+                titleForMain = null,
+                description = keyword,
+                tags = emptyList(),
+                createdAt = null,
+                modifiedAt = null,
+                date = LocalDateTime.now(),
+                isPrivate = false,
+                isSlide = false,
+                isImportant = false,
+                prevId = null,
+                prevTitle = null,
+                nextId = null,
+                nextTitle = null,
+                imageURL = null,
+                attachments = null
+            ),
+            mainImage = null,
+            attachments = null
+        )
+
+        seminarService.createSeminar(
+            SeminarDto(
+                id = -1,
+                title = "title",
+                titleForMain = null,
+                description = keyword,
+                introduction = "introduction",
+                name = "name",
+                speakerURL = "speakerURL",
+                speakerTitle = "speakerTitle",
+                affiliation = "affiliation",
+                affiliationURL = "affiliationURL",
+                startDate = LocalDateTime.now(),
+                endDate = LocalDateTime.now(),
+                location = "location",
+                host = "host",
+                additionalNote = "additionalNote",
+                createdAt = null,
+                modifiedAt = null,
+                isPrivate = false,
+                isImportant = false,
+                prevId = null,
+                prevTitle = null,
+                nextId = null,
+                nextTitle = null,
+                imageURL = null,
+                attachments = null
+            ),
+            mainImage = null,
+            attachments = null
+        )
+
+        professorService.createProfessor(
+            LanguageType.KO,
+            CreateProfessorReqBody(
+                name = "name",
+                email = "email",
+                status = ProfessorStatus.ACTIVE,
+                academicRank = "academicRank",
+                labId = null,
+                startDate = null,
+                endDate = null,
+                office = "office",
+                phone = "phone",
+                fax = "fax",
+                website = "website",
+                educations = listOf(keyword, "education2"),
+                researchAreas = listOf("researchArea1", "researchArea2"),
+                careers = listOf("career1", "career2")
+            ),
+            mainImage = null
+        )
+
+        staffService.createStaff(
+            LanguageType.KO,
+            CreateStaffReqBody(
+                name = "name",
+                role = "role",
+                office = "office",
+                phone = "phone",
+                email = "email",
+                tasks = listOf(keyword, "task2")
+            ),
+            mainImage = null
+        )
+
+        researchService.createResearchLanguage(
+            CreateResearchLanguageReqBody(
+                ko = CreateResearchCenterReqBody(
+                    name = "한국어 연구소",
+                    description = keyword,
+                    mainImageUrl = null,
+                    websiteURL = "https://www.koreanlab.com"
+                ),
+                en = CreateResearchCenterReqBody(
+                    name = "English Research Center",
+                    description = keyword,
+                    mainImageUrl = null,
+                    websiteURL = "https://www.englishlab.com"
+                )
+            ),
+            mainImage = null
+        )
+
+        admissionsService.createAdmission(
+            AdmissionReqBody(
+                name = "name",
+                language = "ko",
+                description = "<p>$keyword</p>"
+            ),
+            AdmissionsMainType.UNDERGRADUATE,
+            AdmissionsPostType.REGULAR_ADMISSION
+        )
+
+        academicsService.createCourse(
+            GroupedCourseDto(
+                code = "code",
+                credit = 3,
+                grade = 1,
+                studentType = "undergraduate",
+                ko = SingleCourseDto(
+                    name = "name",
+                    description = keyword,
+                    classification = "classification"
+                ),
+                en = SingleCourseDto(
+                    name = "name",
+                    description = keyword,
+                    classification = "classification"
+                )
+            )
+        )
+
+        academicsService.createAcademicsYearResponse(
+            language = "ko",
+            studentType = "undergraduate",
+            postType = "CURRICULUM",
+            request = CreateYearReq(
+                name = "name",
+                year = 2000,
+                description = "<p>$keyword</p>"
+            ),
+            attachments = null
+        )
+
+        academicsService.createScholarship(
+            studentType = "undergraduate",
+            request = CreateScholarshipReq(
+                koName = "name",
+                koDescription = "<p>$keyword</p>",
+                enName = "name",
+                enDescription = "<p>$keyword</p>"
+            )
+        )
+
+        When("totalSearch를 호출하면") {
+            val number = 3
+            val memberNumber = 10
+            val stringLength = 200
+            val language = LanguageType.KO
+
+            val totalSearchResult = mainService.totalSearch(
+                keyword = keyword,
+                number = number,
+                memberNumber = memberNumber,
+                stringLength = stringLength,
+                language = language
+            )
+
+            Then("keyword가 포함된 게시글이 전부 검색이 되야 한다") {
+                totalSearchResult.aboutResult.total shouldBe aboutDataNumber
+                totalSearchResult.noticeResult.total shouldBe noticeDataNumber
+                totalSearchResult.newsResult.total shouldBe newsDataNumber
+                totalSearchResult.seminarResult.total shouldBe seminarDataNumber
+                totalSearchResult.memberResult.total shouldBe memberDataNumber
+                totalSearchResult.researchResult.total shouldBe researchDataNumber
+                totalSearchResult.admissionsResult.total shouldBe admissionsDataNumber
+                totalSearchResult.academicsResult.total shouldBe academicsDataNumber
+            }
+
+            Then("하나씩 검색한 것과 같은 결과야 한다") {
+                totalSearchResult.aboutResult shouldBe
+                    aboutService.searchTopAbout(
+                        keyword,
+                        language,
+                        number,
+                        stringLength
+                    )
+                totalSearchResult.noticeResult shouldBe
+                    noticeService.searchTotalNotice(
+                        keyword,
+                        number,
+                        stringLength
+                    )
+                totalSearchResult.newsResult shouldBe
+                    newsService.searchTotalNews(
+                        keyword,
+                        number,
+                        stringLength
+                    )
+                totalSearchResult.seminarResult shouldBe
+                    seminarService.searchSeminar(
+                        keyword,
+                        PageRequest.of(0, 10),
+                        usePageBtn = true,
+                        ContentSearchSortType.DATE
+                    )
+                totalSearchResult.memberResult shouldBe
+                    memberSearchService.searchTopMember(
+                        keyword,
+                        language,
+                        memberNumber
+                    )
+                totalSearchResult.researchResult shouldBe
+                    researchSearchService.searchTopResearch(
+                        keyword,
+                        language,
+                        number,
+                        stringLength
+                    )
+                totalSearchResult.admissionsResult shouldBe
+                    admissionsService.searchTopAdmission(
+                        keyword,
+                        language,
+                        number,
+                        stringLength
+                    )
+                totalSearchResult.academicsResult shouldBe
+                    academicsSearchService.searchTopAcademics(
+                        keyword,
+                        language,
+                        number,
+                        stringLength
+                    )
+            }
+        }
+    }
+})


### PR DESCRIPTION
## totalSearch api 통합

### 한줄 요약

totalSearch를 쓸 때 사용하던 api들을 한 번에 호출할 수 있도록 변경했습니다

직접 http 요청 넣어서 정상 작동함을 확인했습니다

### 상세 설명

```
/v2/about/search/top
/v2/notice/totalSearch
/v2/new/totalSearch
/v2/seminar
/v2/member/search/top
/v2/research/search/top
/v2/admissions/search/top
/v2/academics/search/top
```

위 api들을 하나의 api(/v2/totalSearch)로 사용할 수 있게 되었습니다

param으로 keyword: String 만 넣으면 기존에 사용하던 대로 사용할 수 있습니다

추가 param
number: 항목 당 불러오는 게시글 수(기본 3)
memberNumber: 불러오는 구성원 수(기본 10)
stringLength : 불러오는 설명 길이(기본 200)
language: 검색 기준이 되는 언어(기본 ko)

사용 예시 : GET http://서버주소/api/v2/totalSearch?keyword=computer

기존에 가던 응답들을 하나의 data class로 묶어 응답합니다

### TODO

테스트 코드 짜는 걸 오래 고민했는데 결국 완성을 못했습니다

h2를 사용하면 fulltextsearch를 테스트할 수 없고, 예약어가 column 이름으로 사용된다는 문제가 있어 testContainer를 사용해 mySQL을 사용하려 했습니다

여러 방법으로 시도해봤는데, 계속 hibernate가 table을 안 만들어준다는 문제가 생기고 해결을 못했습니다
