### PR TITLE
정기예약 기간 조회 API 추가

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/reservation/api/v2/ReservationController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/reservation/api/v2/ReservationController.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.csereal.core.reservation.api.v2
 
 import com.wafflestudio.csereal.core.reservation.dto.ReservationDto
 import com.wafflestudio.csereal.core.reservation.dto.ReserveRequest
+import com.wafflestudio.csereal.core.reservation.dto.ReserveTermDto
 import com.wafflestudio.csereal.core.reservation.dto.SimpleReservationDto
 import com.wafflestudio.csereal.core.reservation.service.ReservationService
 import org.springframework.http.ResponseEntity
@@ -44,6 +45,11 @@ class ReservationController(
         val start = LocalDateTime.of(year, month, day, 0, 0).minusHours(9)
         val end = start.plusDays(7)
         return ResponseEntity.ok(reservationService.getRoomReservationsBetween(roomId, start, end))
+    }
+
+    @GetMapping("/terms")
+    fun getReserveTerms(): ResponseEntity<List<ReserveTermDto>> {
+        return ResponseEntity.ok(reservationService.getReserveTerms())
     }
 
     @GetMapping("/{reservationId}")

--- a/src/main/kotlin/com/wafflestudio/csereal/core/reservation/dto/ReserveTermDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/reservation/dto/ReserveTermDto.kt
@@ -1,0 +1,24 @@
+package com.wafflestudio.csereal.core.reservation.dto
+
+import com.wafflestudio.csereal.core.reservation.database.ReserveTermEntity
+import java.time.LocalDateTime
+
+data class ReserveTermDto(
+    val id: Long,
+    val applyStartTime: LocalDateTime,
+    val applyEndTime: LocalDateTime,
+    val termStartTime: LocalDateTime,
+    val termEndTime: LocalDateTime
+) {
+    companion object {
+        fun of(entity: ReserveTermEntity): ReserveTermDto {
+            return ReserveTermDto(
+                id = entity.id,
+                applyStartTime = entity.applyStartTime,
+                applyEndTime = entity.applyEndTime,
+                termStartTime = entity.termStartTime,
+                termEndTime = entity.termEndTime
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/reservation/service/ReservationService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/reservation/service/ReservationService.kt
@@ -8,6 +8,7 @@ import com.wafflestudio.csereal.common.utils.isCurrentUserStaffOrProfessor
 import com.wafflestudio.csereal.core.reservation.database.*
 import com.wafflestudio.csereal.core.reservation.dto.ReservationDto
 import com.wafflestudio.csereal.core.reservation.dto.ReserveRequest
+import com.wafflestudio.csereal.core.reservation.dto.ReserveTermDto
 import com.wafflestudio.csereal.core.reservation.dto.SimpleReservationDto
 import com.wafflestudio.csereal.core.user.service.UserService
 import org.springframework.data.repository.findByIdOrNull
@@ -20,6 +21,7 @@ interface ReservationService {
     fun reserveRoom(reserveRequest: ReserveRequest): List<ReservationDto>
     fun getRoomReservationsBetween(roomId: Long, start: LocalDateTime, end: LocalDateTime): List<SimpleReservationDto>
     fun getReservation(reservationId: Long): ReservationDto
+    fun getReserveTerms(): List<ReserveTermDto>
     fun cancelSpecific(reservationId: Long)
     fun cancelRecurring(recurrenceId: UUID)
 }
@@ -122,6 +124,11 @@ class ReservationServiceImpl(
     ): List<SimpleReservationDto> {
         return reservationRepository.findByRoomIdAndStartTimeBetweenOrderByStartTimeAsc(roomId, start, end)
             .map { SimpleReservationDto.of(it) }
+    }
+
+    @Transactional(readOnly = true)
+    override fun getReserveTerms(): List<ReserveTermDto> {
+        return reserveTermRepository.findAll().map { ReserveTermDto.of(it) }
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 정기예약 기간 조회 API 추가

### 한줄 요약

프론트에서 정기예약 기간 안내를 위해 reserve_term 조회 API 추가

### 상세 설명

`GET /api/v2/reservation/terms`로 등록된 모든 정기예약 기간을 조회할 수 있습니다.
인증 불필요 (공개 정보). 프론트에서 현재 정기예약 기간 여부, 상시예약 전환 시점 등을 안내하는 데 사용할 예정입니다.