### PR TITLE
fix(reservation): align policy columns with enum schema

### DIFF
--- a/src/main/resources/db/migration/V17__change_reservation_policy_columns_to_enum.sql
+++ b/src/main/resources/db/migration/V17__change_reservation_policy_columns_to_enum.sql
@@ -1,0 +1,23 @@
+ALTER TABLE reservation
+    DROP COLUMN reservation_type,
+    ADD COLUMN reservation_type ENUM(
+        'ONE_TIME',
+        'REGULAR',
+        'UNRESTRICTED'
+    ) NULL;
+
+ALTER TABLE reserve_term
+    DROP CHECK chk_reserve_term_metadata_pair,
+    DROP INDEX uk_reserve_term_year_type,
+    DROP COLUMN term_type,
+    ADD COLUMN term_type ENUM(
+        'WINTER',
+        'FIRST_SEMESTER',
+        'SUMMER',
+        'SECOND_SEMESTER'
+    ) NULL,
+    ADD CONSTRAINT chk_reserve_term_metadata_pair CHECK (
+        (term_year IS NULL AND term_type IS NULL)
+        OR (term_year IS NOT NULL AND term_type IS NOT NULL)
+    ),
+    ADD UNIQUE INDEX uk_reserve_term_year_type (term_year, term_type);

--- a/src/test/kotlin/com/wafflestudio/csereal/core/reservation/database/ReservationPolicyMigrationTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/reservation/database/ReservationPolicyMigrationTest.kt
@@ -100,6 +100,40 @@ class ReservationPolicyMigrationTest : FunSpec({
             connection.createStatement().use { statement ->
                 statement.executeQuery(
                     """
+                    SELECT data_type, column_type, is_nullable
+                    FROM information_schema.columns
+                    WHERE table_schema = DATABASE()
+                      AND table_name = 'reservation'
+                      AND column_name = 'reservation_type'
+                    """.trimIndent()
+                ).use { resultSet ->
+                    resultSet.next() shouldBe true
+                    resultSet.getString("data_type") shouldBe "enum"
+                    resultSet.getString("column_type") shouldBe
+                        "enum('ONE_TIME','REGULAR','UNRESTRICTED')"
+                    resultSet.getString("is_nullable") shouldBe "YES"
+                }
+
+                statement.executeQuery(
+                    """
+                    SELECT data_type, column_type, is_nullable
+                    FROM information_schema.columns
+                    WHERE table_schema = DATABASE()
+                      AND table_name = 'reserve_term'
+                      AND column_name = 'term_type'
+                    """.trimIndent()
+                ).use { resultSet ->
+                    resultSet.next() shouldBe true
+                    resultSet.getString("data_type") shouldBe "enum"
+                    resultSet.getString("column_type") shouldBe
+                        "enum('WINTER','FIRST_SEMESTER','SUMMER','SECOND_SEMESTER')"
+                    resultSet.getString("is_nullable") shouldBe "YES"
+                }
+            }
+
+            connection.createStatement().use { statement ->
+                statement.executeQuery(
+                    """
                     SELECT COUNT(*) AS unclassified_count
                     FROM reserve_term
                     WHERE term_year IS NULL AND term_type IS NULL


### PR DESCRIPTION
## Summary
- Recreate reservation policy columns as nullable MySQL ENUM columns.
- Preserve the reserve term metadata CHECK constraint and unique index.
- Add migration metadata assertions for enum types and nullability.

## Verification
- ./gradlew ktlintCheck
- Targeted migration test could not run because the local Docker daemon was unavailable.

## Notes
- Existing V16 migration is preserved; V17 is a forward migration.
- Existing untracked workspace files are not included.