### PR TITLE
Fix 서버 파일/메인이미지 폴더 분리

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/common/entity/AttachmentAttachable.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/entity/AttachmentAttachable.kt
@@ -4,4 +4,6 @@ import com.wafflestudio.csereal.core.resource.attachment.database.AttachmentEnti
 
 interface AttachmentAttachable {
     val attachments: List<AttachmentEntity>
+
+    fun getAttachmentFolder(): String
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/common/entity/MainImageAttachable.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/entity/MainImageAttachable.kt
@@ -3,5 +3,7 @@ package com.wafflestudio.csereal.common.entity
 import com.wafflestudio.csereal.core.resource.mainImage.database.MainImageEntity
 
 interface MainImageAttachable {
-    val mainImage: MainImageEntity?
+    var mainImage: MainImageEntity?
+
+    fun getMainImageFolder(): String
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/about/database/AboutEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/about/database/AboutEntity.kt
@@ -89,4 +89,8 @@ class AboutEntity(
         assert(postType == AboutPostType.FUTURE_CAREERS)
         searchContent = createContent(name, description, statNames, companyNames)
     }
+
+    override fun getAttachmentFolder() = "attachment/about"
+
+    override fun getMainImageFolder() = "mainImage/about"
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/academics/database/AcademicsEntity.kt
@@ -48,4 +48,6 @@ class AcademicsEntity(
             )
         }
     }
+
+    override fun getAttachmentFolder() = "attachment/academics"
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/council/database/CouncilEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/council/database/CouncilEntity.kt
@@ -33,6 +33,8 @@ class CouncilEntity(
                 name = req.name
             )
     }
+
+    override fun getMainImageFolder() = "mainImage/council"
 }
 
 enum class CouncilType {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/council/database/CouncilFileEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/council/database/CouncilFileEntity.kt
@@ -21,4 +21,6 @@ class CouncilFileEntity(
 
     @OneToMany(mappedBy = "councilFile", cascade = [CascadeType.ALL], orphanRemoval = true)
     override val attachments: MutableList<AttachmentEntity> = mutableListOf()
-) : BaseTimeEntity(), AttachmentAttachable
+) : BaseTimeEntity(), AttachmentAttachable {
+    override fun getAttachmentFolder() = "attachment/council"
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/database/ProfessorEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/database/ProfessorEntity.kt
@@ -77,6 +77,8 @@ class ProfessorEntity(
         this.lab = lab
         lab.professors.add(this)
     }
+
+    override fun getMainImageFolder() = "mainImage/professor"
 }
 
 enum class ProfessorStatus(

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/database/StaffEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/database/StaffEntity.kt
@@ -51,4 +51,6 @@ class StaffEntity(
         this.phone = staffDto.phone
         this.email = staffDto.email
     }
+
+    override fun getMainImageFolder() = "mainImage/staff"
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/news/database/NewsEntity.kt
@@ -70,4 +70,8 @@ class NewsEntity(
         this.isImportant = updateNewsRequest.isImportant
         this.importantUntil = if (updateNewsRequest.isImportant) updateNewsRequest.importantUntil else null
     }
+
+    override fun getAttachmentFolder() = "attachment/news"
+
+    override fun getMainImageFolder() = "mainImage/news"
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/notice/database/NoticeEntity.kt
@@ -61,4 +61,6 @@ class NoticeEntity(
         this.isImportant = updateNoticeRequest.isImportant
         this.importantUntil = if (updateNoticeRequest.isImportant) updateNoticeRequest.importantUntil else null
     }
+
+    override fun getAttachmentFolder() = "attachment/notice"
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/recruit/database/RecruitEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/recruit/database/RecruitEntity.kt
@@ -16,4 +16,6 @@ class RecruitEntity(
 
     @OneToOne
     override var mainImage: MainImageEntity? = null
-) : BaseTimeEntity(), MainImageAttachable
+) : BaseTimeEntity(), MainImageAttachable {
+    override fun getMainImageFolder() = "mainImage/research"
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/database/ResearchEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/database/ResearchEntity.kt
@@ -44,4 +44,6 @@ class ResearchEntity(
             )
         }
     }
