### PR TITLE
Image Modal CRUD

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/core/imagemodal/api/req/CreateImageModalReq.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/imagemodal/api/req/CreateImageModalReq.kt
@@ -1,4 +1,4 @@
-package com.wafflestudio.csereal.core.imagemodal.api.v2.req
+package com.wafflestudio.csereal.core.imagemodal.api.req
 
 import java.time.LocalDateTime
 

--- a/src/main/kotlin/com/wafflestudio/csereal/core/imagemodal/api/v2/ImageModalController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/imagemodal/api/v2/ImageModalController.kt
@@ -34,9 +34,9 @@ class ImageModalController(
     fun updateImageModal(
         @PathVariable imageModalId: Long,
         @RequestPart("request") request: CreateImageModalReq,
-        @RequestPart("mainImage") mainImage: MultipartFile?
+        @RequestPart("newMainImage") newMainImage: MultipartFile?
     ): ResponseEntity<ImageModalDto> {
-        return ResponseEntity.ok(imageModalService.updateImageModal(imageModalId, request, mainImage))
+        return ResponseEntity.ok(imageModalService.updateImageModal(imageModalId, request, newMainImage))
     }
 
     @PreAuthorize("hasRole('STAFF')")

--- a/src/main/kotlin/com/wafflestudio/csereal/core/imagemodal/api/v2/ImageModalController.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/imagemodal/api/v2/ImageModalController.kt
@@ -1,0 +1,54 @@
+package com.wafflestudio.csereal.core.imagemodal.api.v2
+
+import com.wafflestudio.csereal.core.imagemodal.api.req.CreateImageModalReq
+import com.wafflestudio.csereal.core.imagemodal.dto.ImageModalDto
+import com.wafflestudio.csereal.core.imagemodal.service.ImageModalService
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestPart
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+
+@RequestMapping("/api/v2/image-modal")
+@RestController
+class ImageModalController(
+    private val imageModalService: ImageModalService
+) {
+    @PreAuthorize("hasRole('STAFF')")
+    @PostMapping
+    fun createImageModal(
+        @RequestPart("request") request: CreateImageModalReq,
+        @RequestPart("mainImage") mainImage: MultipartFile
+    ): ResponseEntity<ImageModalDto> {
+        return ResponseEntity.ok(imageModalService.createImageModal(request, mainImage))
+    }
+
+    @PreAuthorize("hasRole('STAFF')")
+    @PatchMapping("/{imageModalId}")
+    fun updateImageModal(
+        @PathVariable imageModalId: Long,
+        @RequestPart("request") request: CreateImageModalReq,
+        @RequestPart("mainImage") mainImage: MultipartFile?
+    ): ResponseEntity<ImageModalDto> {
+        return ResponseEntity.ok(imageModalService.updateImageModal(imageModalId, request, mainImage))
+    }
+
+    @PreAuthorize("hasRole('STAFF')")
+    @DeleteMapping("/{imageModalId}")
+    fun deleteImageModal(
+        @PathVariable imageModalId: Long
+    ) {
+        imageModalService.deleteImageModal(imageModalId)
+    }
+
+    @GetMapping
+    fun readImageModals(): ResponseEntity<List<ImageModalDto>> {
+        return ResponseEntity.ok(imageModalService.readImageModals())
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/imagemodal/api/v2/req/CreateImageModalReq.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/imagemodal/api/v2/req/CreateImageModalReq.kt
@@ -1,0 +1,12 @@
+package com.wafflestudio.csereal.core.imagemodal.api.v2.req
+
+import java.time.LocalDateTime
+
+data class CreateImageModalReq(
+    val titleKo: String?,
+    val titleEn: String?,
+    val imageAltKo: String?,
+    val imageAltEn: String?,
+    val displayUntil: LocalDateTime?,
+    val externalLink: String?
+)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/imagemodal/database/ImageModalEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/imagemodal/database/ImageModalEntity.kt
@@ -9,7 +9,7 @@ import jakarta.persistence.Entity
 import jakarta.persistence.OneToOne
 import java.time.LocalDateTime
 
-@Entity(name = "imageModal")
+@Entity(name = "image_modal")
 class ImageModalEntity (
     var titleKo: String?,
     var titleEn: String?,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/imagemodal/database/ImageModalEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/imagemodal/database/ImageModalEntity.kt
@@ -3,14 +3,13 @@ package com.wafflestudio.csereal.core.imagemodal.database
 import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import com.wafflestudio.csereal.common.entity.MainImageAttachable
 import com.wafflestudio.csereal.core.imagemodal.api.req.CreateImageModalReq
-import com.wafflestudio.csereal.core.imagemodal.dto.ImageModalDto
 import com.wafflestudio.csereal.core.resource.mainImage.database.MainImageEntity
 import jakarta.persistence.Entity
 import jakarta.persistence.OneToOne
 import java.time.LocalDateTime
 
 @Entity(name = "image_modal")
-class ImageModalEntity (
+class ImageModalEntity(
     var titleKo: String?,
     var titleEn: String?,
     var imageAltKo: String?,
@@ -21,7 +20,7 @@ class ImageModalEntity (
     var externalLink: String?,
 
     @OneToOne
-    override var mainImage : MainImageEntity? = null
+    override var mainImage: MainImageEntity? = null
 ) : BaseTimeEntity(), MainImageAttachable {
     companion object {
         fun of(req: CreateImageModalReq): ImageModalEntity =

--- a/src/main/kotlin/com/wafflestudio/csereal/core/imagemodal/database/ImageModalEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/imagemodal/database/ImageModalEntity.kt
@@ -1,0 +1,46 @@
+package com.wafflestudio.csereal.core.imagemodal.database
+
+import com.wafflestudio.csereal.common.entity.BaseTimeEntity
+import com.wafflestudio.csereal.common.entity.MainImageAttachable
+import com.wafflestudio.csereal.core.imagemodal.api.v2.req.CreateImageModalReq
+import com.wafflestudio.csereal.core.imagemodal.dto.ImageModalDto
+import com.wafflestudio.csereal.core.resource.mainImage.database.MainImageEntity
+import jakarta.persistence.Entity
+import jakarta.persistence.OneToOne
+import java.time.LocalDateTime
+
+@Entity(name = "imageModal")
+class ImageModalEntity (
+    var titleKo: String?,
+    var titleEn: String?,
+    var imageAltKo: String?,
+    var imageAltEn: String?,
+
+    var displayUntil: LocalDateTime? = null,
+
+    var externalLink: String?,
+
+    @OneToOne
+    override var mainImage : MainImageEntity? = null
+) : BaseTimeEntity(), MainImageAttachable {
+    companion object {
+        fun of(req: CreateImageModalReq): ImageModalEntity =
+            ImageModalEntity(
+                titleKo = req.titleKo,
+                titleEn = req.titleEn,
+                imageAltKo = req.imageAltKo,
+                imageAltEn = req.imageAltEn,
+                displayUntil = req.displayUntil,
+                externalLink = req.externalLink
+            )
+    }
+
+    fun update(req: CreateImageModalReq) {
+        this.titleKo = req.titleKo
+        this.titleEn = req.titleEn
+        this.imageAltKo = req.imageAltKo
+        this.imageAltEn = req.imageAltEn
+        this.displayUntil = req.displayUntil
+        this.externalLink = req.externalLink
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/imagemodal/database/ImageModalEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/imagemodal/database/ImageModalEntity.kt
@@ -2,7 +2,7 @@ package com.wafflestudio.csereal.core.imagemodal.database
 
 import com.wafflestudio.csereal.common.entity.BaseTimeEntity
 import com.wafflestudio.csereal.common.entity.MainImageAttachable
-import com.wafflestudio.csereal.core.imagemodal.api.v2.req.CreateImageModalReq
+import com.wafflestudio.csereal.core.imagemodal.api.req.CreateImageModalReq
 import com.wafflestudio.csereal.core.imagemodal.dto.ImageModalDto
 import com.wafflestudio.csereal.core.resource.mainImage.database.MainImageEntity
 import jakarta.persistence.Entity

--- a/src/main/kotlin/com/wafflestudio/csereal/core/imagemodal/database/ImageModalRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/imagemodal/database/ImageModalRepository.kt
@@ -1,0 +1,5 @@
+package com.wafflestudio.csereal.core.imagemodal.database
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ImageModalRepository : JpaRepository<ImageModalEntity, Long>

--- a/src/main/kotlin/com/wafflestudio/csereal/core/imagemodal/dto/ImageModalDto.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/imagemodal/dto/ImageModalDto.kt
@@ -1,0 +1,34 @@
+package com.wafflestudio.csereal.core.imagemodal.dto
+
+import com.wafflestudio.csereal.core.imagemodal.database.ImageModalEntity
+import java.time.LocalDateTime
+
+data class ImageModalDto(
+    val id: Long,
+    val titleKo: String?,
+    val titleEn: String?,
+    val imageAltKo: String?,
+    val imageAltEn: String?,
+    val displayUntil: LocalDateTime?,
+    val externalLink: String?,
+
+    val imageUrl: String
+) {
+    companion object {
+        fun of(
+            entity: ImageModalEntity,
+            imageUrl: String
+        ): ImageModalDto = entity.run {
+            ImageModalDto(
+                id = this.id,
+                titleKo = this.titleKo,
+                titleEn = this.titleEn,
+                imageAltKo = this.imageAltKo,
+                imageAltEn = this.imageAltEn,
+                displayUntil = this.displayUntil,
+                externalLink = this.externalLink,
+                imageUrl = imageUrl
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/imagemodal/service/ImageModalService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/imagemodal/service/ImageModalService.kt
@@ -1,7 +1,7 @@
 package com.wafflestudio.csereal.core.imagemodal.service
 
 import com.wafflestudio.csereal.common.CserealException
-import com.wafflestudio.csereal.core.imagemodal.api.v2.req.CreateImageModalReq
+import com.wafflestudio.csereal.core.imagemodal.api.req.CreateImageModalReq
 import com.wafflestudio.csereal.core.imagemodal.database.ImageModalEntity
 import com.wafflestudio.csereal.core.imagemodal.database.ImageModalRepository
 import com.wafflestudio.csereal.core.imagemodal.dto.ImageModalDto

--- a/src/main/kotlin/com/wafflestudio/csereal/core/imagemodal/service/ImageModalService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/imagemodal/service/ImageModalService.kt
@@ -69,7 +69,7 @@ class ImageModalServiceImpl(
         imageModalRepository.deleteById(id)
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     override fun readImageModals(): List<ImageModalDto> {
         val imageModals = imageModalRepository.findAll()
         return imageModals.map {

--- a/src/main/kotlin/com/wafflestudio/csereal/core/imagemodal/service/ImageModalService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/imagemodal/service/ImageModalService.kt
@@ -19,9 +19,9 @@ interface ImageModalService {
 }
 
 @Service
-class ImageModalServiceImpl (
+class ImageModalServiceImpl(
     private val imageModalRepository: ImageModalRepository,
-    private val mainImageService: MainImageService,
+    private val mainImageService: MainImageService
 ) : ImageModalService {
     @Transactional
     override fun createImageModal(
@@ -39,14 +39,15 @@ class ImageModalServiceImpl (
 
     @Transactional
     override fun updateImageModal(
-        modalId: Long, request: CreateImageModalReq,
+        modalId: Long,
+        request: CreateImageModalReq,
         newImage: MultipartFile?
     ): ImageModalDto {
         val imageModal: ImageModalEntity = getImageModalByIdOrThrow(modalId)
 
         imageModal.update(request)
 
-        if(newImage != null) {
+        if (newImage != null) {
             val originalImage = imageModal.mainImage
             mainImageService.uploadMainImage(imageModal, newImage)
             originalImage?.let { mainImageService.removeImage(it) }
@@ -80,6 +81,8 @@ class ImageModalServiceImpl (
     }
 
     private fun getImageModalByIdOrThrow(imageModalId: Long): ImageModalEntity {
-        return imageModalRepository.findByIdOrNull(imageModalId) ?: throw CserealException.Csereal404("ImageModal Not Found")
+        return imageModalRepository.findByIdOrNull(imageModalId) ?: throw CserealException.Csereal404(
+            "ImageModal Not Found"
+        )
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/imagemodal/service/ImageModalService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/imagemodal/service/ImageModalService.kt
@@ -1,0 +1,85 @@
+package com.wafflestudio.csereal.core.imagemodal.service
+
+import com.wafflestudio.csereal.common.CserealException
+import com.wafflestudio.csereal.core.imagemodal.api.v2.req.CreateImageModalReq
+import com.wafflestudio.csereal.core.imagemodal.database.ImageModalEntity
+import com.wafflestudio.csereal.core.imagemodal.database.ImageModalRepository
+import com.wafflestudio.csereal.core.imagemodal.dto.ImageModalDto
+import com.wafflestudio.csereal.core.resource.mainImage.service.MainImageService
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.multipart.MultipartFile
+
+interface ImageModalService {
+    fun createImageModal(request: CreateImageModalReq, image: MultipartFile): ImageModalDto
+    fun updateImageModal(modalId: Long, request: CreateImageModalReq, newImage: MultipartFile?): ImageModalDto
+    fun deleteImageModal(id: Long)
+    fun readImageModals(): List<ImageModalDto>
+}
+
+@Service
+class ImageModalServiceImpl (
+    private val imageModalRepository: ImageModalRepository,
+    private val mainImageService: MainImageService,
+) : ImageModalService {
+    @Transactional
+    override fun createImageModal(
+        request: CreateImageModalReq,
+        image: MultipartFile
+    ): ImageModalDto {
+        val newImageModal = ImageModalEntity.of(request)
+        mainImageService.uploadMainImage(newImageModal, image)
+        imageModalRepository.save(newImageModal)
+
+        val imageUrl = mainImageService.createImageURL(newImageModal.mainImage)!!
+
+        return ImageModalDto.of(newImageModal, imageUrl)
+    }
+
+    @Transactional
+    override fun updateImageModal(
+        modalId: Long, request: CreateImageModalReq,
+        newImage: MultipartFile?
+    ): ImageModalDto {
+        val imageModal: ImageModalEntity = getImageModalByIdOrThrow(modalId)
+
+        imageModal.update(request)
+
+        if(newImage != null) {
+            val originalImage = imageModal.mainImage
+            mainImageService.uploadMainImage(imageModal, newImage)
+            originalImage?.let { mainImageService.removeImage(it) }
+        }
+        val imageUrl = mainImageService.createImageURL(imageModal.mainImage)!!
+
+        return ImageModalDto.of(imageModal, imageUrl)
+    }
+
+    @Transactional
+    override fun deleteImageModal(id: Long) {
+        val imageModal = getImageModalByIdOrThrow(id)
+
+        imageModal.mainImage?.let {
+            imageModal.mainImage = null
+            mainImageService.removeImage(it)
+        }
+
+        imageModalRepository.deleteById(id)
+    }
+
+    @Transactional
+    override fun readImageModals(): List<ImageModalDto> {
+        val imageModals = imageModalRepository.findAll()
+        return imageModals.map {
+            ImageModalDto.of(
+                it,
+                mainImageService.createImageURL(it.mainImage)!!
+            )
+        }
+    }
+
+    private fun getImageModalByIdOrThrow(imageModalId: Long): ImageModalEntity {
+        return imageModalRepository.findByIdOrNull(imageModalId) ?: throw CserealException.Csereal404("ImageModal Not Found")
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/resource/mainImage/service/MainImageService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/resource/mainImage/service/MainImageService.kt
@@ -5,6 +5,7 @@ import com.wafflestudio.csereal.common.entity.MainImageAttachable
 import com.wafflestudio.csereal.common.properties.EndpointProperties
 import com.wafflestudio.csereal.core.about.database.AboutEntity
 import com.wafflestudio.csereal.core.council.database.CouncilEntity
+import com.wafflestudio.csereal.core.imagemodal.database.ImageModalEntity
 import com.wafflestudio.csereal.core.member.database.ProfessorEntity
 import com.wafflestudio.csereal.core.member.database.StaffEntity
 import com.wafflestudio.csereal.core.news.database.NewsEntity
@@ -130,6 +131,10 @@ class MainImageServiceImpl(
             }
 
             is CouncilEntity -> {
+                contentEntity.mainImage = mainImage
+            }
+
+            is ImageModalEntity -> {
                 contentEntity.mainImage = mainImage
             }
 

--- a/src/main/resources/db/migration/V15__create_image_modal.sql
+++ b/src/main/resources/db/migration/V15__create_image_modal.sql
@@ -1,0 +1,17 @@
+CREATE TABLE image_modal
+(
+    id          BIGINT AUTO_INCREMENT PRIMARY KEY,
+    created_at  datetime(6) default '1999-01-01 00:00:00.000000',
+    modified_at datetime(6) default '1999-01-01 00:00:00.000000',
+
+    title_ko VARCHAR(255),
+    title_en VARCHAR(255),
+    image_alt_ko    VARCHAR(255),
+    image_alt_en    VARCHAR(255),
+    display_until   datetime(6),
+    external_link   VARCHAR(255),
+    main_image_id BIGINT
+
+    CONSTRAINT fk_main_image_main_image_id
+        FOREIGN KEY (main_image_id) REFERENCES main_image (id)
+);

--- a/src/main/resources/db/migration/V15__create_image_modal.sql
+++ b/src/main/resources/db/migration/V15__create_image_modal.sql
@@ -10,7 +10,7 @@ CREATE TABLE image_modal
     image_alt_en    VARCHAR(255),
     display_until   datetime(6),
     external_link   VARCHAR(255),
-    main_image_id BIGINT
+    main_image_id BIGINT,
 
     CONSTRAINT fk_main_image_main_image_id
         FOREIGN KEY (main_image_id) REFERENCES main_image (id)

--- a/src/main/resources/db/migration/V15__create_image_modal.sql
+++ b/src/main/resources/db/migration/V15__create_image_modal.sql
@@ -12,6 +12,6 @@ CREATE TABLE image_modal
     external_link   VARCHAR(255),
     main_image_id BIGINT,
 
-    CONSTRAINT fk_main_image_main_image_id
+    CONSTRAINT FK_image_modal_main_image_main_image_id
         FOREIGN KEY (main_image_id) REFERENCES main_image (id)
 );


### PR DESCRIPTION
## Image Modal CRUD

### 한줄 요약

Image Modal 저장/관리할 수 있도록 기본적인 CRUD 기능 만들어두었습니다

### api 정리

/api/v2/image-modal

POST /api/v2/image-modal

image-modal 생성
request 필드 : titleKo, titleEn, imageAltKo, imageAltEn, displayUntil, externalLink (모든 필드는 생략해도 됨, request는 있어야 함)
mainImage : 필수

PATCH /api/v2/image-modal/{imageModalId}
image-modal 수정
request : 생성과 동일
newMainImage : 이미지 교체 하는 경우에 필요

DELETE /api/v2/image-modal/{imageModalId}
image-modal 삭제

GET /api/v2/image-modal
모든 image-modal 불러오기
