### PR TITLE
FTS 글자수 제한

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/common/repository/CommonRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/repository/CommonRepository.kt
@@ -68,7 +68,7 @@ class CommonRepositoryImpl : CommonRepository {
         Double::class.javaObjectType,
         "function('match',{0},{1})",
         field,
-        replaceOperatorsToSpace(keyword)
+        sanitizeKeyword(keyword)
     )
 
     override fun searchFullDoubleTextTemplate(
@@ -80,7 +80,7 @@ class CommonRepositoryImpl : CommonRepository {
         "function('match2',{0},{1},{2})",
         field1,
         field2,
-        replaceOperatorsToSpace(keyword)
+        sanitizeKeyword(keyword)
     )
 
     override fun searchFullTripleTextTemplate(
@@ -94,7 +94,7 @@ class CommonRepositoryImpl : CommonRepository {
         field1,
         field2,
         field3,
-        replaceOperatorsToSpace(keyword)
+        sanitizeKeyword(keyword)
     )
 
     override fun searchFullQuadrapleTextTemplate(
@@ -110,7 +110,7 @@ class CommonRepositoryImpl : CommonRepository {
         field2,
         field3,
         field4,
-        replaceOperatorsToSpace(keyword)
+        sanitizeKeyword(keyword)
     )
 
     override fun searchFullQuintupleTextTemplate(
@@ -128,7 +128,7 @@ class CommonRepositoryImpl : CommonRepository {
         field3,
         field4,
         field5,
-        replaceOperatorsToSpace(keyword)
+        sanitizeKeyword(keyword)
     )
 
     override fun searchFullSextupleTextTemplate(
@@ -148,7 +148,7 @@ class CommonRepositoryImpl : CommonRepository {
         field4,
         field5,
         field6,
-        replaceOperatorsToSpace(keyword)
+        sanitizeKeyword(keyword)
     )
 
     override fun searchFullSeptupleTextTemplate(
@@ -170,7 +170,7 @@ class CommonRepositoryImpl : CommonRepository {
         field5,
         field6,
         field7,
-        replaceOperatorsToSpace(keyword)
+        sanitizeKeyword(keyword)
     )
 
     override fun searchFullOctupleTextTemplate(
@@ -194,8 +194,15 @@ class CommonRepositoryImpl : CommonRepository {
         field6,
         field7,
         field8,
-        replaceOperatorsToSpace(keyword)
+        sanitizeKeyword(keyword)
     )
+
+    private fun sanitizeKeyword(keyword: String): String =
+        replaceOperatorsToSpace(limitLength(keyword))
+
+    // Prevent Errors like "Too many words in a FTS phrase or proximity search"
+    private fun limitLength(keyword: String): String =
+        keyword.trim().take(50)
 
     val operatorRegex = """[+\-<>'"@()~*]""".toRegex()
 


### PR DESCRIPTION
## FTS 글자수 제한

### 한줄 요약

FTS에 사용되는 keyword의 앞 50자까지만 사용하도록 변경

### 상세 설명

searchTotal... 에서 아주 긴 keyword를 입력할 경우 
Too many words in a FTS phrase or proximity search 오류가 발생해 사용자 입장에선 500이 뜹니다.
이를 방지하기 위해 긴 keyword를 입력하면 앞 50자만 검색에 사용하도록 수정하였습니다.