+
+    override fun getMainImageFolder() = "mainImage/research"
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/database/AttachmentEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/database/AttachmentEntity.kt
@@ -19,6 +19,8 @@ class AttachmentEntity(
     @Column(unique = true)
     val filename: String,
 
+    val folder: String? = null,
+
     val attachmentsOrder: Int,
     val size: Long,
 
@@ -57,4 +59,8 @@ class AttachmentEntity(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "council_file_id")
     var councilFile: CouncilFileEntity? = null
-) : BaseTimeEntity()
+) : BaseTimeEntity() {
+    fun filePath(): String {
+        return if(folder.isNullOrBlank()) return filename else "${folder}/${filename}"
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/database/AttachmentEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/database/AttachmentEntity.kt
@@ -61,6 +61,6 @@ class AttachmentEntity(
     var councilFile: CouncilFileEntity? = null
 ) : BaseTimeEntity() {
     fun filePath(): String {
-        return if(folder.isNullOrBlank()) return filename else "${folder}/${filename}"
+        return if (folder.isNullOrBlank()) return filename else "$folder/$filename"
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/service/AttachmentService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/attachment/service/AttachmentService.kt
@@ -21,6 +21,7 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
+import java.lang.invoke.WrongMethodTypeException
 import java.nio.file.Files
 import java.nio.file.Paths
 
@@ -71,6 +72,7 @@ class AttachmentServiceImpl(
         )
 
         labEntity.pdf = attachment
+        attachment.lab = labEntity
         attachmentRepository.save(attachment)
 
         return AttachmentDto(
@@ -85,7 +87,7 @@ class AttachmentServiceImpl(
         contentEntityType: AttachmentAttachable,
         requestAttachments: List<MultipartFile>
     ): List<AttachmentDto> {
-        val folder = getAttachmentFolder(contentEntityType)
+        val folder = contentEntityType.getAttachmentFolder()
         val uploadDir = Paths.get(path, folder)
         Files.createDirectories(uploadDir)
 
@@ -221,18 +223,10 @@ class AttachmentServiceImpl(
                 contentEntity.attachments.add(attachment)
                 attachment.councilFile = contentEntity
             }
-        }
-    }
 
-    private fun getAttachmentFolder(contentEntityType: AttachmentAttachable): String {
-        return "attachment/" + when (contentEntityType) {
-            is NewsEntity -> "news"
-            is NoticeEntity -> "notice"
-            is SeminarEntity -> "seminar"
-            is AboutEntity -> "about"
-            is AcademicsEntity -> "academics"
-            is CouncilFileEntity -> "council"
-            else -> ""
+            else -> {
+                throw WrongMethodTypeException("파일을 엔티티에 연결할 수 없습니다")
+            }
         }
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/common/api/FileController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/common/api/FileController.kt
@@ -69,7 +69,7 @@ class FileController(
                 val saveFile = Paths.get(totalFilename)
                 file.transferTo(saveFile)
 
-                val imageUrl = "${endpointProperties.backend}/v1/file/$filename"
+                val imageUrl = "/v1/file/$filename"
 
                 results.add(
                     UploadFileInfo(

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/mainImage/database/MainImageEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/mainImage/database/MainImageEntity.kt
@@ -10,7 +10,13 @@ class MainImageEntity(
     @Column(unique = true)
     val filename: String,
 
+    val folder: String? = null,
+
     val imagesOrder: Int,
     val size: Long
 
-) : BaseTimeEntity()
+) : BaseTimeEntity() {
+    fun filePath(): String {
+        return if(folder.isNullOrBlank()) return filename else "${folder}/${filename}"
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/mainImage/database/MainImageEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/mainImage/database/MainImageEntity.kt
@@ -17,6 +17,6 @@ class MainImageEntity(
 
 ) : BaseTimeEntity() {
     fun filePath(): String {
-        return if(folder.isNullOrBlank()) return filename else "${folder}/${filename}"
+        return if (folder.isNullOrBlank()) return filename else "$folder/$filename"
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/mainImage/service/MainImageService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/mainImage/service/MainImageService.kt
@@ -3,25 +3,16 @@ package com.wafflestudio.csereal.core.resource.mainImage.service
 import com.wafflestudio.csereal.common.CserealException
 import com.wafflestudio.csereal.common.entity.MainImageAttachable
 import com.wafflestudio.csereal.common.properties.EndpointProperties
-import com.wafflestudio.csereal.core.about.database.AboutEntity
-import com.wafflestudio.csereal.core.council.database.CouncilEntity
-import com.wafflestudio.csereal.core.member.database.ProfessorEntity
-import com.wafflestudio.csereal.core.member.database.StaffEntity
-import com.wafflestudio.csereal.core.news.database.NewsEntity
-import com.wafflestudio.csereal.core.recruit.database.RecruitEntity
-import com.wafflestudio.csereal.core.research.database.ResearchEntity
 import com.wafflestudio.csereal.core.resource.common.event.FileDeleteEvent
 import com.wafflestudio.csereal.core.resource.mainImage.database.MainImageRepository
 import com.wafflestudio.csereal.core.resource.mainImage.database.MainImageEntity
 import com.wafflestudio.csereal.core.resource.mainImage.dto.MainImageDto
-import com.wafflestudio.csereal.core.seminar.database.SeminarEntity
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
 import org.apache.commons.io.FilenameUtils
 import org.springframework.context.ApplicationEventPublisher
-import java.lang.invoke.WrongMethodTypeException
 import java.nio.file.Files
 import java.nio.file.Paths
 
@@ -50,7 +41,7 @@ class MainImageServiceImpl(
         contentEntityType: MainImageAttachable,
         requestImage: MultipartFile
     ): MainImageDto {
-        val folder = getMainImageFolder(contentEntityType)
+        val folder = contentEntityType.getMainImageFolder()
         val uploadDir = Paths.get(path, folder)
         Files.createDirectories(uploadDir)
 
@@ -73,7 +64,7 @@ class MainImageServiceImpl(
             size = requestImage.size
         )
 
-        connectMainImageToEntity(contentEntityType, mainImage)
+        contentEntityType.mainImage = mainImage
         mainImageRepository.save(mainImage)
 
         return MainImageDto(
@@ -100,58 +91,7 @@ class MainImageServiceImpl(
         eventPublisher.publishEvent(FileDeleteEvent(fileDirectory))
     }
 
-    // TODO: 각 entity의 interface로 refactoring하기.
     private fun connectMainImageToEntity(contentEntity: MainImageAttachable, mainImage: MainImageEntity) {
-        when (contentEntity) {
-            is NewsEntity -> {
-                contentEntity.mainImage = mainImage
-            }
-
-            is SeminarEntity -> {
-                contentEntity.mainImage = mainImage
-            }
-
-            is AboutEntity -> {
-                contentEntity.mainImage = mainImage
-            }
-
-            is ProfessorEntity -> {
-                contentEntity.mainImage = mainImage
-            }
-
-            is StaffEntity -> {
-                contentEntity.mainImage = mainImage
-            }
-
-            is ResearchEntity -> {
-                contentEntity.mainImage = mainImage
-            }
-
-            is RecruitEntity -> {
-                contentEntity.mainImage = mainImage
-            }
-
-            is CouncilEntity -> {
-                contentEntity.mainImage = mainImage
-            }
-
-            else -> {
-                throw WrongMethodTypeException("해당하는 엔티티가 없습니다")
-            }
-        }
-    }
-
-    private fun getMainImageFolder(contentEntityType: MainImageAttachable): String {
-        return "mainImage/" + when (contentEntityType) {
-            is NewsEntity -> "news"
-            is SeminarEntity -> "seminar"
-            is AboutEntity -> "about"
-            is ProfessorEntity -> "professor"
-            is StaffEntity -> "staff"
-            is ResearchEntity -> "research"
-            is RecruitEntity -> "recruit"
-            is CouncilEntity -> "council"
-            else -> ""
-        }
+        contentEntity.mainImage = mainImage
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/seminar/database/SeminarEntity.kt
@@ -128,4 +128,8 @@ class SeminarEntity(
         isImportant = updateSeminarRequest.isImportant
         importantUntil = if (updateSeminarRequest.isImportant) updateSeminarRequest.importantUntil else null
     }
+
+    override fun getAttachmentFolder() = "attachment/seminar"
+
+    override fun getMainImageFolder() = "mainImage/seminar"
 }

--- a/src/main/resources/db/migration/V12__add_folder_to_attachment_and_mainimage.sql
+++ b/src/main/resources/db/migration/V12__add_folder_to_attachment_and_mainimage.sql
@@ -1,0 +1,5 @@
+ALTER TABLE attachment
+ADD COLUMN folder VARCHAR(255) NULL;
+
+ALTER TABLE main_image
+ADD COLUMN folder VARCHAR(255) NULL;


### PR DESCRIPTION
## 서버에서 첨부파일/메인이미지가 저장되는 폴더 분리

### 한줄 요약

게시물의 타입별로 첨부파일이나 메인이미지가 저장되는 폴더를 분리

### 상세 설명

attachmentEntity와 mainImageEntity에 nullable folder 필드를 추가해서 기존 파일도 일단은 별도 마이그레이션 없이 그대로 사용할 수 있도록 했습니다.

app/files/attachment(또는 mainImage)/"폴더이름"/"파일이름" 위치에 저장됩니다

attachment의 하위 폴더 : news, notice, seminar, about, academics, council, lab

mainIamge의 하위 폴더 : news, seminar, about, professor, staff, research, recruit, council

폴더 이름은 각 엔티티에서 함수로 반환하도록 했습니다

### TODO

로컬에서 실행 시 의도하지 않은 빈 폴더(app/attachment와 app/mainImage)가 생성되는 문제를 아직 해결하지 못했습니다