### PR TITLE
v3 API: 이중언어 단일 id, 파일 파트명·에러 응답·통합 검색 정리

### DIFF
--- a/src/main/kotlin/com/wafflestudio/csereal/common/CserealException.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/CserealException.kt
@@ -32,19 +32,18 @@ enum class ErrorCode(val status: HttpStatus, val code: String, val msg: String) 
     TERM_NOT_OPENED(HttpStatus.FORBIDDEN, "RESERVE-08", "겹치는 정기예약 기간이 끝난 이후에 예약 가능"),
     RESERVATION_OCCUPIED(HttpStatus.CONFLICT, "RESERVE-09", "해당 시간에 이미 예약이 있습니다"),
 
-    // research/lab (v3 — 도메인별 안정 코드 시범. 기존 code:null Csereal404를 코드 보유로 전환)
+    // research/lab (v3): 기존 code:null Csereal404를 코드 보유 에러로 전환
     LAB_NOT_FOUND(HttpStatus.NOT_FOUND, "RESEARCH-01", "해당 연구실을 찾을 수 없습니다."),
     LAB_PROFESSOR_OCCUPIED(HttpStatus.BAD_REQUEST, "RESEARCH-02", "이미 다른 연구실에 속한 교수님이 존재합니다."),
     RESEARCH_GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "RESEARCH-03", "해당 연구그룹을 찾을 수 없습니다."),
     PROFESSORS_NOT_FOUND(HttpStatus.NOT_FOUND, "RESEARCH-04", "해당 교수님들을 찾을 수 없습니다."),
 
-    // member (v3 — 단일-id 확장)
+    // member (v3): 단일-id 확장
     PROFESSOR_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER-01", "해당 교수님을 찾을 수 없습니다."),
     STAFF_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER-02", "해당 직원을 찾을 수 없습니다.")
 }
 
-// 도메인 무관 횡단 에러. 모든 에러 경로(검증·인가·인증·미처리)가 동일한 envelope로 나가도록
-// 코드를 부여한다. (이전엔 @Valid·401·403·500이 envelope 밖 맨 문자열/Spring 기본이었음)
+// 도메인 무관 횡단 에러(검증·인가·인증·미처리). 모든 에러 경로를 동일 envelope로 통일하기 위한 코드.
 enum class SystemErrorCode(val status: HttpStatus, val code: String, val msg: String) {
     DATA_DUPLICATION(HttpStatus.CONFLICT, "SYS-01", "중복된 값이 있습니다."),
     VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "SYS-02", "요청 값이 올바르지 않습니다."),

--- a/src/main/kotlin/com/wafflestudio/csereal/common/CserealException.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/CserealException.kt
@@ -30,9 +30,26 @@ enum class ErrorCode(val status: HttpStatus, val code: String, val msg: String) 
     RESERVATION_TIME_EXCEEDED(HttpStatus.BAD_REQUEST, "RESERVE-06", "정기예약 기간에 3시간을 초과한 예약 불가"),
     TERM_NOT_REGISTERED(HttpStatus.FORBIDDEN, "RESERVE-07", "아직 등록되지 않은 기간은 예약 불가"),
     TERM_NOT_OPENED(HttpStatus.FORBIDDEN, "RESERVE-08", "겹치는 정기예약 기간이 끝난 이후에 예약 가능"),
-    RESERVATION_OCCUPIED(HttpStatus.CONFLICT, "RESERVE-09", "해당 시간에 이미 예약이 있습니다")
+    RESERVATION_OCCUPIED(HttpStatus.CONFLICT, "RESERVE-09", "해당 시간에 이미 예약이 있습니다"),
+
+    // research/lab (v3 — 도메인별 안정 코드 시범. 기존 code:null Csereal404를 코드 보유로 전환)
+    LAB_NOT_FOUND(HttpStatus.NOT_FOUND, "RESEARCH-01", "해당 연구실을 찾을 수 없습니다."),
+    LAB_PROFESSOR_OCCUPIED(HttpStatus.BAD_REQUEST, "RESEARCH-02", "이미 다른 연구실에 속한 교수님이 존재합니다."),
+    RESEARCH_GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "RESEARCH-03", "해당 연구그룹을 찾을 수 없습니다."),
+    PROFESSORS_NOT_FOUND(HttpStatus.NOT_FOUND, "RESEARCH-04", "해당 교수님들을 찾을 수 없습니다."),
+
+    // member (v3 — 단일-id 확장)
+    PROFESSOR_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER-01", "해당 교수님을 찾을 수 없습니다."),
+    STAFF_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER-02", "해당 직원을 찾을 수 없습니다.")
 }
 
+// 도메인 무관 횡단 에러. 모든 에러 경로(검증·인가·인증·미처리)가 동일한 envelope로 나가도록
+// 코드를 부여한다. (이전엔 @Valid·401·403·500이 envelope 밖 맨 문자열/Spring 기본이었음)
 enum class SystemErrorCode(val status: HttpStatus, val code: String, val msg: String) {
-    DATA_DUPLICATION(HttpStatus.CONFLICT, "SYS-01", "중복된 값이 있습니다.")
+    DATA_DUPLICATION(HttpStatus.CONFLICT, "SYS-01", "중복된 값이 있습니다."),
+    VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "SYS-02", "요청 값이 올바르지 않습니다."),
+    AUTHENTICATION_REQUIRED(HttpStatus.UNAUTHORIZED, "SYS-03", "로그인이 필요합니다."),
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "SYS-04", "접근 권한이 없습니다."),
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SYS-05", "서버 오류가 발생했습니다."),
+    EXTERNAL_AUTH_ERROR(HttpStatus.BAD_GATEWAY, "SYS-06", "인증 서버 오류가 발생했습니다.")
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/common/config/CserealExceptionHandler.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/config/CserealExceptionHandler.kt
@@ -2,47 +2,80 @@ package com.wafflestudio.csereal.common.config
 
 import com.wafflestudio.csereal.common.CserealException
 import com.wafflestudio.csereal.common.SystemErrorCode
+import com.wafflestudio.csereal.common.dto.ErrorResponse
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.validation.BindingResult
+import org.springframework.security.access.AccessDeniedException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.client.RestClientException
 import java.sql.SQLIntegrityConstraintViolationException
 
