### PR TITLE
feat: Domain 구조체 정의

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/common/domain/Domain.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/domain/Domain.kt
@@ -1,0 +1,35 @@
+package com.wafflestudio.csereal.common.domain
+
+enum class Domain {
+    // 소개
+    ABOUT,              // Department information, statistics, student clubs
+
+    // 학사 및 교과
+    ACADEMICS,          // Degree programs, courses, scholarships
+
+    // 입학
+    ADMISSIONS,         // Admission requirements and procedures
+
+    // 소식
+    NEWS,               // News articles with tagging and scheduling
+    NOTICE,             // Official notices with expiration dates
+    SEMINAR,            // Seminar scheduling and management
+    RECRUIT,            // Recruitment information
+    COUNCIL,            // Student council information
+
+    // 구성원
+    PROFESSOR,          // Professor management (member subdomain)
+    STAFF,              // Staff management (member subdomain)
+
+    // 연구 교육
+    RESEARCH,           // Research groups and laboratories
+    LAB,                // Laboratory management (research subdomain)
+    CONFERENCE,         // Conference information
+
+    // 시설 예약
+    RESERVATION,        // Room reservation system
+    ROOM,               // Room information (reservation subdomain)
+
+    // 메일링 리스트
+    INTERNAL,           // Internal information
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/common/domain/Domain.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/domain/Domain.kt
@@ -2,34 +2,34 @@ package com.wafflestudio.csereal.common.domain
 
 enum class Domain {
     // 소개
-    ABOUT,              // Department information, statistics, student clubs
+    ABOUT, // Department information, statistics, student clubs
 
     // 학사 및 교과
-    ACADEMICS,          // Degree programs, courses, scholarships
+    ACADEMICS, // Degree programs, courses, scholarships
 
     // 입학
-    ADMISSIONS,         // Admission requirements and procedures
+    ADMISSIONS, // Admission requirements and procedures
 
     // 소식
-    NEWS,               // News articles with tagging and scheduling
-    NOTICE,             // Official notices with expiration dates
-    SEMINAR,            // Seminar scheduling and management
-    RECRUIT,            // Recruitment information
-    COUNCIL,            // Student council information
+    NEWS, // News articles with tagging and scheduling
+    NOTICE, // Official notices with expiration dates
+    SEMINAR, // Seminar scheduling and management
+    RECRUIT, // Recruitment information
+    COUNCIL, // Student council information
 
     // 구성원
-    PROFESSOR,          // Professor management (member subdomain)
-    STAFF,              // Staff management (member subdomain)
+    PROFESSOR, // Professor management (member subdomain)
+    STAFF, // Staff management (member subdomain)
 
     // 연구 교육
-    RESEARCH,           // Research groups and laboratories
-    LAB,                // Laboratory management (research subdomain)
-    CONFERENCE,         // Conference information
+    RESEARCH, // Research groups and laboratories
+    LAB, // Laboratory management (research subdomain)
+    CONFERENCE, // Conference information
 
     // 시설 예약
-    RESERVATION,        // Room reservation system
-    ROOM,               // Room information (reservation subdomain)
+    RESERVATION, // Room reservation system
+    ROOM, // Room information (reservation subdomain)
 
     // 메일링 리스트
-    INTERNAL,           // Internal information
+    INTERNAL // Internal information
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/common/entity/BaseTimeEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/entity/BaseTimeEntity.kt
@@ -1,4 +1,4 @@
-package com.wafflestudio.csereal.common.config
+package com.wafflestudio.csereal.common.entity
 
 import jakarta.persistence.*
 import org.springframework.data.annotation.CreatedDate

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/database/AboutEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/database/AboutEntity.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.about.database
 
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import com.wafflestudio.csereal.common.controller.AttachmentContentEntityType
 import com.wafflestudio.csereal.common.controller.MainImageContentEntityType
 import com.wafflestudio.csereal.common.enums.LanguageType

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/database/AboutLanguageEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/database/AboutLanguageEntity.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.about.database
 
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import jakarta.persistence.*
 
 @Entity(name = "about_language")

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/database/CompanyEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/database/CompanyEntity.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.about.database
 
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import com.wafflestudio.csereal.core.about.dto.FutureCareersCompanyDto
 import jakarta.persistence.Entity
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/database/StatEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/database/StatEntity.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.about.database
 
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import com.wafflestudio.csereal.core.about.dto.FutureCareersStatDegreeDto
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsEntity.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.academics.database
 
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import com.wafflestudio.csereal.common.controller.AttachmentContentEntityType
 import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.academics.api.req.CreateYearReq

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsSearchEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsSearchEntity.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.academics.database
 
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.common.utils.cleanTextFromHtml
 import jakarta.persistence.*

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/CourseEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/CourseEntity.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.academics.database
 
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import com.wafflestudio.csereal.common.enums.LanguageType
 import jakarta.persistence.*
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/ScholarshipEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/ScholarshipEntity.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.academics.database
 
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import com.wafflestudio.csereal.common.enums.LanguageType
 import jakarta.persistence.*
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/ScholarshipLanguageEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/ScholarshipLanguageEntity.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.academics.database
 
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import jakarta.persistence.*
 
 @Entity(name = "scholarship_language")

--- a/src/main/kotlin/com/wafflestudio/csereal/core/admissions/database/AdmissionsEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/admissions/database/AdmissionsEntity.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.admissions.database
 
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.common.utils.cleanTextFromHtml
 import com.wafflestudio.csereal.core.admissions.api.req.AdmissionReqBody

--- a/src/main/kotlin/com/wafflestudio/csereal/core/conference/database/ConferenceEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/conference/database/ConferenceEntity.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.conference.database
 
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.conference.dto.ConferenceDto
 import com.wafflestudio.csereal.core.research.database.ResearchSearchEntity

--- a/src/main/kotlin/com/wafflestudio/csereal/core/conference/database/ConferencePageEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/conference/database/ConferencePageEntity.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.conference.database
 
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import com.wafflestudio.csereal.core.user.database.UserEntity
 import jakarta.persistence.*
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/council/database/CouncilEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/council/database/CouncilEntity.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.council.database
 
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import com.wafflestudio.csereal.common.controller.MainImageContentEntityType
 import com.wafflestudio.csereal.core.council.dto.ReportCreateRequest
 import com.wafflestudio.csereal.core.resource.mainImage.database.MainImageEntity

--- a/src/main/kotlin/com/wafflestudio/csereal/core/council/database/CouncilFileEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/council/database/CouncilFileEntity.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.council.database
 
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import com.wafflestudio.csereal.common.controller.AttachmentContentEntityType
 import com.wafflestudio.csereal.core.council.type.CouncilFileType
 import com.wafflestudio.csereal.core.resource.attachment.database.AttachmentEntity

--- a/src/main/kotlin/com/wafflestudio/csereal/core/internal/database/InternalEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/internal/database/InternalEntity.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.internal.database
 
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import com.wafflestudio.csereal.core.internal.dto.InternalDto
 import jakarta.persistence.Column
 import jakarta.persistence.Entity

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/database/MemberLanguageEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/database/MemberLanguageEntity.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.member.database
 
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import com.wafflestudio.csereal.core.member.type.MemberType
 import jakarta.persistence.*
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/database/MemberSearchEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/database/MemberSearchEntity.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.member.database
 
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.member.type.MemberType
 import jakarta.persistence.*

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/database/ProfessorEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/database/ProfessorEntity.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.member.database
 
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import com.wafflestudio.csereal.common.controller.MainImageContentEntityType
 import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.common.utils.StringListConverter

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/database/StaffEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/database/StaffEntity.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.member.database
 
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import com.wafflestudio.csereal.common.controller.MainImageContentEntityType
 import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.common.utils.StringListConverter

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsEntity.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.news.database
 
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import com.wafflestudio.csereal.common.controller.AttachmentContentEntityType
 import com.wafflestudio.csereal.common.controller.MainImageContentEntityType
 import com.wafflestudio.csereal.common.utils.cleanTextFromHtml

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsTagEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsTagEntity.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.news.database
 
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
 import jakarta.persistence.JoinColumn

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/database/TagInNewsEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/database/TagInNewsEntity.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.news.database
 
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeEntity.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.notice.database
 
 import com.wafflestudio.csereal.common.utils.cleanTextFromHtml
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import com.wafflestudio.csereal.common.controller.AttachmentContentEntityType
 import com.wafflestudio.csereal.core.notice.dto.NoticeDto
 import com.wafflestudio.csereal.core.resource.attachment.database.AttachmentEntity

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeTagEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeTagEntity.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.notice.database
 
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import jakarta.persistence.*
 
 @Entity(name = "noticeTag")

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/TagInNoticeEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/TagInNoticeEntity.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.notice.database
 
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated

--- a/src/main/kotlin/com/wafflestudio/csereal/core/recruit/database/RecruitEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/recruit/database/RecruitEntity.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.recruit.database
 
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import com.wafflestudio.csereal.common.controller.MainImageContentEntityType
 import com.wafflestudio.csereal.core.resource.mainImage.database.MainImageEntity
 import jakarta.persistence.Column

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/database/LabEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/database/LabEntity.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.research.database
 
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.member.database.ProfessorEntity
 import com.wafflestudio.csereal.core.research.dto.LabUpdateRequest

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/database/ResearchEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/database/ResearchEntity.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.research.database
 
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import com.wafflestudio.csereal.common.controller.MainImageContentEntityType
 import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.research.dto.ResearchDto

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/database/ResearchLanguageEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/database/ResearchLanguageEntity.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.research.database
 
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import com.wafflestudio.csereal.core.research.type.ResearchRelatedType
 import jakarta.persistence.*
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/database/ResearchSearchEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/database/ResearchSearchEntity.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.research.database
 
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.common.utils.cleanTextFromHtml
 import com.wafflestudio.csereal.core.conference.database.ConferenceEntity

--- a/src/main/kotlin/com/wafflestudio/csereal/core/reservation/database/ReservationEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/reservation/database/ReservationEntity.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.reservation.database
 
 import com.wafflestudio.csereal.common.CserealException
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import com.wafflestudio.csereal.core.reservation.dto.ReserveRequest
 import com.wafflestudio.csereal.core.user.database.UserEntity
 import jakarta.persistence.Entity

--- a/src/main/kotlin/com/wafflestudio/csereal/core/reservation/database/RoomEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/reservation/database/RoomEntity.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.reservation.database
 
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/database/AttachmentEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/database/AttachmentEntity.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.resource.attachment.database
 
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import com.wafflestudio.csereal.core.about.database.AboutEntity
 import com.wafflestudio.csereal.core.academics.database.AcademicsEntity
 import com.wafflestudio.csereal.core.academics.database.CourseEntity

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/mainImage/database/MainImageEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/mainImage/database/MainImageEntity.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.resource.mainImage.database
 
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import jakarta.persistence.*
 
 @Entity(name = "mainImage")

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarEntity.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.seminar.database
 
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import com.wafflestudio.csereal.common.controller.AttachmentContentEntityType
 import com.wafflestudio.csereal.common.controller.MainImageContentEntityType
 import com.wafflestudio.csereal.common.utils.cleanTextFromHtml

--- a/src/main/kotlin/com/wafflestudio/csereal/core/user/database/UserEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/user/database/UserEntity.kt
@@ -1,6 +1,6 @@
 package com.wafflestudio.csereal.core.user.database
 
-import com.wafflestudio.csereal.common.config.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import jakarta.persistence.Entity
 
 @Entity(name = "users")


### PR DESCRIPTION
### 한줄 요약
- `Domain` enum을 정의
    - 추후 domain을 가로지르는 관심사에 대한 작업 시 domain 정보를 나타내기 위한 구조체
- `BaseTimeEntity` 패키지를 `common/entity` 위치로 이동
