### PR TITLE
feat: seminar, news 중요 설정 만료일 추가

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsEntity.kt
@@ -9,6 +9,7 @@ import com.wafflestudio.csereal.core.resource.attachment.database.AttachmentEnti
 import com.wafflestudio.csereal.core.resource.mainImage.database.MainImageEntity
 import jakarta.persistence.*
 import java.time.LocalDateTime
+import java.time.LocalDate
 
 @Entity(name = "news")
 class NewsEntity(
@@ -29,6 +30,7 @@ class NewsEntity(
     var isPrivate: Boolean,
     var isSlide: Boolean,
     var isImportant: Boolean,
+    var importantUntil: LocalDate? = null,
 
     @OneToOne
     var mainImage: MainImageEntity? = null,
@@ -53,7 +55,8 @@ class NewsEntity(
                 date = newsDto.date,
                 isPrivate = newsDto.isPrivate,
                 isSlide = newsDto.isSlide,
-                isImportant = newsDto.isImportant
+                isImportant = newsDto.isImportant,
+                importantUntil = if (newsDto.isImportant) newsDto.importantUntil else null
             )
         }
     }
@@ -69,5 +72,6 @@ class NewsEntity(
         this.isPrivate = updateNewsRequest.isPrivate
         this.isSlide = updateNewsRequest.isSlide
         this.isImportant = updateNewsRequest.isImportant
+        this.importantUntil = if (updateNewsRequest.isImportant) updateNewsRequest.importantUntil else null
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsRepository.kt
@@ -22,9 +22,12 @@ import com.wafflestudio.csereal.core.resource.mainImage.database.QMainImageEntit
 import com.wafflestudio.csereal.core.resource.mainImage.service.MainImageService
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import java.time.LocalDateTime
+import java.time.LocalDate
 
 interface NewsRepository : JpaRepository<NewsEntity, Long>, CustomNewsRepository {
     fun findFirstByIsDeletedFalseAndIsPrivateFalseAndCreatedAtLessThanOrderByCreatedAtDesc(
@@ -37,6 +40,10 @@ interface NewsRepository : JpaRepository<NewsEntity, Long>, CustomNewsRepository
 
     @Query("SELECT n.id FROM news n")
     fun findAllIds(): List<Long>
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE news n SET n.isImportant = false, n.importantUntil = NULL WHERE n.isImportant = true AND n.importantUntil < :currentDate")
+    fun updateExpiredImportantStatus(@Param("currentDate") currentDate: LocalDate): Int
 }
 
 interface CustomNewsRepository {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsRepository.kt
@@ -42,7 +42,10 @@ interface NewsRepository : JpaRepository<NewsEntity, Long>, CustomNewsRepository
     fun findAllIds(): List<Long>
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("UPDATE news n SET n.isImportant = false, n.importantUntil = NULL WHERE n.isImportant = true AND n.importantUntil < :currentDate")
+    @Query(
+        "UPDATE news n SET n.isImportant = false, n.importantUntil = NULL " +
+            "WHERE n.isImportant = true AND n.importantUntil < :currentDate"
+    )
     fun updateExpiredImportantStatus(@Param("currentDate") currentDate: LocalDate): Int
 }
 
@@ -112,7 +115,11 @@ class NewsRepositoryImpl(
         val jpaQuery = queryFactory.selectFrom(newsEntity)
             .leftJoin(newsTagEntity).on(newsTagEntity.news.eq(newsEntity))
             .where(newsEntity.isDeleted.eq(false))
-            .where(keywordBooleanBuilder, tagsBooleanBuilder, isPrivateBooleanBuilder)
+            .where(
+                keywordBooleanBuilder,
+                tagsBooleanBuilder,
+                isPrivateBooleanBuilder
+            )
 
         val total: Long
         var pageRequest = pageable
@@ -131,9 +138,10 @@ class NewsRepositoryImpl(
             .distinct()
 
         val newsEntityList = when {
-            sortBy == ContentSearchSortType.DATE || keyword.isNullOrEmpty() -> newsEntityQuery.orderBy(
-                newsEntity.date.desc()
-            )
+            sortBy == ContentSearchSortType.DATE || keyword.isNullOrEmpty() ->
+                newsEntityQuery.orderBy(
+                    newsEntity.date.desc()
+                )
 
             else /* sortBy == RELEVANCE */ -> newsEntityQuery
         }.fetch()
@@ -146,7 +154,9 @@ class NewsRepositoryImpl(
                 description = it.plainTextDescription,
                 createdAt = it.createdAt,
                 date = it.date,
-                tags = it.newsTags.map { newsTagEntity -> newsTagEntity.tag.name.krName },
+                tags = it.newsTags.map { newsTagEntity ->
+                    newsTagEntity.tag.name.krName
+                },
                 imageURL = imageURL,
                 isPrivate = it.isPrivate
             )
@@ -176,7 +186,8 @@ class NewsRepositoryImpl(
             newsEntity.plainTextDescription,
             mainImageEntity
         ).from(newsEntity)
-            .leftJoin(mainImageEntity).on(newsEntity.mainImage.eq(mainImageEntity))
+            .leftJoin(mainImageEntity)
+            .on(newsEntity.mainImage.eq(mainImageEntity))
             .where(doubleTemplate.gt(0.0), privateBoolean)
             .orderBy(newsEntity.date.desc())
             .limit(number.toLong())
@@ -188,7 +199,11 @@ class NewsRepositoryImpl(
         ).from(newsTagEntity)
             .rightJoin(newsEntity).on(newsTagEntity.news.eq(newsEntity))
             .leftJoin(tagInNewsEntity).on(newsTagEntity.tag.eq(tagInNewsEntity))
-            .where(newsTagEntity.news.id.`in`(searchResult.map { it[newsEntity.id] }))
+            .where(
+                newsTagEntity.news.id.`in`(
+                    searchResult.map { it[newsEntity.id] }
+                )
+            )
             .distinct()
             .fetch()
 
@@ -224,7 +239,11 @@ class NewsRepositoryImpl(
             newsEntity.title,
             newsEntity.createdAt
         ).from(newsEntity)
-            .where(newsEntity.isDeleted.eq(false), newsEntity.isPrivate.eq(false), newsEntity.isSlide.eq(true))
+            .where(
+                newsEntity.isDeleted.eq(false),
+                newsEntity.isPrivate.eq(false),
+                newsEntity.isSlide.eq(true)
+            )
             .orderBy(newsEntity.createdAt.desc())
             .offset(pageSize * pageNum)
             .limit(pageSize.toLong())
@@ -232,7 +251,11 @@ class NewsRepositoryImpl(
 
         val total = queryFactory.select(newsEntity.count())
             .from(newsEntity)
-            .where(newsEntity.isDeleted.eq(false), newsEntity.isPrivate.eq(false), newsEntity.isSlide.eq(true))
+            .where(
+                newsEntity.isDeleted.eq(false),
+                newsEntity.isPrivate.eq(false),
+                newsEntity.isSlide.eq(true)
+            )
             .fetchOne()!!
 
         return AdminSlidesResponse(

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/dto/NewsDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/dto/NewsDto.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.csereal.core.news.dto
 import com.wafflestudio.csereal.core.news.database.NewsEntity
 import com.wafflestudio.csereal.core.resource.attachment.dto.AttachmentResponse
 import java.time.LocalDateTime
+import java.time.LocalDate
 
 data class NewsDto(
     val id: Long,
@@ -16,6 +17,7 @@ data class NewsDto(
     val isPrivate: Boolean,
     val isSlide: Boolean,
     val isImportant: Boolean,
+    val importantUntil: LocalDate?,
     val prevId: Long?,
     val prevTitle: String?,
     val nextId: Long?,
@@ -44,6 +46,7 @@ data class NewsDto(
                 isPrivate = this.isPrivate,
                 isSlide = this.isSlide,
                 isImportant = this.isImportant,
+                importantUntil = this.importantUntil,
                 prevId = prevNews?.id,
                 prevTitle = prevNews?.title,
                 nextId = nextNews?.id,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/scheduler/NewsScheduler.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/scheduler/NewsScheduler.kt
@@ -42,4 +42,4 @@ class NewsScheduler(
             currentDate
         )
     }
-} 
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/scheduler/NewsScheduler.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/scheduler/NewsScheduler.kt
@@ -1,0 +1,45 @@
+package com.wafflestudio.csereal.core.news.scheduler
+
+import com.wafflestudio.csereal.core.news.database.NewsRepository
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.ZoneId
+
+@Component
+class NewsScheduler(
+    private val newsRepository: NewsRepository
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    /**
+     * Scheduled task to update the status of news items whose importance period has expired.
+     * Runs every day at 1:00 AM KST.
+     */
+    @Scheduled(cron = "0 10 1 * * *", zone = "Asia/Seoul")
+    @Transactional
+    fun updateNewsExpirationStatus() {
+        val currentDate = LocalDate.now(ZoneId.of("Asia/Seoul"))
+        logger.info(
+            "[updateNewsExpirationStatus] Running scheduled task to update news expired before: {}",
+            currentDate
+        )
+
+        try {
+            val updatedCount = newsRepository.updateExpiredImportantStatus(currentDate)
+            logger.info("[updateNewsExpirationStatus] Marked {} news items as not important.", updatedCount)
+        } catch (e: Exception) {
+            logger.error(
+                "[updateNewsExpirationStatus] Error occurred during news expiration update for date {}.",
+                currentDate,
+                e
+            )
+        }
+        logger.info(
+            "[updateNewsExpirationStatus] Finished scheduled task for news expired before: {}",
+            currentDate
+        )
+    }
+} 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarEntity.kt
@@ -9,6 +9,7 @@ import com.wafflestudio.csereal.core.resource.mainImage.database.MainImageEntity
 import com.wafflestudio.csereal.core.seminar.dto.SeminarDto
 import jakarta.persistence.*
 import java.time.LocalDateTime
+import java.time.LocalDate
 
 @Entity(name = "seminar")
 class SeminarEntity(
@@ -51,6 +52,7 @@ class SeminarEntity(
 
     var isPrivate: Boolean,
     var isImportant: Boolean,
+    var importantUntil: LocalDate? = null,
 
     @Column(columnDefinition = "text")
     var additionalNote: String?,
@@ -92,6 +94,7 @@ class SeminarEntity(
                 host = seminarDto.host,
                 isPrivate = seminarDto.isPrivate,
                 isImportant = seminarDto.isImportant,
+                importantUntil = if (seminarDto.isImportant) seminarDto.importantUntil else null,
                 additionalNote = seminarDto.additionalNote,
                 plainTextAdditionalNote = plainTextAdditionalNote
             )
@@ -128,5 +131,6 @@ class SeminarEntity(
         host = updateSeminarRequest.host
         isPrivate = updateSeminarRequest.isPrivate
         isImportant = updateSeminarRequest.isImportant
+        importantUntil = if (updateSeminarRequest.isImportant) updateSeminarRequest.importantUntil else null
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarRepository.kt
@@ -34,7 +34,10 @@ interface SeminarRepository : JpaRepository<SeminarEntity, Long>, CustomSeminarR
     fun findAllIds(): List<Long>
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("UPDATE seminar s SET s.isImportant = false, s.importantUntil = NULL WHERE s.isImportant = true AND s.importantUntil < :currentDate")
+    @Query(
+        "UPDATE seminar s SET s.isImportant = false, s.isImportant = NULL " +
+            "WHERE s.isImportant = true AND s.importantUntil < :currentDate"
+    )
     fun updateExpiredImportantStatus(@Param("currentDate") currentDate: LocalDate): Int
 }
 
@@ -106,9 +109,10 @@ class SeminarRepositoryImpl(
             .limit(pageRequest.pageSize.toLong())
 
         val seminarEntityList = when {
-            sortBy == ContentSearchSortType.DATE || keyword.isNullOrEmpty() -> seminarEntityQuery.orderBy(
-                seminarEntity.startDate.desc()
-            )
+            sortBy == ContentSearchSortType.DATE || keyword.isNullOrEmpty() ->
+                seminarEntityQuery.orderBy(
+                    seminarEntity.startDate.desc()
+                )
 
             else /* sortBy == RELEVANCE */ -> seminarEntityQuery
         }.fetch()

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarRepository.kt
@@ -35,7 +35,7 @@ interface SeminarRepository : JpaRepository<SeminarEntity, Long>, CustomSeminarR
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(
-        "UPDATE seminar s SET s.isImportant = false, s.isImportant = NULL " +
+        "UPDATE seminar s SET s.isImportant = false, s.importantUntil = NULL " +
             "WHERE s.isImportant = true AND s.importantUntil < :currentDate"
     )
     fun updateExpiredImportantStatus(@Param("currentDate") currentDate: LocalDate): Int

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarRepository.kt
@@ -14,9 +14,12 @@ import com.wafflestudio.csereal.core.seminar.dto.SeminarSearchDto
 import com.wafflestudio.csereal.core.seminar.dto.SeminarSearchResponse
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Component
 import java.time.LocalDateTime
+import java.time.LocalDate
 
 interface SeminarRepository : JpaRepository<SeminarEntity, Long>, CustomSeminarRepository {
     fun findFirstByIsDeletedFalseAndIsPrivateFalseAndCreatedAtLessThanOrderByCreatedAtDesc(
@@ -29,6 +32,10 @@ interface SeminarRepository : JpaRepository<SeminarEntity, Long>, CustomSeminarR
 
     @Query("SELECT s.id FROM seminar s")
     fun findAllIds(): List<Long>
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE seminar s SET s.isImportant = false, s.importantUntil = NULL WHERE s.isImportant = true AND s.importantUntil < :currentDate")
+    fun updateExpiredImportantStatus(@Param("currentDate") currentDate: LocalDate): Int
 }
 
 interface CustomSeminarRepository {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/dto/SeminarDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/dto/SeminarDto.kt
@@ -3,6 +3,7 @@ package com.wafflestudio.csereal.core.seminar.dto
 import com.wafflestudio.csereal.core.resource.attachment.dto.AttachmentResponse
 import com.wafflestudio.csereal.core.seminar.database.SeminarEntity
 import java.time.LocalDateTime
+import java.time.LocalDate
 
 data class SeminarDto(
     val id: Long,
@@ -24,6 +25,7 @@ data class SeminarDto(
     val modifiedAt: LocalDateTime?,
     val isPrivate: Boolean,
     val isImportant: Boolean,
+    val importantUntil: LocalDate?,
     val prevId: Long?,
     val prevTitle: String?,
     val nextId: Long?,
@@ -61,6 +63,7 @@ data class SeminarDto(
                 modifiedAt = this.modifiedAt,
                 isPrivate = this.isPrivate,
                 isImportant = this.isImportant,
+                importantUntil = this.importantUntil,
                 prevId = prevSeminar?.id,
                 prevTitle = prevSeminar?.title,
                 nextId = nextSeminar?.id,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/scheduler/SeminarScheduler.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/scheduler/SeminarScheduler.kt
@@ -1,0 +1,45 @@
+package com.wafflestudio.csereal.core.seminar.scheduler
+
+import com.wafflestudio.csereal.core.seminar.database.SeminarRepository
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.ZoneId
+
+@Component
+class SeminarScheduler(
+    private val seminarRepository: SeminarRepository
+) {
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    /**
+     * Scheduled task to update the status of seminars whose importance period has expired.
+     * Runs every day at 1:05 AM KST.
+     */
+    @Scheduled(cron = "0 5 1 * * *", zone = "Asia/Seoul")
+    @Transactional
+    fun updateSeminarExpirationStatus() {
+        val currentDate = LocalDate.now(ZoneId.of("Asia/Seoul"))
+        logger.info(
+            "[updateSeminarExpirationStatus] Running scheduled task to update seminars expired before: {}",
+            currentDate
+        )
+
+        try {
+            val updatedCount = seminarRepository.updateExpiredImportantStatus(currentDate)
+            logger.info("[updateSeminarExpirationStatus] Marked {} seminars as not important.", updatedCount)
+        } catch (e: Exception) {
+            logger.error(
+                "[updateSeminarExpirationStatus] Error occurred during seminar expiration update for date {}.",
+                currentDate,
+                e
+            )
+        }
+        logger.info(
+            "[updateSeminarExpirationStatus] Finished scheduled task for seminars expired before: {}",
+            currentDate
+        )
+    }
+} 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/scheduler/SeminarScheduler.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/scheduler/SeminarScheduler.kt
@@ -42,4 +42,4 @@ class SeminarScheduler(
             currentDate
         )
     }
-} 
+}

--- a/src/main/resources/db/migration/V10__add_important_until_to_seminar_and_news.sql
+++ b/src/main/resources/db/migration/V10__add_important_until_to_seminar_and_news.sql
@@ -1,0 +1,5 @@
+ALTER TABLE seminar
+ADD COLUMN important_until DATE DEFAULT NULL;
+
+ALTER TABLE news
+ADD COLUMN important_until DATE DEFAULT NULL; 

--- a/src/test/kotlin/com/wafflestudio/csereal/core/news/NewsServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/news/NewsServiceTest.kt
@@ -42,6 +42,7 @@ class NewsServiceTest(
                 isPrivate = false,
                 isSlide = false,
                 isImportant = false,
+                importantUntil = null,
                 prevId = null,
                 prevTitle = null,
                 nextId = null,

--- a/src/test/kotlin/com/wafflestudio/csereal/core/news/scheduler/NewsSchedulerTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/news/scheduler/NewsSchedulerTest.kt
@@ -2,8 +2,6 @@ package com.wafflestudio.csereal.core.news.scheduler
 
 import com.wafflestudio.csereal.core.news.database.NewsEntity
 import com.wafflestudio.csereal.core.news.database.NewsRepository
-// import com.wafflestudio.csereal.core.user.database.UserEntity // 제거
-// import com.wafflestudio.csereal.core.user.database.UserRepository // 제거
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.extensions.spring.SpringExtension
 import io.kotest.matchers.shouldBe
@@ -35,7 +33,10 @@ class NewsSchedulerTest(
             newsRepository.deleteAll()
         }
 
-        Given("Various news items with different importance expiration dates are present") {
+        Given(
+            "Various news items with different importance " +
+                "expiration dates are present"
+        ) {
             val newsExpiredImportant = createTestNews(
                 title = "Expired Important News",
                 isImportant = true,
@@ -68,13 +69,19 @@ class NewsSchedulerTest(
             When("The updateNewsExpirationStatus scheduler task runs") {
                 newsScheduler.updateNewsExpirationStatus()
 
-                Then("News items with importance expiration date before today should be updated") {
+                Then(
+                    "News items with importance expiration date before today " +
+                        "should be updated"
+                ) {
                     val updatedExpiredImportant = newsRepository.findByIdOrNull(newsExpiredImportant.id)!!
                     updatedExpiredImportant.isImportant shouldBe false
                     updatedExpiredImportant.importantUntil shouldBe null
                 }
 
-                Then("News items with importance expiration date today or later, or no expiration date, should remain unchanged") {
+                Then(
+                    "News items with importance expiration date today or later, " +
+                        "or no expiration date, should remain unchanged"
+                ) {
                     val updatedTodayImportant = newsRepository.findByIdOrNull(newsTodayImportant.id)!!
                     updatedTodayImportant.isImportant shouldBe true
                     updatedTodayImportant.importantUntil shouldBe today
@@ -117,4 +124,4 @@ class NewsSchedulerTest(
             )
         )
     }
-} 
+}

--- a/src/test/kotlin/com/wafflestudio/csereal/core/news/scheduler/NewsSchedulerTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/news/scheduler/NewsSchedulerTest.kt
@@ -1,0 +1,120 @@
+package com.wafflestudio.csereal.core.news.scheduler
+
+import com.wafflestudio.csereal.core.news.database.NewsEntity
+import com.wafflestudio.csereal.core.news.database.NewsRepository
+// import com.wafflestudio.csereal.core.user.database.UserEntity // 제거
+// import com.wafflestudio.csereal.core.user.database.UserRepository // 제거
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.kotest.matchers.shouldBe
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.ZoneId
+
+@SpringBootTest
+@Transactional
+class NewsSchedulerTest(
+    private val newsScheduler: NewsScheduler,
+    private val newsRepository: NewsRepository
+) : BehaviorSpec() {
+
+    override fun extensions() = listOf(SpringExtension)
+
+    private val KST: ZoneId = ZoneId.of("Asia/Seoul")
+    private val today: LocalDate = LocalDate.now(KST)
+    private val yesterday: LocalDate = today.minusDays(1)
+    private val tomorrow: LocalDate = today.plusDays(1)
+
+    init {
+        beforeSpec {
+        }
+
+        afterSpec {
+            newsRepository.deleteAll()
+        }
+
+        Given("Various news items with different importance expiration dates are present") {
+            val newsExpiredImportant = createTestNews(
+                title = "Expired Important News",
+                isImportant = true,
+                importantUntil = yesterday
+            )
+
+            val newsTodayImportant = createTestNews(
+                title = "Today Important News",
+                isImportant = true,
+                importantUntil = today
+            )
+
+            val newsFutureImportant = createTestNews(
+                title = "Future Important News",
+                isImportant = true,
+                importantUntil = tomorrow
+            )
+
+            val newsPermanentImportant = createTestNews(
+                title = "Permanent Important News",
+                isImportant = true,
+                importantUntil = null
+            )
+
+            val newsNotImportant = createTestNews(
+                title = "Not Important News",
+                isImportant = false
+            )
+
+            When("The updateNewsExpirationStatus scheduler task runs") {
+                newsScheduler.updateNewsExpirationStatus()
+
+                Then("News items with importance expiration date before today should be updated") {
+                    val updatedExpiredImportant = newsRepository.findByIdOrNull(newsExpiredImportant.id)!!
+                    updatedExpiredImportant.isImportant shouldBe false
+                    updatedExpiredImportant.importantUntil shouldBe null
+                }
+
+                Then("News items with importance expiration date today or later, or no expiration date, should remain unchanged") {
+                    val updatedTodayImportant = newsRepository.findByIdOrNull(newsTodayImportant.id)!!
+                    updatedTodayImportant.isImportant shouldBe true
+                    updatedTodayImportant.importantUntil shouldBe today
+
+                    val updatedFutureImportant = newsRepository.findByIdOrNull(newsFutureImportant.id)!!
+                    updatedFutureImportant.isImportant shouldBe true
+                    updatedFutureImportant.importantUntil shouldBe tomorrow
+
+                    val updatedPermanentImportant = newsRepository.findByIdOrNull(newsPermanentImportant.id)!!
+                    updatedPermanentImportant.isImportant shouldBe true
+                    updatedPermanentImportant.importantUntil shouldBe null
+
+                    val updatedNotImportant = newsRepository.findByIdOrNull(newsNotImportant.id)!!
+                    updatedNotImportant.isImportant shouldBe false
+                    updatedNotImportant.importantUntil shouldBe null
+                }
+            }
+        }
+    }
+
+    private fun createTestNews(
+        title: String,
+        isImportant: Boolean = false,
+        importantUntil: LocalDate? = null
+    ): NewsEntity {
+        return newsRepository.save(
+            NewsEntity(
+                title = title,
+                titleForMain = null,
+                description = "Test description for $title",
+                plainTextDescription = "Test plain text description for $title",
+                date = today.atStartOfDay(),
+                isPrivate = false,
+                isSlide = false,
+                isImportant = isImportant,
+                importantUntil = importantUntil,
+                mainImage = null,
+                attachments = mutableListOf(),
+                newsTags = mutableSetOf()
+            )
+        )
+    }
+} 

--- a/src/test/kotlin/com/wafflestudio/csereal/core/news/scheduler/NewsSchedulerTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/news/scheduler/NewsSchedulerTest.kt
@@ -3,7 +3,8 @@ package com.wafflestudio.csereal.core.news.scheduler
 import com.wafflestudio.csereal.core.news.database.NewsEntity
 import com.wafflestudio.csereal.core.news.database.NewsRepository
 import io.kotest.core.spec.style.BehaviorSpec
-import io.kotest.extensions.spring.SpringExtension
+import io.kotest.extensions.spring.SpringTestExtension
+import io.kotest.extensions.spring.SpringTestLifecycleMode
 import io.kotest.matchers.shouldBe
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.data.repository.findByIdOrNull
@@ -18,16 +19,13 @@ class NewsSchedulerTest(
     private val newsRepository: NewsRepository
 ) : BehaviorSpec() {
 
-    override fun extensions() = listOf(SpringExtension)
-
     private val KST: ZoneId = ZoneId.of("Asia/Seoul")
     private val today: LocalDate = LocalDate.now(KST)
     private val yesterday: LocalDate = today.minusDays(1)
     private val tomorrow: LocalDate = today.plusDays(1)
 
     init {
-        beforeSpec {
-        }
+        extensions(SpringTestExtension(SpringTestLifecycleMode.Root))
 
         afterSpec {
             newsRepository.deleteAll()

--- a/src/test/kotlin/com/wafflestudio/csereal/core/notice/scheduler/NoticeSchedulerTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/notice/scheduler/NoticeSchedulerTest.kt
@@ -5,7 +5,8 @@ import com.wafflestudio.csereal.core.notice.database.NoticeRepository
 import com.wafflestudio.csereal.core.user.database.UserEntity
 import com.wafflestudio.csereal.core.user.database.UserRepository
 import io.kotest.core.spec.style.BehaviorSpec
-import io.kotest.extensions.spring.SpringExtension
+import io.kotest.extensions.spring.SpringTestExtension
+import io.kotest.extensions.spring.SpringTestLifecycleMode
 import io.kotest.matchers.shouldBe
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.data.repository.findByIdOrNull
@@ -21,8 +22,6 @@ class NoticeSchedulerTest(
     private val userRepository: UserRepository
 ) : BehaviorSpec() {
 
-    override fun extensions() = listOf(SpringExtension)
-
     private lateinit var user: UserEntity
     private val KST: ZoneId = ZoneId.of("Asia/Seoul")
     private val today: LocalDate = LocalDate.now(KST)
@@ -30,6 +29,8 @@ class NoticeSchedulerTest(
     private val tomorrow: LocalDate = today.plusDays(1)
 
     init {
+        extensions(SpringTestExtension(SpringTestLifecycleMode.Root))
+
         // Setup: Create a user first
         beforeSpec {
             user = userRepository.save(UserEntity("username", "name", "email", "studentId"))

--- a/src/test/kotlin/com/wafflestudio/csereal/core/seminar/scheduler/SeminarSchedulerTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/seminar/scheduler/SeminarSchedulerTest.kt
@@ -3,7 +3,8 @@ package com.wafflestudio.csereal.core.seminar.scheduler
 import com.wafflestudio.csereal.core.seminar.database.SeminarEntity
 import com.wafflestudio.csereal.core.seminar.database.SeminarRepository
 import io.kotest.core.spec.style.BehaviorSpec
-import io.kotest.extensions.spring.SpringExtension
+import io.kotest.extensions.spring.SpringTestExtension
+import io.kotest.extensions.spring.SpringTestLifecycleMode
 import io.kotest.matchers.shouldBe
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.data.repository.findByIdOrNull
@@ -19,14 +20,14 @@ class SeminarSchedulerTest(
     private val seminarRepository: SeminarRepository
 ) : BehaviorSpec() {
 
-    override fun extensions() = listOf(SpringExtension)
-
     private val KST: ZoneId = ZoneId.of("Asia/Seoul")
     private val today: LocalDate = LocalDate.now(KST)
     private val yesterday: LocalDate = today.minusDays(1)
     private val tomorrow: LocalDate = today.plusDays(1)
 
     init {
+        extensions(SpringTestExtension(SpringTestLifecycleMode.Root))
+
         beforeSpec {
         }
 

--- a/src/test/kotlin/com/wafflestudio/csereal/core/seminar/scheduler/SeminarSchedulerTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/seminar/scheduler/SeminarSchedulerTest.kt
@@ -1,0 +1,129 @@
+package com.wafflestudio.csereal.core.seminar.scheduler
+
+import com.wafflestudio.csereal.core.seminar.database.SeminarEntity
+import com.wafflestudio.csereal.core.seminar.database.SeminarRepository
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.kotest.matchers.shouldBe
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+@SpringBootTest
+@Transactional
+class SeminarSchedulerTest(
+    private val seminarScheduler: SeminarScheduler,
+    private val seminarRepository: SeminarRepository
+) : BehaviorSpec() {
+
+    override fun extensions() = listOf(SpringExtension)
+
+    private val KST: ZoneId = ZoneId.of("Asia/Seoul")
+    private val today: LocalDate = LocalDate.now(KST)
+    private val yesterday: LocalDate = today.minusDays(1)
+    private val tomorrow: LocalDate = today.plusDays(1)
+
+    init {
+        beforeSpec {
+        }
+
+        afterSpec {
+            seminarRepository.deleteAll()
+        }
+
+        Given("Various seminars with different importance expiration dates are present") {
+            val seminarExpiredImportant = createTestSeminar(
+                title = "Expired Important Seminar",
+                isImportant = true,
+                importantUntil = yesterday
+            )
+
+            val seminarTodayImportant = createTestSeminar(
+                title = "Today Important Seminar",
+                isImportant = true,
+                importantUntil = today
+            )
+
+            val seminarFutureImportant = createTestSeminar(
+                title = "Future Important Seminar",
+                isImportant = true,
+                importantUntil = tomorrow
+            )
+
+            val seminarPermanentImportant = createTestSeminar(
+                title = "Permanent Important Seminar",
+                isImportant = true,
+                importantUntil = null
+            )
+
+            val seminarNotImportant = createTestSeminar(
+                title = "Not Important Seminar",
+                isImportant = false
+            )
+
+            When("The updateSeminarExpirationStatus scheduler task runs") {
+                seminarScheduler.updateSeminarExpirationStatus()
+
+                Then("Seminars with importance expiration date before today should be updated") {
+                    val updatedExpiredImportant = seminarRepository.findByIdOrNull(seminarExpiredImportant.id)!!
+                    updatedExpiredImportant.isImportant shouldBe false
+                    updatedExpiredImportant.importantUntil shouldBe null
+                }
+
+                Then("Seminars with importance expiration date today or later, or no expiration date, should remain unchanged") {
+                    val updatedTodayImportant = seminarRepository.findByIdOrNull(seminarTodayImportant.id)!!
+                    updatedTodayImportant.isImportant shouldBe true
+                    updatedTodayImportant.importantUntil shouldBe today
+
+                    val updatedFutureImportant = seminarRepository.findByIdOrNull(seminarFutureImportant.id)!!
+                    updatedFutureImportant.isImportant shouldBe true
+                    updatedFutureImportant.importantUntil shouldBe tomorrow
+
+                    val updatedPermanentImportant = seminarRepository.findByIdOrNull(seminarPermanentImportant.id)!!
+                    updatedPermanentImportant.isImportant shouldBe true
+                    updatedPermanentImportant.importantUntil shouldBe null
+
+                    val updatedNotImportant = seminarRepository.findByIdOrNull(seminarNotImportant.id)!!
+                    updatedNotImportant.isImportant shouldBe false
+                    updatedNotImportant.importantUntil shouldBe null
+                }
+            }
+        }
+    }
+
+    private fun createTestSeminar(
+        title: String,
+        isImportant: Boolean = false,
+        importantUntil: LocalDate? = null
+    ): SeminarEntity {
+        return seminarRepository.save(
+            SeminarEntity(
+                title = title,
+                titleForMain = "Title for Main: $title",
+                description = "Test description for $title",
+                plainTextDescription = "Test plain text description for $title",
+                introduction = "Test introduction for $title",
+                plainTextIntroduction = "Test plain text introduction for $title",
+                name = "Seminar Speaker Name",
+                speakerURL = null,
+                speakerTitle = "Speaker Title",
+                affiliation = "Speaker Affiliation",
+                affiliationURL = null,
+                startDate = LocalDateTime.now(),
+                endDate = LocalDateTime.now().plusHours(1),
+                location = "Room 401",
+                host = "CSE department",
+                isPrivate = false,
+                isImportant = isImportant,
+                importantUntil = importantUntil,
+                additionalNote = "Additional note for $title",
+                plainTextAdditionalNote = "Additional note for $title",
+                mainImage = null,
+                attachments = mutableListOf()
+            )
+        )
+    }
+} 

--- a/src/test/kotlin/com/wafflestudio/csereal/core/seminar/scheduler/SeminarSchedulerTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/seminar/scheduler/SeminarSchedulerTest.kt
@@ -34,7 +34,10 @@ class SeminarSchedulerTest(
             seminarRepository.deleteAll()
         }
 
-        Given("Various seminars with different importance expiration dates are present") {
+        Given(
+            "Various seminars with different importance " +
+                "expiration dates are present"
+        ) {
             val seminarExpiredImportant = createTestSeminar(
                 title = "Expired Important Seminar",
                 isImportant = true,
@@ -67,13 +70,19 @@ class SeminarSchedulerTest(
             When("The updateSeminarExpirationStatus scheduler task runs") {
                 seminarScheduler.updateSeminarExpirationStatus()
 
-                Then("Seminars with importance expiration date before today should be updated") {
+                Then(
+                    "Seminars with importance expiration date before today " +
+                        "should be updated"
+                ) {
                     val updatedExpiredImportant = seminarRepository.findByIdOrNull(seminarExpiredImportant.id)!!
                     updatedExpiredImportant.isImportant shouldBe false
                     updatedExpiredImportant.importantUntil shouldBe null
                 }
 
-                Then("Seminars with importance expiration date today or later, or no expiration date, should remain unchanged") {
+                Then(
+                    "Seminars with importance expiration date today or later, " +
+                        "or no expiration date, should remain unchanged"
+                ) {
                     val updatedTodayImportant = seminarRepository.findByIdOrNull(seminarTodayImportant.id)!!
                     updatedTodayImportant.isImportant shouldBe true
                     updatedTodayImportant.importantUntil shouldBe today
@@ -126,4 +135,4 @@ class SeminarSchedulerTest(
             )
         )
     }
-} 
+}

--- a/src/test/kotlin/com/wafflestudio/csereal/core/seminar/service/SeminarServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/seminar/service/SeminarServiceTest.kt
@@ -59,6 +59,7 @@ class SeminarServiceTest(
                 modifiedAt = null,
                 isPrivate = false,
                 isImportant = false,
+                importantUntil = null,
                 prevId = null,
                 prevTitle = null,
                 nextId = null,


### PR DESCRIPTION
## 제목
[Feature] Seminar/News 중요 공지 만료 기능 추가

### 한줄 요약
Seminar 및 News 게시물에 중요 공지 설정 시 만료일을 지정하고, 스케줄러를 통해 만료된 공지를 자동으로 일반 공지로 전환하는 기능을 추가합니다.

### 상세 설명
이번 PR은 Seminar와 News의 '중요' 표시에 만료 기한을 설정하는 기능을 구현합니다. `importantUntil` 필드를 각 엔티티와 DTO에 추가하고, 관련 로직을 수정했습니다. 또한, 매일 새벽 특정 시간에 만료된 중요 게시물을 자동으로 일반 게시물로 전환하는 스케줄러를 각각 추가했습니다. 데이터베이스 스키마 변경 및 관련 테스트 코드도 포함되었습니다.

- [`de1614f`]: feat(db): add important_until column to seminar and news tables
- [`11a42bb`]: feat(news): add importantUntil field to NewsEntity and NewsDto
- [`8a3fa51`]: feat(seminar): add importantUntil field to SeminarEntity and SeminarDto
- [`12579a1`]: feat(news): add repository method to update expired important news
- [`38c860f`]: feat(seminar): add repository method to update expired important seminars
- [`f65fd3c`]: feat(news): add scheduler to manage expiration of important news
- [`e0d5939`]: feat(seminar): add scheduler to manage expiration of important seminars
- [`fd4a5fa`]: test(news): update NewsServiceTest and add NewsSchedulerTest for expiration feature
- [`2201444`]: test(seminar): update SeminarServiceTest and add SeminarSchedulerTest for expiration feature