+/**
+ * 모든 에러를 단일 envelope(ErrorResponse{code, message})로 내보낸다.
+ * 401/403은 Spring Security 필터에서 발생하므로 SecurityConfig의 entryPoint/accessDeniedHandler가
+ * 같은 envelope로 처리한다(여기선 못 잡음).
+ */
 @RestControllerAdvice
 class CserealExceptionHandler {
     private val log = LoggerFactory.getLogger(this::class.java)
 
-    // @Valid로 인해 오류 떴을 때 메시지 전송
-    @ExceptionHandler(value = [MethodArgumentNotValidException::class])
-    fun handle(e: MethodArgumentNotValidException): ResponseEntity<Any> {
-        val bindingResult: BindingResult = e.bindingResult
-        return ResponseEntity(bindingResult.fieldError?.defaultMessage, HttpStatus.BAD_REQUEST)
-    }
-
     // csereal 내부 규정 오류
     @ExceptionHandler(value = [CserealException::class])
-    fun handle(e: CserealException): ResponseEntity<Any> {
-        val response = mapOf("code" to e.code, "message" to e.message)
-        return ResponseEntity(response, e.status)
+    fun handle(e: CserealException): ResponseEntity<ErrorResponse> =
+        ResponseEntity(ErrorResponse(e.code, e.message), e.status)
+
+    // @Valid 검증 실패 — 이전엔 맨 문자열을 반환해 envelope 밖이었다. 이제 동일 envelope로.
+    @ExceptionHandler(value = [MethodArgumentNotValidException::class])
+    fun handle(e: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> {
+        val fieldError = e.bindingResult.fieldError
+        val message = fieldError?.let { "${it.field}: ${it.defaultMessage}" }
+            ?: SystemErrorCode.VALIDATION_FAILED.msg
+        return ResponseEntity(
+            ErrorResponse.of(SystemErrorCode.VALIDATION_FAILED, message),
+            HttpStatus.BAD_REQUEST
+        )
     }
 
     // db에서 중복된 값 있을 때
     @ExceptionHandler(value = [SQLIntegrityConstraintViolationException::class])
-    fun handle(e: SQLIntegrityConstraintViolationException): ResponseEntity<Any> {
+    fun handle(e: SQLIntegrityConstraintViolationException): ResponseEntity<ErrorResponse> {
         log.error(e.stackTraceToString())
-        val eCode = SystemErrorCode.DATA_DUPLICATION
-        val response = mapOf("code" to eCode.code, "message" to eCode.msg)
-        return ResponseEntity(response, eCode.status)
+        return ResponseEntity(
+            ErrorResponse.of(SystemErrorCode.DATA_DUPLICATION),
+            SystemErrorCode.DATA_DUPLICATION.status
+        )
     }
 
     // oidc provider 서버에 문제가 있을때
     @ExceptionHandler(value = [RestClientException::class])
-    fun handle(e: RestClientException): ResponseEntity<Any> {
+    fun handle(e: RestClientException): ResponseEntity<ErrorResponse> {
         log.error(e.stackTraceToString())
-        return ResponseEntity("idsnucse error: ${e.message}", HttpStatus.BAD_GATEWAY)
+        return ResponseEntity(
+            ErrorResponse.of(SystemErrorCode.EXTERNAL_AUTH_ERROR, "idsnucse error: ${e.message}"),
+            SystemErrorCode.EXTERNAL_AUTH_ERROR.status
+        )
+    }
+
+    // @PreAuthorize 메서드 인가 거부는 컨트롤러 호출 중 발생해 advice가 잡는다(필터 핸들러 아님).
+    // AuthorizationDeniedException도 AccessDeniedException 하위라 함께 처리됨.
+    // 명시적으로 잡지 않으면 아래 generic Exception 핸들러가 500으로 삼켜버린다.
+    @ExceptionHandler(value = [AccessDeniedException::class])
+    fun handle(e: AccessDeniedException): ResponseEntity<ErrorResponse> =
+        ResponseEntity(
+            ErrorResponse.of(SystemErrorCode.ACCESS_DENIED),
+            SystemErrorCode.ACCESS_DENIED.status
+        )
+
+    // 미처리 예외 — 이전엔 Spring 기본(envelope 밖 + 스택 노출 위험). 이제 동일 envelope로.
+    @ExceptionHandler(value = [Exception::class])
+    fun handle(e: Exception): ResponseEntity<ErrorResponse> {
+        log.error(e.stackTraceToString())
+        return ResponseEntity(
+            ErrorResponse.of(SystemErrorCode.INTERNAL_ERROR),
+            SystemErrorCode.INTERNAL_ERROR.status
+        )
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/common/config/CserealExceptionHandler.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/config/CserealExceptionHandler.kt
@@ -13,11 +13,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.client.RestClientException
 import java.sql.SQLIntegrityConstraintViolationException
 
-/**
- * 모든 에러를 단일 envelope(ErrorResponse{code, message})로 내보낸다.
- * 401/403은 Spring Security 필터에서 발생하므로 SecurityConfig의 entryPoint/accessDeniedHandler가
- * 같은 envelope로 처리한다(여기선 못 잡음).
- */
+// 모든 에러를 단일 envelope(ErrorResponse{code, message})로 통일.
+// 401/403은 필터에서 발생해 여기선 못 잡고 SecurityConfig가 같은 형태로 처리.
 @RestControllerAdvice
 class CserealExceptionHandler {
     private val log = LoggerFactory.getLogger(this::class.java)
@@ -27,7 +24,7 @@ class CserealExceptionHandler {
     fun handle(e: CserealException): ResponseEntity<ErrorResponse> =
         ResponseEntity(ErrorResponse(e.code, e.message), e.status)
 
-    // @Valid 검증 실패 — 이전엔 맨 문자열을 반환해 envelope 밖이었다. 이제 동일 envelope로.
+    // @Valid 검증 실패 (이전엔 맨 문자열 반환 → envelope로 통일)
     @ExceptionHandler(value = [MethodArgumentNotValidException::class])
     fun handle(e: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> {
         val fieldError = e.bindingResult.fieldError
@@ -59,9 +56,8 @@ class CserealExceptionHandler {
         )
     }
 
-    // @PreAuthorize 메서드 인가 거부는 컨트롤러 호출 중 발생해 advice가 잡는다(필터 핸들러 아님).
-    // AuthorizationDeniedException도 AccessDeniedException 하위라 함께 처리됨.
-    // 명시적으로 잡지 않으면 아래 generic Exception 핸들러가 500으로 삼켜버린다.
+    // @PreAuthorize 인가 거부(AuthorizationDeniedException 포함)는 컨트롤러에서 발생해 advice가 잡는다.
+    // 안 잡으면 아래 generic Exception이 500으로 처리.
     @ExceptionHandler(value = [AccessDeniedException::class])
     fun handle(e: AccessDeniedException): ResponseEntity<ErrorResponse> =
         ResponseEntity(
@@ -69,7 +65,7 @@ class CserealExceptionHandler {
             SystemErrorCode.ACCESS_DENIED.status
         )
 
-    // 미처리 예외 — 이전엔 Spring 기본(envelope 밖 + 스택 노출 위험). 이제 동일 envelope로.
+    // 미처리 예외 (이전엔 Spring 기본 → envelope로 통일)
     @ExceptionHandler(value = [Exception::class])
     fun handle(e: Exception): ResponseEntity<ErrorResponse> {
         log.error(e.stackTraceToString())

--- a/src/main/kotlin/com/wafflestudio/csereal/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/config/SecurityConfig.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.csereal.common.config
 
+import com.wafflestudio.csereal.common.SystemErrorCode
 import com.wafflestudio.csereal.common.properties.EndpointProperties
 import com.wafflestudio.csereal.core.user.service.CustomOidcUserService
 import jakarta.servlet.http.HttpServletRequest
@@ -63,12 +64,29 @@ class SecurityConfig(
                     .requestMatchers("/api/v2/admin/**").hasRole("STAFF")
                     .anyRequest().permitAll()
             }
+            // 인증/인가 실패도 컨트롤러 에러와 같은 envelope({code,message})로 내보낸다.
+            // (필터 레벨에서 발생해 @RestControllerAdvice가 못 잡으므로 여기서 처리)
+            .exceptionHandling { ex ->
+                ex.authenticationEntryPoint { _, response, _ ->
+                    writeErrorEnvelope(response, SystemErrorCode.AUTHENTICATION_REQUIRED)
+                }
+                ex.accessDeniedHandler { _, response, _ ->
+                    writeErrorEnvelope(response, SystemErrorCode.ACCESS_DENIED)
+                }
+            }
             .headers { header ->
                 header.referrerPolicy {
                     it.policy(ReferrerPolicyHeaderWriter.ReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN)
                 }
             }
             .build()
+    }
+
+    private fun writeErrorEnvelope(response: HttpServletResponse, errorCode: SystemErrorCode) {
+        response.status = errorCode.status.value()
+        response.contentType = "application/json"
+        response.characterEncoding = "UTF-8"
+        response.writer.write("""{"code":"${errorCode.code}","message":"${errorCode.msg}"}""")
     }
 
     @Bean

--- a/src/main/kotlin/com/wafflestudio/csereal/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/config/SecurityConfig.kt
@@ -64,8 +64,7 @@ class SecurityConfig(
                     .requestMatchers("/api/v2/admin/**").hasRole("STAFF")
                     .anyRequest().permitAll()
             }
-            // 인증/인가 실패도 컨트롤러 에러와 같은 envelope({code,message})로 내보낸다.
-            // (필터 레벨에서 발생해 @RestControllerAdvice가 못 잡으므로 여기서 처리)
+            // 인증/인가 실패(필터 레벨이라 advice가 못 잡음)도 같은 envelope로 내보낸다.
             .exceptionHandling { ex ->
                 ex.authenticationEntryPoint { _, response, _ ->
                     writeErrorEnvelope(response, SystemErrorCode.AUTHENTICATION_REQUIRED)

--- a/src/main/kotlin/com/wafflestudio/csereal/common/dto/ErrorResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/dto/ErrorResponse.kt
@@ -3,13 +3,7 @@ package com.wafflestudio.csereal.common.dto
 import com.wafflestudio.csereal.common.ErrorCode
 import com.wafflestudio.csereal.common.SystemErrorCode
 
-/**
- * 모든 에러 경로가 공유하는 단일 envelope.
- *
- * 이전엔 경로마다 모양이 달랐다(@Valid→맨 문자열, 401/403→Spring 기본, CserealException→{code,message}).
- * 프론트가 `code`로 분기하고 `message`를 표시할 수 있도록 전 경로를 이 형태로 통일한다.
- * `code`는 안정 머신코드(없으면 null), `message`는 표시용.
- */
+// 모든 에러 경로가 공유하는 단일 envelope. code로 분기, message는 표시용(code는 없으면 null).
 data class ErrorResponse(
     val code: String?,
     val message: String?

--- a/src/main/kotlin/com/wafflestudio/csereal/common/dto/ErrorResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/dto/ErrorResponse.kt
@@ -1,0 +1,22 @@
+package com.wafflestudio.csereal.common.dto
+
+import com.wafflestudio.csereal.common.ErrorCode
+import com.wafflestudio.csereal.common.SystemErrorCode
+
+/**
+ * 모든 에러 경로가 공유하는 단일 envelope.
+ *
+ * 이전엔 경로마다 모양이 달랐다(@Valid→맨 문자열, 401/403→Spring 기본, CserealException→{code,message}).
+ * 프론트가 `code`로 분기하고 `message`를 표시할 수 있도록 전 경로를 이 형태로 통일한다.
+ * `code`는 안정 머신코드(없으면 null), `message`는 표시용.
+ */
+data class ErrorResponse(
+    val code: String?,
+    val message: String?
+) {
+    companion object {
+        fun of(errorCode: ErrorCode) = ErrorResponse(errorCode.code, errorCode.msg)
+        fun of(errorCode: SystemErrorCode, message: String? = null) =
+            ErrorResponse(errorCode.code, message ?: errorCode.msg)
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/api/v3/SearchV3Controller.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/api/v3/SearchV3Controller.kt
@@ -11,13 +11,8 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
-/**
- * v3 통합 검색 — 단일 엔드포인트로 전 섹션을 서버에서 집계한다.
- *
- * 이전엔 프론트가 도메인별 search/top·totalSearch 8개로 팬아웃해 직접 집계했다.
- * 이제 한 번 호출하면 끝. sections로 원하는 섹션만 받는다(태그 필터 대응).
- * sections: about | notice | news | seminar | member | research | admissions | academics
- */
+// v3 통합 검색: 단일 엔드포인트로 여러 섹션을 서버에서 집계(기존엔 도메인별로 여러 번 호출).
+// sections로 일부만 지정 가능, 비우면 전체. (about|notice|news|seminar|member|research|admissions|academics)
 @RequestMapping("/api/v3/search")
 @RestController
 class SearchV3Controller(

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/api/v3/SearchV3Controller.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/api/v3/SearchV3Controller.kt
@@ -1,0 +1,45 @@
+package com.wafflestudio.csereal.core.main.api.v3
+
+import com.wafflestudio.csereal.common.enums.LanguageType
+import com.wafflestudio.csereal.core.main.dto.SearchV3Response
+import com.wafflestudio.csereal.core.main.service.MainService
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Positive
+import org.hibernate.validator.constraints.Length
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * v3 통합 검색 — 단일 엔드포인트로 전 섹션을 서버에서 집계한다.
+ *
+ * 이전엔 프론트가 도메인별 search/top·totalSearch 8개로 팬아웃해 직접 집계했다.
+ * 이제 한 번 호출하면 끝. sections로 원하는 섹션만 받는다(태그 필터 대응).
+ * sections: about | notice | news | seminar | member | research | admissions | academics
+ */
+@RequestMapping("/api/v3/search")
+@RestController
+class SearchV3Controller(
+    private val mainService: MainService
+) {
+    @GetMapping
+    fun search(
+        @RequestParam(required = true)
+        @Length(min = 2)
+        @NotBlank
+        keyword: String,
+        @RequestParam(required = false) sections: Set<String>?,
+        @RequestParam(required = false, defaultValue = "3") @Positive number: Int,
+        @RequestParam(required = false, defaultValue = "10") @Positive memberNumber: Int,
+        @RequestParam(required = false, defaultValue = "200") @Positive stringLength: Int,
+        @RequestParam(required = false, defaultValue = "ko") language: String
+    ): SearchV3Response = mainService.searchV3(
+        keyword,
+        sections,
+        number,
+        memberNumber,
+        stringLength,
+        LanguageType.makeStringToLanguageType(language)
+    )
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/dto/SearchV3Response.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/dto/SearchV3Response.kt
@@ -1,0 +1,28 @@
+package com.wafflestudio.csereal.core.main.dto
+
+import com.wafflestudio.csereal.core.about.api.res.AboutSearchResBody
+import com.wafflestudio.csereal.core.academics.api.res.AcademicsSearchResBody
+import com.wafflestudio.csereal.core.admissions.api.res.AdmissionSearchResBody
+import com.wafflestudio.csereal.core.member.api.res.MemberSearchResBody
+import com.wafflestudio.csereal.core.news.dto.NewsTotalSearchDto
+import com.wafflestudio.csereal.core.notice.dto.NoticeTotalSearchResponse
+import com.wafflestudio.csereal.core.research.api.res.ResearchSearchResBody
+import com.wafflestudio.csereal.core.seminar.dto.SeminarSearchResponse
+
+/**
+ * v3 통합 검색 응답. TotalSearchResponse와 달리 모든 섹션이 nullable이다 —
+ * 클라이언트가 `sections`로 원하는 섹션만 요청하면 나머지는 null.
+ *
+ * 이전엔 프론트가 8개 도메인 엔드포인트로 팬아웃해 직접 집계했다. 이제 백엔드가
+ * 한 번에 집계해 돌려주므로 프론트는 1콜로 끝난다(섹션 트리/카운트도 이 응답에서 파생).
+ */
+data class SearchV3Response(
+    val about: AboutSearchResBody? = null,
+    val notice: NoticeTotalSearchResponse? = null,
+    val news: NewsTotalSearchDto? = null,
+    val seminar: SeminarSearchResponse? = null,
+    val member: MemberSearchResBody? = null,
+    val research: ResearchSearchResBody? = null,
+    val admissions: AdmissionSearchResBody? = null,
+    val academics: AcademicsSearchResBody? = null
+)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/dto/SearchV3Response.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/dto/SearchV3Response.kt
@@ -9,13 +9,7 @@ import com.wafflestudio.csereal.core.notice.dto.NoticeTotalSearchResponse
 import com.wafflestudio.csereal.core.research.api.res.ResearchSearchResBody
 import com.wafflestudio.csereal.core.seminar.dto.SeminarSearchResponse
 
-/**
- * v3 통합 검색 응답. TotalSearchResponse와 달리 모든 섹션이 nullable이다 —
- * 클라이언트가 `sections`로 원하는 섹션만 요청하면 나머지는 null.
- *
- * 이전엔 프론트가 8개 도메인 엔드포인트로 팬아웃해 직접 집계했다. 이제 백엔드가
- * 한 번에 집계해 돌려주므로 프론트는 1콜로 끝난다(섹션 트리/카운트도 이 응답에서 파생).
- */
+// v3 통합 검색 응답. sections로 일부만 요청하면 나머지는 null(TotalSearchResponse와 달리 전부 nullable).
 data class SearchV3Response(
     val about: AboutSearchResBody? = null,
     val notice: NoticeTotalSearchResponse? = null,

--- a/src/main/kotlin/com/wafflestudio/csereal/core/main/service/MainService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/main/service/MainService.kt
@@ -5,6 +5,7 @@ import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.about.service.AboutService
 import com.wafflestudio.csereal.core.academics.service.AcademicsSearchService
 import com.wafflestudio.csereal.core.admissions.service.AdmissionsService
+import com.wafflestudio.csereal.core.main.dto.SearchV3Response
 import com.wafflestudio.csereal.core.main.dto.TotalSearchResponse
 import com.wafflestudio.csereal.core.main.database.MainRepository
 import com.wafflestudio.csereal.core.main.dto.MainImportantResponse
@@ -36,6 +37,15 @@ interface MainService {
         stringLength: Int,
         language: LanguageType
     ): TotalSearchResponse
+
+    fun searchV3(
+        keyword: String,
+        sections: Set<String>?,
+        number: Int,
+        memberNumber: Int,
+        stringLength: Int,
+        language: LanguageType
+    ): SearchV3Response
 }
 
 @Service
@@ -147,6 +157,67 @@ class MainServiceImpl(
             researchResult = researchResult,
             admissionsResult = admissionsResult,
             academicsResult = academicsResult
+        )
+    }
+
+    @Transactional(readOnly = true)
+    override fun searchV3(
+        keyword: String,
+        sections: Set<String>?,
+        number: Int,
+        memberNumber: Int,
+        stringLength: Int,
+        language: LanguageType
+    ): SearchV3Response {
+        // sections 미지정이면 전체. 지정 시 해당 섹션만 집계해 나머지는 null로 둔다.
+        fun want(section: String) = sections.isNullOrEmpty() || section in sections
+
+        return SearchV3Response(
+            about = if (want("about")) {
+                aboutService.searchTopAbout(keyword, language, number, stringLength)
+            } else {
+                null
+            },
+            notice = if (want("notice")) {
+                noticeService.searchTotalNotice(keyword, number, stringLength)
+            } else {
+                null
+            },
+            news = if (want("news")) {
+                newsService.searchTotalNews(keyword, number, stringLength)
+            } else {
+                null
+            },
+            seminar = if (want("seminar")) {
+                seminarService.searchSeminar(
+                    keyword,
+                    PageRequest.of(0, 10),
+                    usePageBtn = true,
+                    ContentSearchSortType.DATE
+                )
+            } else {
+                null
+            },
+            member = if (want("member")) {
+                memberSearchService.searchTopMember(keyword, language, memberNumber)
+            } else {
+                null
+            },
+            research = if (want("research")) {
+                researchSearchService.searchTopResearch(keyword, language, number, stringLength)
+            } else {
+                null
+            },
+            admissions = if (want("admissions")) {
+                admissionsService.searchTopAdmission(keyword, language, number, stringLength)
+            } else {
+                null
+            },
+            academics = if (want("academics")) {
+                academicsSearchService.searchTopAcademics(keyword, language, number, stringLength)
+            } else {
+                null
+            }
         )
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/api/v3/ProfessorV3Controller.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/api/v3/ProfessorV3Controller.kt
@@ -1,0 +1,66 @@
+package com.wafflestudio.csereal.core.member.api.v3
+
+import com.wafflestudio.csereal.core.member.api.req.CreateProfessorLanguagesReqBody
+import com.wafflestudio.csereal.core.member.api.req.ModifyProfessorLanguagesReqBody
+import com.wafflestudio.csereal.core.member.dto.ProfessorLanguagesDto
+import com.wafflestudio.csereal.core.member.dto.ProfessorPageDto
+import com.wafflestudio.csereal.core.member.dto.SimpleProfessorDto
+import com.wafflestudio.csereal.core.member.service.ProfessorService
+import jakarta.validation.constraints.Positive
+import org.springframework.http.HttpStatus
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.*
+import org.springframework.web.multipart.MultipartFile
+
+/**
+ * v3 교수 API — 이중언어 콘텐츠를 단일 리소스로.
+ *
+ * v2 대비: 수정/삭제가 dual-id(`/{koProfessorId}/{enProfessorId}`)가 아니라 단일 id(쌍은
+ * member_language에서 서버가 해소). 그리고 **파일 파트명을 create/update 모두 `mainImage`로 통일**
+ * (v2는 create=`mainImage`, update=`newMainImage`로 갈라져 프론트가 분기해야 했다).
+ */
+@RequestMapping("/api/v3/professor")
+@RestController
+class ProfessorV3Controller(
+    private val professorService: ProfessorService
+) {
+    @GetMapping("/{professorId}")
+    fun getProfessor(
+        @PathVariable @Positive
+        professorId: Long
+    ): ProfessorLanguagesDto = professorService.getProfessorLanguages(professorId)
+
+    @GetMapping("/active")
+    fun getActiveProfessors(
+        @RequestParam(required = false, defaultValue = "ko") language: String
+    ): ProfessorPageDto = professorService.getActiveProfessors(language)
+
+    @GetMapping("/inactive")
+    fun getInactiveProfessors(
+        @RequestParam(required = false, defaultValue = "ko") language: String
+    ): List<SimpleProfessorDto> = professorService.getInactiveProfessors(language)
+
+    @PreAuthorize("hasRole('STAFF')")
+    @PostMapping(consumes = ["multipart/form-data"])
+    fun createProfessor(
+        @RequestPart("request") request: CreateProfessorLanguagesReqBody,
+        @RequestPart("mainImage") mainImage: MultipartFile?
+    ): ProfessorLanguagesDto = professorService.createProfessorLanguages(request, mainImage)
+
+    @PreAuthorize("hasRole('STAFF')")
+    @PutMapping("/{professorId}", consumes = ["multipart/form-data"])
+    fun updateProfessor(
+        @PathVariable @Positive
+        professorId: Long,
+        @RequestPart("request") request: ModifyProfessorLanguagesReqBody,
+        @RequestPart("mainImage") mainImage: MultipartFile?
+    ): ProfessorLanguagesDto = professorService.updateProfessorById(professorId, request, mainImage)
+
+    @PreAuthorize("hasRole('STAFF')")
+    @DeleteMapping("/{professorId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun deleteProfessor(
+        @PathVariable @Positive
+        professorId: Long
+    ) = professorService.deleteProfessorById(professorId)
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/api/v3/ProfessorV3Controller.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/api/v3/ProfessorV3Controller.kt
@@ -12,13 +12,8 @@ import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 
-/**
- * v3 교수 API — 이중언어 콘텐츠를 단일 리소스로.
- *
- * v2 대비: 수정/삭제가 dual-id(`/{koProfessorId}/{enProfessorId}`)가 아니라 단일 id(쌍은
- * member_language에서 서버가 해소). 그리고 **파일 파트명을 create/update 모두 `mainImage`로 통일**
- * (v2는 create=`mainImage`, update=`newMainImage`로 갈라져 프론트가 분기해야 했다).
- */
+// v3 교수 API: 단일 id로 한/영 쌍 수정·삭제 (v2는 dual-id).
+// 쌍은 member_language에서 해소, 파일 파트명 create/update 모두 mainImage 통일(v2는 mainImage/newMainImage).
 @RequestMapping("/api/v3/professor")
 @RestController
 class ProfessorV3Controller(

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/api/v3/StaffV3Controller.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/api/v3/StaffV3Controller.kt
@@ -11,10 +11,7 @@ import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 
-/**
- * v3 행정직원 API — 이중언어 단일 리소스. ProfessorV3Controller와 동일한 패턴
- * (단일-id 수정/삭제 + 파일 파트명 `mainImage` 통일 + DELETE 204).
- */
+// v3 행정직원 API: ProfessorV3Controller와 동일 패턴(단일 id 수정·삭제, mainImage 통일, DELETE 204).
 @RequestMapping("/api/v3/staff")
 @RestController
 class StaffV3Controller(

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/api/v3/StaffV3Controller.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/api/v3/StaffV3Controller.kt
@@ -1,0 +1,57 @@
+package com.wafflestudio.csereal.core.member.api.v3
+
+import com.wafflestudio.csereal.core.member.api.req.CreateStaffLanguagesReqBody
+import com.wafflestudio.csereal.core.member.api.req.ModifyStaffLanguagesReqBody
+import com.wafflestudio.csereal.core.member.dto.SimpleStaffDto
+import com.wafflestudio.csereal.core.member.dto.StaffLanguagesDto
+import com.wafflestudio.csereal.core.member.service.StaffService
+import jakarta.validation.constraints.Positive
+import org.springframework.http.HttpStatus
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.*
+import org.springframework.web.multipart.MultipartFile
+
+/**
+ * v3 행정직원 API — 이중언어 단일 리소스. ProfessorV3Controller와 동일한 패턴
+ * (단일-id 수정/삭제 + 파일 파트명 `mainImage` 통일 + DELETE 204).
+ */
+@RequestMapping("/api/v3/staff")
+@RestController
+class StaffV3Controller(
+    private val staffService: StaffService
+) {
+    @GetMapping("/{staffId}")
+    fun getStaff(
+        @PathVariable @Positive
+        staffId: Long
+    ): StaffLanguagesDto = staffService.getStaffLanguages(staffId)
+
+    @GetMapping
+    fun getAllStaff(
+        @RequestParam(required = false, defaultValue = "ko") language: String
+    ): List<SimpleStaffDto> = staffService.getAllStaff(language)
+
+    @PreAuthorize("hasRole('STAFF')")
+    @PostMapping(consumes = ["multipart/form-data"])
+    fun createStaff(
+        @RequestPart("request") request: CreateStaffLanguagesReqBody,
+        @RequestPart("mainImage") mainImage: MultipartFile?
+    ): StaffLanguagesDto = staffService.createStaffLanguages(request, mainImage)
+
+    @PreAuthorize("hasRole('STAFF')")
+    @PutMapping("/{staffId}", consumes = ["multipart/form-data"])
+    fun updateStaff(
+        @PathVariable @Positive
+        staffId: Long,
+        @RequestPart("request") request: ModifyStaffLanguagesReqBody,
+        @RequestPart("mainImage") mainImage: MultipartFile?
+    ): StaffLanguagesDto = staffService.updateStaffById(staffId, request, mainImage)
+
+    @PreAuthorize("hasRole('STAFF')")
+    @DeleteMapping("/{staffId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun deleteStaff(
+        @PathVariable @Positive
+        staffId: Long
+    ) = staffService.deleteStaffById(staffId)
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/service/ProfessorService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/service/ProfessorService.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.csereal.core.member.service
 
 import com.wafflestudio.csereal.common.CserealException
+import com.wafflestudio.csereal.common.ErrorCode
 import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.common.utils.startsWithEnglish
 import com.wafflestudio.csereal.core.member.api.req.CreateProfessorLanguagesReqBody
@@ -57,6 +58,15 @@ interface ProfessorService {
 
     fun deleteProfessor(professorId: Long)
     fun deleteProfessorLanguages(koProfessorId: Long, enProfessorId: Long)
+
+    // v3 단일-id: 하나의 id로 한/영 쌍을 해소(member_language)해 양쪽 수정/삭제
+    fun updateProfessorById(
+        id: Long,
+        req: ModifyProfessorLanguagesReqBody,
+        mainImage: MultipartFile?
+    ): ProfessorLanguagesDto
+
+    fun deleteProfessorById(id: Long)
 }
 
 @Service
@@ -340,5 +350,30 @@ class ProfessorServiceImpl(
         memberLanguageRepository.findByKoreanIdAndEnglishIdAndType(koProfessorId, enProfessorId, MemberType.PROFESSOR)
             ?.let { memberLanguageRepository.delete(it) }
             ?: throw CserealException.Csereal404("해당 교수 쌍을 찾을 수 없습니다. <$koProfessorId, $enProfessorId>")
+    }
+
+    override fun updateProfessorById(
+        id: Long,
+        req: ModifyProfessorLanguagesReqBody,
+        mainImage: MultipartFile?
+    ): ProfessorLanguagesDto {
+        val (koId, enId) = resolveProfessorPair(id)
+        return updateProfessorLanguages(koId, enId, req, mainImage)
+    }
+
+    override fun deleteProfessorById(id: Long) {
+        val (koId, enId) = resolveProfessorPair(id)
+        deleteProfessorLanguages(koId, enId)
+    }
+
+    // 단일 id(한 또는 영) → (koId, enId). findProfessorAllLanguages가 같은 멤버의 양 언어 행을 준다.
+    private fun resolveProfessorPair(id: Long): Pair<Long, Long> {
+        val byLang = professorRepository.findProfessorAllLanguages(id)
+        val koId = byLang[LanguageType.KO]?.firstOrNull()?.id
+        val enId = byLang[LanguageType.EN]?.firstOrNull()?.id
+        if (koId == null || enId == null) {
+            throw CserealException(ErrorCode.PROFESSOR_NOT_FOUND, customMsg = "해당 교수님을 찾을 수 없습니다. professorId: $id")
+        }
+        return koId to enId
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/member/service/StaffService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/member/service/StaffService.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.csereal.core.member.service
 
 import com.wafflestudio.csereal.common.CserealException
+import com.wafflestudio.csereal.common.ErrorCode
 import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.member.api.req.CreateStaffLanguagesReqBody
 import com.wafflestudio.csereal.core.member.api.req.CreateStaffReqBody
@@ -45,6 +46,10 @@ interface StaffService {
 
     fun deleteStaffLanguages(koStaffId: Long, enStaffId: Long)
     fun deleteStaff(staffId: Long)
+
+    // v3 단일-id: 하나의 id로 한/영 쌍을 해소(member_language)해 양쪽 수정/삭제
+    fun updateStaffById(id: Long, req: ModifyStaffLanguagesReqBody, mainImage: MultipartFile?): StaffLanguagesDto
+    fun deleteStaffById(id: Long)
 }
 
 @Service
@@ -221,5 +226,29 @@ class StaffServiceImpl(
             }
             staffRepository.delete(staff)
         } ?: throw CserealException.Csereal404("해당 행정직원을 찾을 수 없습니다. staffId: $staffId")
+    }
+
+    override fun updateStaffById(
+        id: Long,
+        req: ModifyStaffLanguagesReqBody,
+        mainImage: MultipartFile?
+    ): StaffLanguagesDto {
+        val (koId, enId) = resolveStaffPair(id)
+        return updateStaffLanguages(koId, enId, req, mainImage)
+    }
+
+    override fun deleteStaffById(id: Long) {
+        val (koId, enId) = resolveStaffPair(id)
+        deleteStaffLanguages(koId, enId)
+    }
+
+    private fun resolveStaffPair(id: Long): Pair<Long, Long> {
+        val byLang = staffRepository.findStaffAllLanguages(id)
+        val koId = byLang[LanguageType.KO]?.firstOrNull()?.id
+        val enId = byLang[LanguageType.EN]?.firstOrNull()?.id
+        if (koId == null || enId == null) {
+            throw CserealException(ErrorCode.STAFF_NOT_FOUND, customMsg = "해당 직원을 찾을 수 없습니다. staffId: $id")
+        }
+        return koId to enId
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/api/v3/ResearchV3Controller.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/api/v3/ResearchV3Controller.kt
@@ -1,0 +1,104 @@
+package com.wafflestudio.csereal.core.research.api.v3
+
+import com.wafflestudio.csereal.core.research.api.req.CreateLabLanguageReqBody
+import com.wafflestudio.csereal.core.research.api.req.CreateResearchLanguageReqBody
+import com.wafflestudio.csereal.core.research.api.req.ModifyLabLanguageReqBody
+import com.wafflestudio.csereal.core.research.api.req.ModifyResearchLanguageReqBody
+import com.wafflestudio.csereal.core.research.dto.LabDto
+import com.wafflestudio.csereal.core.research.dto.LabLanguageDto
+import com.wafflestudio.csereal.core.research.dto.ResearchLanguageDto
+import com.wafflestudio.csereal.core.research.service.LabService
+import com.wafflestudio.csereal.core.research.service.ResearchService
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Positive
+import org.springframework.http.HttpStatus
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.*
+import org.springframework.web.multipart.MultipartFile
+
+/**
+ * v3 연구(연구실·연구그룹·연구센터) API — 이중언어 콘텐츠를 "단일 리소스"로 다룬다.
+ *
+ * v2와의 차이: 수정/삭제가 dual-id(`/{koreanId}/{englishId}`)가 아니라 단일 id다.
+ * 한/영 쌍은 서버가 research_language에서 해소하므로, 클라이언트는 목록에서 얻은 아무 언어의
+ * id 하나만 있으면 된다(삭제 전 상세조회로 두 id를 캐낼 필요가 없다 — v2 centers/groups의
+ * 안티패턴 제거). 파일 파트명도 create·update 모두 `mainImage`로 통일.
+ * 읽기/생성은 v2도 이미 단일 id·`{ko, en}` 본문이라 그대로 옮겨온다.
+ */
+@RequestMapping("/api/v3/research")
+@RestController
+class ResearchV3Controller(
+    private val labService: LabService,
+    private val researchService: ResearchService
+) {
+    // ── 연구그룹·연구센터 (research) ──
+    @GetMapping("/{researchId:[0-9]+}")
+    fun readResearch(
+        @PathVariable @Positive
+        researchId: Long
+    ): ResearchLanguageDto = researchService.readResearchLanguage(researchId)
+
+    @PreAuthorize("hasRole('STAFF')")
+    @PostMapping(consumes = ["multipart/form-data"])
+    fun createResearch(
+        @RequestPart("request") request: CreateResearchLanguageReqBody,
+        @RequestPart("mainImage") mainImage: MultipartFile?
+    ): ResearchLanguageDto = researchService.createResearchLanguage(request, mainImage)
+
+    @PreAuthorize("hasRole('STAFF')")
+    @PutMapping("/{researchId:[0-9]+}", consumes = ["multipart/form-data"])
+    fun updateResearch(
+        @PathVariable @Positive
+        researchId: Long,
+        @RequestPart("request") request: ModifyResearchLanguageReqBody,
+        @RequestPart("mainImage") mainImage: MultipartFile?
+    ): ResearchLanguageDto = researchService.updateResearchLanguageById(researchId, request, mainImage)
+
+    @PreAuthorize("hasRole('STAFF')")
+    @DeleteMapping("/{researchId:[0-9]+}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun deleteResearch(
+        @PathVariable @Positive
+        researchId: Long
+    ) = researchService.deleteResearchLanguageById(researchId)
+
+    // ── 연구실 (lab) ──
+    @GetMapping("/lab")
+    fun readAllLabs(
+        @RequestParam(required = false, defaultValue = "ko") language: String
+    ): List<LabDto> = labService.readAllLabs(language)
+
+    @GetMapping("/lab/{labId}")
+    fun readLab(
+        @PathVariable @Positive
+        labId: Long
+    ): LabLanguageDto = labService.readLabLanguage(labId)
+
+    @PreAuthorize("hasRole('STAFF')")
+    @PostMapping("/lab", consumes = ["multipart/form-data"])
+    fun createLab(
+        @Valid
+        @RequestPart("request")
+        request: CreateLabLanguageReqBody,
+        @RequestPart("pdf") pdf: MultipartFile?
+    ): LabLanguageDto = labService.createLabLanguage(request, pdf)
+
+    @PreAuthorize("hasRole('STAFF')")
+    @PutMapping("/lab/{labId}", consumes = ["multipart/form-data"])
+    fun updateLab(
+        @PathVariable @Positive
+        labId: Long,
+        @Valid
+        @RequestPart("request")
+        request: ModifyLabLanguageReqBody,
+        @RequestPart("pdf") pdf: MultipartFile?
+    ): LabLanguageDto = labService.updateLabById(labId, request, pdf)
+
+    @PreAuthorize("hasRole('STAFF')")
+    @DeleteMapping("/lab/{labId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun deleteLab(
+        @PathVariable @Positive
+        labId: Long
+    ) = labService.deleteLabById(labId)
+}

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/api/v3/ResearchV3Controller.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/api/v3/ResearchV3Controller.kt
@@ -16,15 +16,8 @@ import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 
-/**
- * v3 연구(연구실·연구그룹·연구센터) API — 이중언어 콘텐츠를 "단일 리소스"로 다룬다.
- *
- * v2와의 차이: 수정/삭제가 dual-id(`/{koreanId}/{englishId}`)가 아니라 단일 id다.
- * 한/영 쌍은 서버가 research_language에서 해소하므로, 클라이언트는 목록에서 얻은 아무 언어의
- * id 하나만 있으면 된다(삭제 전 상세조회로 두 id를 캐낼 필요가 없다 — v2 centers/groups의
- * 안티패턴 제거). 파일 파트명도 create·update 모두 `mainImage`로 통일.
- * 읽기/생성은 v2도 이미 단일 id·`{ko, en}` 본문이라 그대로 옮겨온다.
- */
+// v3 연구(연구실·연구그룹·연구센터) API: 단일 id로 한/영 쌍 수정·삭제 (v2는 dual-id라 삭제 전 상세조회 필요).
+// 쌍은 research_language에서 해소, 파일 파트명 mainImage 통일. 읽기/생성은 v2와 동일하고 경로만 옮김.
 @RequestMapping("/api/v3/research")
 @RestController
 class ResearchV3Controller(

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/service/LabService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/service/LabService.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.csereal.core.research.service
 
 import com.wafflestudio.csereal.common.CserealException
+import com.wafflestudio.csereal.common.ErrorCode
 import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.common.properties.EndpointProperties
 import com.wafflestudio.csereal.common.utils.startsWithEnglish
@@ -42,8 +43,13 @@ interface LabService {
 
     fun updateLab(language: LanguageType, labId: Long, request: ModifyLabReqBody, pdf: MultipartFile?): LabDto
 
+    // v3 단일-id API: 클라이언트가 (koreanId, englishId) 쌍을 알 필요 없이 하나의 id로
+    // 한/영 양쪽을 수정/삭제한다. 쌍은 research_language(type=LAB)에서 서버가 해소한다.
+    fun updateLabById(id: Long, request: ModifyLabLanguageReqBody, pdf: MultipartFile?): LabLanguageDto
+
     fun deleteLabLanguage(koreanId: Long, englishId: Long)
     fun deleteLab(id: Long)
+    fun deleteLabById(id: Long)
 }
 
 @Service
@@ -142,7 +148,7 @@ class LabServiceImpl(
                     throw CserealException.Csereal404("해당 교수님들을 찾을 수 없습니다.(professorIds = ${request.professorIds})")
                 }
                 if (it.any { p -> p.lab != null }) {
-                    throw CserealException.Csereal400("이미 다른 연구실에 속한 교수님이 존재합니다.")
+                    throw CserealException(ErrorCode.LAB_PROFESSOR_OCCUPIED)
                 }
             }
 
@@ -192,6 +198,22 @@ class LabServiceImpl(
     }
 
     @Transactional
+    override fun updateLabById(
+        id: Long,
+        request: ModifyLabLanguageReqBody,
+        pdf: MultipartFile?
+    ): LabLanguageDto {
+        val pair = researchLanguageRepository.findLabPairById(id)
+            ?: throw CserealException(ErrorCode.LAB_NOT_FOUND, customMsg = "해당 연구실을 찾을 수 없습니다.(labId=$id)")
+        return updateLabLanguage(
+            pair[LanguageType.KO]!!.id,
+            pair[LanguageType.EN]!!.id,
+            request,
+            pdf
+        )
+    }
+
+    @Transactional
     override fun updateLab(
         language: LanguageType,
         labId: Long,
@@ -215,7 +237,7 @@ class LabServiceImpl(
                 }
 
                 if (!(it.all { p -> p.lab == null || p.lab!!.id == labId })) {
-                    throw CserealException.Csereal400("이미 다른 연구실에 속한 교수님이 존재합니다.")
+                    throw CserealException(ErrorCode.LAB_PROFESSOR_OCCUPIED)
                 }
             }
 
@@ -266,6 +288,13 @@ class LabServiceImpl(
         deleteLab(koreanId)
         deleteLab(englishId)
         researchLanguageRepository.delete(labLanguage)
+    }
+
+    @Transactional
+    override fun deleteLabById(id: Long) {
+        val pair = researchLanguageRepository.findLabPairById(id)
+            ?: throw CserealException(ErrorCode.LAB_NOT_FOUND, customMsg = "해당 연구실을 찾을 수 없습니다.(labId=$id)")
+        deleteLabLanguage(pair[LanguageType.KO]!!.id, pair[LanguageType.EN]!!.id)
     }
 
     @Transactional

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/service/LabService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/service/LabService.kt
@@ -43,8 +43,7 @@ interface LabService {
 
     fun updateLab(language: LanguageType, labId: Long, request: ModifyLabReqBody, pdf: MultipartFile?): LabDto
 
-    // v3 단일-id API: 클라이언트가 (koreanId, englishId) 쌍을 알 필요 없이 하나의 id로
-    // 한/영 양쪽을 수정/삭제한다. 쌍은 research_language(type=LAB)에서 서버가 해소한다.
+    // v3 단일-id: 하나의 id로 한/영 쌍을 해소(research_language, type=LAB)해 양쪽 수정/삭제
     fun updateLabById(id: Long, request: ModifyLabLanguageReqBody, pdf: MultipartFile?): LabLanguageDto
 
     fun deleteLabLanguage(koreanId: Long, englishId: Long)

--- a/src/main/kotlin/com/wafflestudio/csereal/core/research/service/ResearchService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/research/service/ResearchService.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.csereal.core.research.service
 
 import com.wafflestudio.csereal.common.CserealException
+import com.wafflestudio.csereal.common.ErrorCode
 import com.wafflestudio.csereal.common.enums.LanguageType
 import com.wafflestudio.csereal.core.research.api.req.*
 import com.wafflestudio.csereal.core.research.database.*
@@ -36,6 +37,15 @@ interface ResearchService {
 
     fun deleteResearchLanguage(koreanId: Long, englishId: Long)
     fun deleteResearch(researchId: Long)
+
+    // v3 단일-id: 하나의 id로 한/영 쌍을 해소(research_language)해 양쪽 수정/삭제
+    fun updateResearchLanguageById(
+        id: Long,
+        req: ModifyResearchLanguageReqBody,
+        updateImage: MultipartFile?
+    ): ResearchLanguageDto
+
+    fun deleteResearchLanguageById(id: Long)
 
     fun readResearchLanguage(id: Long): ResearchLanguageDto
     fun readAllResearch(language: LanguageType, type: ResearchType): List<ResearchSealedDto>
@@ -199,6 +209,28 @@ class ResearchServiceImpl(
         deleteResearch(koreanId)
         deleteResearch(englishId)
         researchLanguageRepository.delete(researchLanguage)
+    }
+
+    @Transactional
+    override fun updateResearchLanguageById(
+        id: Long,
+        req: ModifyResearchLanguageReqBody,
+        updateImage: MultipartFile?
+    ): ResearchLanguageDto {
+        val (koId, enId) = resolveResearchPair(id)
+        return updateResearchLanguage(koId, enId, req, updateImage)
+    }
+
+    @Transactional
+    override fun deleteResearchLanguageById(id: Long) {
+        val (koId, enId) = resolveResearchPair(id)
+        deleteResearchLanguage(koId, enId)
+    }
+
+    private fun resolveResearchPair(id: Long): Pair<Long, Long> {
+        val pair = researchLanguageRepository.findResearchPairById(id)
+            ?: throw CserealException(ErrorCode.RESEARCH_GROUP_NOT_FOUND, customMsg = "해당 Research를 찾을 수 없습니다.(id=$id)")
+        return pair[LanguageType.KO]!!.id to pair[LanguageType.EN]!!.id
     }
 
     @Transactional


### PR DESCRIPTION
프론트 입장에서 api 이상한 부분 개선하는 PR입니다. 

솔직히 말해서 코드는 클로드가 다 짜줬고요,

저는 책임없는 쾌락만 즐기고 리뷰는 여러분들께 맡깁니다.

---

## v3 API: 이중언어 단일 id, 파일 파트명·에러 응답·통합 검색 정리

### 한줄 요약

한국어/영어가 별도 레코드로 나뉜 콘텐츠(연구·교수·직원)의 수정·삭제를 id 하나로 할 수 있게 하고, 파일 파트명·에러 응답·통합 검색을 v3로 정리했습니다. DB 변경은 없고 v2 엔드포인트는 그대로 둡니다.

### 상세 설명

연구(연구실·연구그룹·연구센터), 교수, 직원은 한국어와 영어가 각각 별도 레코드(별도 PK)로 저장됩니다. 그래서 기존 v2에서는 수정·삭제할 때 한국어 id와 영어 id 두 개를 모두 경로에 넣어야 했습니다. 프론트는 목록에서 받은 id 하나만으로는 삭제할 수 없어서, 상세를 한 번 더 조회해 두 id를 알아낸 뒤에야 삭제할 수 있었습니다.

v3에서는 id 하나만 받고, 서버가 `*_language` 테이블에서 나머지 언어 짝을 찾아 양쪽을 함께 처리합니다. 읽기·생성은 v2도 이미 id 하나에 `{ko, en}` 본문을 쓰고 있어서 경로만 v3로 옮겼습니다.

함께 정리한 것:

- **파일 파트명**: 생성은 `mainImage`, 수정은 `newMainImage`로 갈라져 있던 것을 v3에서는 양쪽 모두 `mainImage`로 통일했습니다. 연구 쪽은 생성 시 프론트가 `newMainImage`로 보내고 있어 이미지가 저장되지 않던 불일치도 함께 해소됩니다.
- **에러 응답**: 모든 에러를 `{code, message}` 형태로 통일했습니다. 기존에는 `@Valid` 검증 실패는 평문 문자열로, 인증·인가 실패(401/403)는 핸들러가 없어 Spring 기본 응답으로 나갔습니다. 코드 값도 추가했습니다(`SYS-*`, `RESEARCH-*`, `MEMBER-*`).
- **통합 검색**: 도메인별로 흩어져 있던 검색을 한 번에 호출하는 엔드포인트를 추가했습니다.

### api 정리

**수정·삭제** (기존 `{koId}/{enId}` → 단일 `{id}`)

```
PUT    /api/v3/research/{id}           연구그룹·연구센터 수정
DELETE /api/v3/research/{id}           연구그룹·연구센터 삭제 (204)
PUT    /api/v3/research/lab/{id}       연구실 수정
DELETE /api/v3/research/lab/{id}       연구실 삭제 (204)
PUT    /api/v3/professor/{id}          교수 수정
DELETE /api/v3/professor/{id}          교수 삭제 (204)
PUT    /api/v3/staff/{id}              직원 수정
DELETE /api/v3/staff/{id}              직원 삭제 (204)
```

**읽기·생성** (v2와 본문·응답 동일, 경로만 v3)

```
GET  /api/v3/research/{id}, /research/lab/{id}, /professor/{id}, /staff/{id}   한/영 둘 다 반환
POST /api/v3/research, /research/lab, /professor, /staff                       생성
```

**통합 검색**

```
GET /api/v3/search?keyword=&sections=&language=
```
- 한 번 호출로 모든 영역(about, notice, news, seminar, member, research, admissions, academics)을 검색합니다.
- `sections`를 비우면 전체, 지정하면 해당 영역만 채우고 나머지는 null입니다.
- 영역별 응답 형태는 기존 도메인별 검색 API와 동일합니다.

**파일 업로드 파트명**: 생성·수정 모두 `mainImage` (연구실은 `pdf`)
