### PR TITLE
fix(reservation): use UTC reserve term times

### DIFF
--- a/docs/reservation-client-handoff.md
+++ b/docs/reservation-client-handoff.md
@@ -46,6 +46,8 @@ interface Reservation {
 
 `GET /api/v2/reservation/terms`는 다음 조건을 만족하고 다른 유효한 term 구간과 겹치지 않는 행만 반환합니다.
 
+네 시각은 실제 UTC components로 응답됩니다. 기본 일정의 09:00 `Asia/Seoul`은 `00:00Z`, KST 자정 경계는 전날 `15:00Z`이므로 `/terms` 값은 표준 UTC instant로 파싱한 뒤 사용자 timezone으로 표시합니다.
+
 ```text
 applyStartTime < applyEndTime <= termEndTime
 termStartTime < termEndTime
@@ -73,7 +75,7 @@ termStartTime < termEndTime
 
 Phase는 신청 기간을 먼저 확인합니다. Term이 활성 상태여도 `applyStartTime <= now < applyEndTime`이면 `REGULAR_APPLICATION`입니다. Term 안에서 신청 기간이 열리기 전과 닫힌 뒤에는 `TERM_ACTIVE`입니다.
 
-Non-staff 예약은 각 회차가 같은 KST 날짜 안에 끝나야 하며 3시간을 넘을 수 없습니다. Room ID 8은 `ROLE_PROFESSOR`가 추가로 필요하지만, professor 역할만으로 예약 생성 권한이 생기지는 않습니다.
+Non-staff 예약은 각 회차가 UTC 구성요소 기준으로 같은 날짜 안에 끝나야 하며 3시간을 넘을 수 없습니다. Room ID 8은 `ROLE_PROFESSOR`가 추가로 필요하지만, professor 역할만으로 예약 생성 권한이 생기지는 않습니다.
 
 `ONE_TIME` 예약은 요청 날짜 2주 전 09:00 `Asia/Seoul`에 열립니다. 그날이 토요일이나 일요일이면 다음 월요일 09:00로 미룹니다. 유효한 활성 term에서는 `termStartTime`보다 먼저 열리지 않으며, 공휴일은 따로 보정하지 않습니다.
 
@@ -91,28 +93,29 @@ Non-staff 예약은 각 회차가 같은 KST 날짜 안에 끝나야 하며 3시
 
 기존 room, permission, duration, overlap, past-time 오류 코드는 유지됩니다. 오류를 처리할 때는 HTTP status보다 code를 우선하세요. 알 수 없는 code만 서버 메시지나 기본 오류 처리로 넘깁니다.
 
-## 5. 날짜·시각 구성요소 유지
+## 5. 날짜·시각 해석
 
-요청 시각은 offset이 없는 KST wall-clock 구성요소로 보냅니다.
+예약 요청과 응답 시각은 UTC instant입니다. 요청에는 `Z`를 붙인 ISO 8601 형식을 권장합니다. 기존 클라이언트와의 호환을 위해 offset 없는 `LocalDateTime` 형식도 허용되지만, 이 경우에도 숫자 구성요소를 UTC로 해석합니다.
 
 ```json
 {
-  "startTime": "2027-03-20T10:00:00",
-  "endTime": "2027-03-20T11:00:00"
+  "startTime": "2027-03-20T01:00:00Z",
+  "endTime": "2027-03-20T02:00:00Z"
 }
 ```
 
-`Date.toISOString()`으로 `2027-03-20T01:00:00Z`를 보내면 숫자 구성요소가 달라지므로 이 계약과 맞지 않습니다.
+위 시각은 `2027-03-20 10:00`부터 `11:00 Asia/Seoul`까지의 예약입니다. 브라우저에서는 응답을 표준 instant로 파싱한 뒤 사용자 timezone으로 표시합니다.
 
-응답에는 기존 공통 serializer의 동작에 따라 날짜·시각 구성요소를 유지한 채 끝에 `Z`가 붙습니다. 실제 UTC instant를 뜻하지 않습니다.
+예약 응답의 `startTime`, `endTime` 끝에 붙는 `Z`도 실제 UTC를 뜻합니다.
 
 ```text
-server:  2027-03-20T10:00:00Z
+server:  2027-03-20T01:00:00Z
 screen:  2027-03-20 10:00 KST
-wrong:   2027-03-20 19:00 KST
 ```
 
-예약 전용 parser는 끝의 `Z`를 제거한 뒤 `Asia/Seoul` wall-clock으로 해석해야 합니다. 소수점 이하 초의 유무는 모두 허용합니다. 공통 instant parser의 의미는 바꾸지 마세요. 이 방식을 이 문서에서는 component-preserving 처리라고 부릅니다.
+`Z`를 제거하거나 `Asia/Seoul` wall-clock으로 다시 해석하는 예약 전용 parser를 사용하지 않습니다. 소수점 이하 초의 유무와 관계없이 표준 instant parser를 사용합니다.
+
+`GET /api/v2/reservation/terms`의 네 시각도 실제 UTC입니다. 다만 기본 reserve term 일정은 `Asia/Seoul` 달력과 시각으로 정의한 뒤 UTC로 변환합니다. 예를 들어 `applyStartTime: "2027-02-01T00:00:00Z"`는 `2027-02-01 09:00 Asia/Seoul`입니다.
 
 ## 6. 완료 조건
 
@@ -122,6 +125,6 @@ wrong:   2027-03-20 19:00 KST
 - `REGULAR_APPLICATION` 구간은 `applyStartTime <= now < applyEndTime`입니다.
 - 유효한 GAP과 `Missing` 대체 규칙을 다르게 안내합니다.
 - Non-staff `ONE_TIME` 요청은 `recurringWeeks = 1`이고, 각 회차가 같은 날 3시간 안에 끝납니다.
-- 응답 `10:00:00Z`를 화면에 10:00 KST로 표시합니다.
+- 예약과 `/terms` 응답을 실제 UTC instant로 파싱해 사용자 timezone으로 표시합니다.
 
 클라이언트 소스 변경은 이 서버 작업 범위에 포함되지 않습니다.

--- a/docs/reservation-logic-overview.md
+++ b/docs/reservation-logic-overview.md
@@ -1,6 +1,6 @@
 # 예약 로직 개요
 
-서버는 예약을 생성할 때 역할, 방, DB에 저장된 예약 학기와 현재 KST를 조합해 `UNRESTRICTED`, `REGULAR`, `ONE_TIME` 중 하나를 결정합니다. 클라이언트는 예약 유형을 보내지 않습니다. API 계약은 [클라이언트 안내](reservation-client-handoff.md), 운영 복구 절차는 [ReserveTerm 복구 런북](reserve-term-recovery-runbook.md)을 참고하세요.
+서버는 예약을 생성할 때 역할, 방, DB에 저장된 예약 학기와 현재 UTC-component 시각을 조합해 `UNRESTRICTED`, `REGULAR`, `ONE_TIME` 중 하나를 결정합니다. 클라이언트는 예약 유형을 보내지 않습니다. API 계약은 [클라이언트 안내](reservation-client-handoff.md), 운영 복구 절차는 [ReserveTerm 복구 런북](reserve-term-recovery-runbook.md)을 참고하세요.
 
 ## 1. 구성 요소
 
@@ -16,8 +16,8 @@ flowchart LR
     Creation --> TermRepository
 ```
 
-- `ReserveTermPolicy`는 KST 기준 시각, 저장된 시각의 조건, phase, `ONE_TIME` 오픈 시각과 반복 범위를 계산합니다.
-- `ReserveTermDefaultPolicy`는 scheduler에서만 쓰는 current/next key와 기본 네 시각을 계산합니다. 예약 요청을 판정할 때는 사용하지 않습니다.
+- `ReserveTermPolicy`는 UTC-component 현재 시각, 저장된 시각의 조건, phase, `ONE_TIME` 오픈 시각과 반복 범위를 계산합니다. 달력 규칙이 필요한 경우에만 `Asia/Seoul` 날짜로 변환합니다.
+- `ReserveTermDefaultPolicy`는 scheduler에서만 쓰는 current/next key와 기본 네 시각을 `Asia/Seoul` 일정 규칙으로 계산한 뒤 UTC components로 변환합니다. 예약 요청을 판정할 때는 사용하지 않습니다.
 - `ReserveTermValidationService`는 요청 시작 시각을 포함하는 행을 `Missing`, `Valid`, `Invalid`, `Multiple`로 나눕니다.
 - `ReserveTermCreationService`는 기본 행 하나를 생성하는 create-only transaction과 insert 실패 뒤 상태를 확인하는 transaction을 관리합니다.
 - `ReserveTermGenerationService`는 current와 next를 서로 독립적으로 처리합니다.
@@ -27,6 +27,8 @@ flowchart LR
 ## 2. 저장 일정 계약
 
 예약 정책은 `reserve_term`에 저장된 다음 네 시각을 유일한 기준으로 사용합니다.
+
+애플리케이션 내부의 네 시각과 `/terms` 응답은 UTC components입니다. 예를 들어 기본 신청 시작 09:00 `Asia/Seoul`은 `00:00Z`, term 경계의 KST 자정은 전날 `15:00Z`입니다. 기존 JDBC 변환을 거쳐 DB에서 조회되는 값은 의도한 `Asia/Seoul` wall-clock 구성요소입니다.
 
 ```text
 applyStartTime < applyEndTime <= termEndTime
@@ -72,7 +74,7 @@ Term 안에서 신청 기간이 열리면 phase는 `TERM_ACTIVE -> REGULAR_APPLI
 유효한 활성 term에서 `ONE_TIME` 예약이 열리는 시각은 다음 두 값 중 늦은 값입니다.
 
 ```text
-max(termStartTime, adjustWeekend(requestStart.date - 2 weeks at 09:00 Asia/Seoul))
+max(termStartTime UTC, toUtc(adjustWeekend(toSeoulDate(requestStart UTC) - 2 weeks at 09:00 Asia/Seoul)))
 ```
 
 `Missing` 대체 규칙에는 term 시작 시각이 없으므로 주말을 보정한 2주 전 오픈 시각만 사용합니다. 두 `ONE_TIME` 경로 모두 `recurringWeeks == 1`이어야 합니다. 오픈 전에는 `RESERVE-12`, 반복 요청에는 `RESERVE-11`을 반환합니다. 공휴일은 보정하지 않습니다.
@@ -104,12 +106,14 @@ Scheduler는 기존 행을 update하거나 delete하지 않으며 metadata도 �
 
 V16은 기존 `reservation.reservation_type = NULL`과 `reserve_term`의 `NULL/NULL` metadata를 채우지 않습니다. Metadata pair CHECK와 값이 모두 있는 pair의 unique index만 추가합니다.
 
-요청 `LocalDateTime`은 offset이 없는 KST wall-clock 구성요소입니다. 응답은 기존 serializer와의 호환을 위해 날짜·시각 구성요소를 유지한 채 끝에 `Z`를 붙입니다. 실제 UTC instant로 변환하지 않습니다.
+예약 요청과 응답의 `LocalDateTime` 숫자 구성요소는 UTC입니다. 요청은 `Z`가 붙은 형식과 기존 offset 없는 형식을 모두 역직렬화하지만, 두 형식 모두 같은 UTC 구성요소로 정책에 전달됩니다. 응답의 `Z`는 실제 UTC instant를 뜻합니다.
 
 ```text
-stored:  2027-03-20T10:00
-wire:    2027-03-20T10:00:00Z
+request: 2027-03-20T01:00:00Z
+wire:    2027-03-20T01:00:00Z
 display: 2027-03-20 10:00 KST
 ```
 
-클라이언트가 이를 일반 UTC instant로 변환하면 19:00으로 잘못 표시됩니다. 날짜·시각 구성요소를 그대로 해석하는 component-preserving parser를 사용해야 합니다.
+클라이언트는 표준 instant parser로 응답을 해석한 뒤 사용자 timezone으로 표시합니다. offset 없는 요청을 사용하는 기존 클라이언트도 숫자 구성요소를 UTC로 보내야 합니다.
+
+ReserveTerm의 내부 값과 `GET /api/v2/reservation/terms` 응답도 실제 UTC components입니다. 기본 일정은 `Asia/Seoul` 달력 규칙으로 계산한 뒤 UTC로 변환하므로 `2027-02-01T00:00:00Z`는 `2027-02-01 09:00 Asia/Seoul`을 뜻합니다. Custom term POST는 기존 offset 없는 `LocalDateTime` JSON shape을 유지하며 입력한 UTC 숫자 구성요소를 그대로 전달합니다.

--- a/docs/reservation-logic-overview.md
+++ b/docs/reservation-logic-overview.md
@@ -28,7 +28,7 @@ flowchart LR
 
 예약 정책은 `reserve_term`에 저장된 다음 네 시각을 유일한 기준으로 사용합니다.
 
-애플리케이션 내부의 네 시각과 `/terms` 응답은 UTC components입니다. 예를 들어 기본 신청 시작 09:00 `Asia/Seoul`은 `00:00Z`, term 경계의 KST 자정은 전날 `15:00Z`입니다. 기존 JDBC 변환을 거쳐 DB에서 조회되는 값은 의도한 `Asia/Seoul` wall-clock 구성요소입니다.
+애플리케이션 내부의 네 시각과 `/terms` 응답은 UTC components입니다. 예를 들어 기본 신청 시작 09:00 `Asia/Seoul`은 `00:00Z`, term 경계의 KST 자정은 전날 `15:00Z`입니다. `reserve_term`의 MySQL `DATETIME(6)`에는 이 `LocalDateTime` 구성요소가 그대로 저장됩니다.
 
 ```text
 applyStartTime < applyEndTime <= termEndTime

--- a/docs/reserve-term-recovery-runbook.md
+++ b/docs/reserve-term-recovery-runbook.md
@@ -20,7 +20,7 @@ flowchart TD
 
 ### Custom term 생성
 
-`POST /api/v2/reservation/terms/custom`은 네 개의 UTC-component 시각을 기존 offset 없는 `LocalDateTime` JSON shape으로 받고 그대로 전달하여 `termYear=NULL`, `termType=NULL`인 행을 생성합니다. 기존 JDBC 변환 후 DB에는 대응하는 `Asia/Seoul` wall-clock 구성요소가 저장됩니다.
+`POST /api/v2/reservation/terms/custom`은 네 개의 UTC-component 시각을 기존 offset 없는 `LocalDateTime` JSON shape으로 받고 그대로 전달하여 `termYear=NULL`, `termType=NULL`인 행을 생성합니다. `reserve_term` 컬럼은 MySQL `DATETIME(6)`이므로 DB에는 전달된 `LocalDateTime` 구성요소가 그대로 저장됩니다.
 
 ```json
 {

--- a/docs/reserve-term-recovery-runbook.md
+++ b/docs/reserve-term-recovery-runbook.md
@@ -20,14 +20,14 @@ flowchart TD
 
 ### Custom term 생성
 
-`POST /api/v2/reservation/terms/custom`은 네 개의 KST wall-clock 시각만 받고 `termYear=NULL`, `termType=NULL`인 행을 생성합니다.
+`POST /api/v2/reservation/terms/custom`은 네 개의 UTC-component 시각을 기존 offset 없는 `LocalDateTime` JSON shape으로 받고 그대로 전달하여 `termYear=NULL`, `termType=NULL`인 행을 생성합니다. 기존 JDBC 변환 후 DB에는 대응하는 `Asia/Seoul` wall-clock 구성요소가 저장됩니다.
 
 ```json
 {
-  "applyStartTime": "2027-02-01T09:00:00",
-  "applyEndTime": "2027-03-01T00:00:00",
-  "termStartTime": "2027-03-01T00:00:00",
-  "termEndTime": "2027-07-01T00:00:00"
+  "applyStartTime": "2027-02-01T00:00:00",
+  "applyEndTime": "2027-02-28T15:00:00",
+  "termStartTime": "2027-02-28T15:00:00",
+  "termEndTime": "2027-06-30T15:00:00"
 }
 ```
 
@@ -83,6 +83,8 @@ ORDER BY term_start_time, id;
 
 특정 요청 시작 시각의 대상 후보는 다음 반열린 조건으로 찾습니다.
 
+아래 직접 SQL의 `:request_start`, `:default_term_start`, `:default_term_end`는 raw MySQL `DATETIME`과 비교되므로 API의 UTC components가 아니라 DB에 저장되는 `Asia/Seoul` wall-clock 구성요소로 바인딩해야 합니다. 예를 들어 API의 `2027-03-20T01:00:00Z`는 직접 SQL에서 `2027-03-20 10:00:00`으로 바인딩합니다. 애플리케이션/JPA 실행은 기존 JDBC representation path를 거치지만, 운영자가 raw SQL을 실행할 때는 이 변환을 직접 적용해야 합니다.
+
 ```sql
 SELECT id, term_year, term_type,
        apply_start_time, apply_end_time, term_start_time, term_end_time
@@ -129,4 +131,6 @@ DB 변경이 안전하지 않거나 원인을 알 수 없으면 행을 보존하
 
 V16은 기존 `reservation_type = NULL`과 `reserve_term`의 `NULL/NULL` metadata를 유지하며 metadata pair CHECK를 추가합니다. 다른 checksum의 V16이 이미 배포된 증거가 있다면 파일이나 migration history를 임의로 고치지 말고 forward migration을 설계해야 합니다.
 
-API 응답 시각은 `LocalDateTime`의 날짜·시각 구성요소를 유지한 채 끝에 `Z`를 붙이는 기존 형식입니다. 이 API에서 `2027-03-20T10:00:00Z`는 실제 UTC instant가 아니라 `10:00 KST` wall-clock을 뜻합니다. 운영 확인 도구도 날짜·시각 구성요소를 유지해 표시해야 합니다. 이 방식을 component-preserving 처리라고 부릅니다.
+ReserveTerm 내부 값과 `GET /api/v2/reservation/terms`의 네 시각은 실제 UTC components입니다. 기본 일정의 09:00 `Asia/Seoul`은 API에서 `00:00Z`, KST 자정은 전날 `15:00Z`로 보입니다. 운영 확인 도구는 `/terms` 응답을 표준 UTC instant로 해석하고, DB를 직접 조회할 때는 기존 JDBC 변환으로 저장된 `Asia/Seoul` wall-clock 구성요소와 같은 시각인지 확인해야 합니다.
+
+예약 API의 시간 계약은 바뀌지 않습니다. 예약 요청과 응답의 `LocalDateTime` 숫자 구성요소 및 응답의 `Z`는 실제 UTC를 뜻하며, 운영 확인 도구는 표준 instant로 처리합니다. Custom term POST는 offset 없는 기존 JSON shape을 유지하지만 숫자 구성요소는 UTC로 해석하며, 입력한 네 값을 애플리케이션에서 변환하지 않습니다.

--- a/src/main/kotlin/com/wafflestudio/csereal/core/reservation/service/ReserveTermDefaultPolicy.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/reservation/service/ReserveTermDefaultPolicy.kt
@@ -7,6 +7,8 @@ import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.time.ZoneId
+import java.time.ZoneOffset
 
 data class ReserveTermDescriptor(
     val termYear: Int,
@@ -22,8 +24,9 @@ class ReserveTermDefaultPolicy(
     private val clock: Clock
 ) {
     fun currentAndNextDescriptors(): List<ReserveTermDescriptor> {
-        val current = descriptorFor(LocalDate.now(clock))
-        return listOf(current, descriptorFor(current.termEndTime.toLocalDate()))
+        val current = descriptorFor(LocalDate.now(clock.withZone(SEOUL_ZONE)))
+        val nextDate = current.termEndTime.toInstant(ZoneOffset.UTC).atZone(SEOUL_ZONE).toLocalDate()
+        return listOf(current, descriptorFor(nextDate))
     }
 
     fun descriptorFor(date: LocalDate): ReserveTermDescriptor {
@@ -68,12 +71,15 @@ class ReserveTermDefaultPolicy(
         return ReserveTermDescriptor(
             termYear = termYear,
             termType = termType,
-            applyStartTime = adjustWeekend(applyStartDate.atTime(OPEN_TIME)),
-            applyEndTime = termStartTime,
-            termStartTime = termStartTime,
-            termEndTime = termEndDate.atStartOfDay()
+            applyStartTime = adjustWeekend(applyStartDate.atTime(OPEN_TIME)).toUtcComponents(),
+            applyEndTime = termStartTime.toUtcComponents(),
+            termStartTime = termStartTime.toUtcComponents(),
+            termEndTime = termEndDate.atStartOfDay().toUtcComponents()
         )
     }
+
+    private fun LocalDateTime.toUtcComponents(): LocalDateTime =
+        atZone(SEOUL_ZONE).withZoneSameInstant(ZoneOffset.UTC).toLocalDateTime()
 
     private fun adjustWeekend(dateTime: LocalDateTime): LocalDateTime = when (dateTime.dayOfWeek) {
         DayOfWeek.SATURDAY -> dateTime.plusDays(2)
@@ -82,6 +88,7 @@ class ReserveTermDefaultPolicy(
     }
 
     companion object {
+        private val SEOUL_ZONE: ZoneId = ZoneId.of("Asia/Seoul")
         private val OPEN_TIME: LocalTime = LocalTime.of(9, 0)
     }
 }

--- a/src/main/kotlin/com/wafflestudio/csereal/core/reservation/service/ReserveTermPolicy.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/reservation/service/ReserveTermPolicy.kt
@@ -6,6 +6,8 @@ import java.time.Clock
 import java.time.DayOfWeek
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.time.ZoneId
+import java.time.ZoneOffset
 import java.time.temporal.ChronoUnit
 
 enum class ReserveTermPhase {
@@ -19,7 +21,7 @@ enum class ReserveTermPhase {
 class ReserveTermPolicy(
     val clock: Clock
 ) {
-    fun now(): LocalDateTime = LocalDateTime.now(clock)
+    fun now(): LocalDateTime = LocalDateTime.ofInstant(clock.instant(), ZoneOffset.UTC)
 
     fun invalidReasons(entity: ReserveTermEntity): List<String> = buildList {
         if (!entity.applyStartTime.isBefore(entity.applyEndTime)) add("invalid_application_window")
@@ -37,7 +39,11 @@ class ReserveTermPolicy(
     }
 
     fun oneTimeReservationOpenTime(reservationStart: LocalDateTime): LocalDateTime {
-        return adjustWeekend(reservationStart.toLocalDate().minusWeeks(2).atTime(OPEN_TIME))
+        val reservationDate = reservationStart.toInstant(ZoneOffset.UTC).atZone(SEOUL_ZONE).toLocalDate()
+        return adjustWeekend(reservationDate.minusWeeks(2).atTime(OPEN_TIME))
+            .atZone(SEOUL_ZONE)
+            .withZoneSameInstant(ZoneOffset.UTC)
+            .toLocalDateTime()
     }
 
     fun activeTermOneTimeReservationOpenTime(term: ReserveTermEntity, reservationStart: LocalDateTime): LocalDateTime {
@@ -58,6 +64,7 @@ class ReserveTermPolicy(
     }
 
     companion object {
+        private val SEOUL_ZONE: ZoneId = ZoneId.of("Asia/Seoul")
         private val OPEN_TIME: LocalTime = LocalTime.of(9, 0)
     }
 }

--- a/src/test/kotlin/com/wafflestudio/csereal/core/reservation/api/v2/ReservationControllerTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/reservation/api/v2/ReservationControllerTest.kt
@@ -8,6 +8,7 @@ import com.wafflestudio.csereal.common.config.CserealExceptionHandler
 import com.wafflestudio.csereal.common.config.LocalDateTimeSerializer
 import com.wafflestudio.csereal.core.reservation.database.ReserveTermEntity
 import com.wafflestudio.csereal.core.reservation.database.ReserveTermType
+import com.wafflestudio.csereal.core.reservation.dto.CreateCustomReserveTermRequest
 import com.wafflestudio.csereal.core.reservation.dto.ReserveTermDto
 import com.wafflestudio.csereal.core.reservation.service.ReservationService
 import com.wafflestudio.csereal.core.reservation.service.ReserveTermDescriptor
@@ -16,9 +17,11 @@ import com.wafflestudio.csereal.core.reservation.service.ReserveTermGenerationRe
 import com.wafflestudio.csereal.core.reservation.service.ReserveTermGenerationService
 import com.wafflestudio.csereal.core.reservation.service.ReserveTermManualCreationService
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
 import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import org.springframework.http.MediaType
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
@@ -54,7 +57,8 @@ class ReservationControllerTest : StringSpec({
     }
 
     "POST custom returns 201 through the JSON boundary" {
-        every { manualCreationService.createCustom(any()) } returns customEntity()
+        val requestSlot = slot<CreateCustomReserveTermRequest>()
+        every { manualCreationService.createCustom(capture(requestSlot)) } returns customEntity()
 
         mockMvc.perform(
             post(CUSTOM_PATH)
@@ -63,23 +67,24 @@ class ReservationControllerTest : StringSpec({
         )
             .andExpect(status().isCreated)
             .andExpect(jsonPath("$.id").value(0))
-            .andExpect(jsonPath("$.applyStartTime").value("2027-02-01T09:00:00Z"))
-            .andExpect(jsonPath("$.applyEndTime").value("2027-03-01T00:00:00Z"))
-            .andExpect(jsonPath("$.termStartTime").value("2027-03-01T00:00:00Z"))
-            .andExpect(jsonPath("$.termEndTime").value("2027-07-01T00:00:00Z"))
+            .andExpect(jsonPath("$.applyStartTime").value("2027-02-01T00:00:00Z"))
+            .andExpect(jsonPath("$.applyEndTime").value("2027-02-28T15:00:00Z"))
+            .andExpect(jsonPath("$.termStartTime").value("2027-02-28T15:00:00Z"))
+            .andExpect(jsonPath("$.termEndTime").value("2027-06-30T15:00:00Z"))
 
         verify(exactly = 1) { manualCreationService.createCustom(any()) }
+        requestSlot.captured shouldBe customRequest
     }
 
     listOf(
         "no body" to null,
-        "a missing field" to validRequestJson.replace(",\"termEndTime\":\"2027-07-01T00:00:00\"", ""),
+        "a missing field" to validRequestJson.replace(",\"termEndTime\":\"2027-06-30T15:00:00\"", ""),
         "a null field" to validRequestJson.replace(
-            "\"termEndTime\":\"2027-07-01T00:00:00\"",
+            "\"termEndTime\":\"2027-06-30T15:00:00\"",
             "\"termEndTime\":null"
         ),
         "malformed JSON" to "{",
-        "a malformed date-time" to validRequestJson.replace("2027-02-01T09:00:00", "not-a-date")
+        "a malformed date-time" to validRequestJson.replace("2027-02-01T00:00:00", "not-a-date")
     ).forEach { (case, body) ->
         "POST custom rejects $case before service invocation" {
             val request = post(CUSTOM_PATH).contentType(MediaType.APPLICATION_JSON)
@@ -151,20 +156,20 @@ class ReservationControllerTest : StringSpec({
     "GET terms keeps the existing public response boundary" {
         val term = ReserveTermDto(
             id = 17,
-            applyStartTime = LocalDateTime.of(2027, 2, 1, 9, 0),
-            applyEndTime = LocalDateTime.of(2027, 3, 1, 0, 0),
-            termStartTime = LocalDateTime.of(2027, 3, 1, 0, 0),
-            termEndTime = LocalDateTime.of(2027, 7, 1, 0, 0)
+            applyStartTime = customRequest.applyStartTime,
+            applyEndTime = customRequest.applyEndTime,
+            termStartTime = customRequest.termStartTime,
+            termEndTime = customRequest.termEndTime
         )
         every { reservationService.getReserveTerms() } returns listOf(term)
 
         mockMvc.perform(get("/api/v2/reservation/terms"))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$[0].id").value(17))
-            .andExpect(jsonPath("$[0].applyStartTime").value("2027-02-01T09:00:00Z"))
-            .andExpect(jsonPath("$[0].applyEndTime").value("2027-03-01T00:00:00Z"))
-            .andExpect(jsonPath("$[0].termStartTime").value("2027-03-01T00:00:00Z"))
-            .andExpect(jsonPath("$[0].termEndTime").value("2027-07-01T00:00:00Z"))
+            .andExpect(jsonPath("$[0].applyStartTime").value("2027-02-01T00:00:00Z"))
+            .andExpect(jsonPath("$[0].applyEndTime").value("2027-02-28T15:00:00Z"))
+            .andExpect(jsonPath("$[0].termStartTime").value("2027-02-28T15:00:00Z"))
+            .andExpect(jsonPath("$[0].termEndTime").value("2027-06-30T15:00:00Z"))
 
         verify(exactly = 1) { reservationService.getReserveTerms() }
     }
@@ -173,27 +178,34 @@ class ReservationControllerTest : StringSpec({
         private const val CUSTOM_PATH = "/api/v2/reservation/terms/custom"
         private const val DEFAULTS_PATH = "/api/v2/reservation/terms/defaults"
         private val validRequestJson = """{
-            "applyStartTime":"2027-02-01T09:00:00",
-            "applyEndTime":"2027-03-01T00:00:00",
-            "termStartTime":"2027-03-01T00:00:00",
-            "termEndTime":"2027-07-01T00:00:00"
+            "applyStartTime":"2027-02-01T00:00:00",
+            "applyEndTime":"2027-02-28T15:00:00",
+            "termStartTime":"2027-02-28T15:00:00",
+            "termEndTime":"2027-06-30T15:00:00"
         }
         """.trimIndent().replace("\n", "").replace(" ", "")
 
+        private val customRequest = CreateCustomReserveTermRequest(
+            LocalDateTime.of(2027, 2, 1, 0, 0),
+            LocalDateTime.of(2027, 2, 28, 15, 0),
+            LocalDateTime.of(2027, 2, 28, 15, 0),
+            LocalDateTime.of(2027, 6, 30, 15, 0)
+        )
+
         private fun customEntity() = ReserveTermEntity(
-            LocalDateTime.of(2027, 2, 1, 9, 0),
-            LocalDateTime.of(2027, 3, 1, 0, 0),
-            LocalDateTime.of(2027, 3, 1, 0, 0),
-            LocalDateTime.of(2027, 7, 1, 0, 0)
+            customRequest.applyStartTime,
+            customRequest.applyEndTime,
+            customRequest.termStartTime,
+            customRequest.termEndTime
         )
 
         private fun descriptor(year: Int, type: ReserveTermType) = ReserveTermDescriptor(
             year,
             type,
-            LocalDateTime.of(year, 1, 1, 9, 0),
-            LocalDateTime.of(year, 1, 15, 0, 0),
-            LocalDateTime.of(year, 2, 1, 0, 0),
-            LocalDateTime.of(year, 3, 1, 0, 0)
+            LocalDateTime.of(year, 1, 1, 0, 0),
+            LocalDateTime.of(year, 1, 14, 15, 0),
+            LocalDateTime.of(year, 1, 31, 15, 0),
+            LocalDateTime.of(year, 2, 28, 15, 0)
         )
     }
 }

--- a/src/test/kotlin/com/wafflestudio/csereal/core/reservation/dto/ReserveRequestJsonCompatibilityTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/reservation/dto/ReserveRequestJsonCompatibilityTest.kt
@@ -7,14 +7,16 @@ import io.kotest.matchers.shouldBe
 import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import java.time.LocalDateTime
 
 class ReserveRequestJsonCompatibilityTest : StringSpec({
-    "the application-configured ObjectMapper ignores a stale reservationType without policy effect" {
+    "the configured ObjectMapper preserves UTC components with or without Z and ignores a stale type" {
         ApplicationContextRunner()
             .withConfiguration(AutoConfigurations.of(JacksonAutoConfiguration::class.java))
             .run { context ->
                 context.startupFailure shouldBe null
-                val request = context.getBean(ObjectMapper::class.java).readValue<ReserveRequest>(
+                val objectMapper = context.getBean(ObjectMapper::class.java)
+                val offsetFreeJson =
                     """
                     {
                       "roomId": 1,
@@ -30,9 +32,18 @@ class ReserveRequestJsonCompatibilityTest : StringSpec({
                       "reservationType": "REGULAR"
                     }
                     """.trimIndent()
+                val offsetFreeRequest = objectMapper.readValue<ReserveRequest>(offsetFreeJson)
+                val utcRequest = objectMapper.readValue<ReserveRequest>(
+                    offsetFreeJson
+                        .replace("2027-03-10T10:00:00", "2027-03-10T10:00:00Z")
+                        .replace("2027-03-10T11:00:00", "2027-03-10T11:00:00Z")
                 )
 
-                request.recurringWeeks shouldBe 1
+                offsetFreeRequest.recurringWeeks shouldBe 1
+                offsetFreeRequest.startTime shouldBe LocalDateTime.of(2027, 3, 10, 10, 0)
+                offsetFreeRequest.endTime shouldBe LocalDateTime.of(2027, 3, 10, 11, 0)
+                utcRequest.startTime shouldBe offsetFreeRequest.startTime
+                utcRequest.endTime shouldBe offsetFreeRequest.endTime
                 ReserveRequest::class.java.declaredFields.map { it.name }.contains("reservationType") shouldBe false
             }
     }

--- a/src/test/kotlin/com/wafflestudio/csereal/core/reservation/service/CommonUserReserveTermServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/reservation/service/CommonUserReserveTermServiceTest.kt
@@ -68,7 +68,7 @@ class CommonUserReserveTermServiceTest(
         } shouldBe CserealException(ErrorCode.ONE_TIME_RECURRING_DENIED)
     }
 
-    "every non-staff occurrence must be at most three hours and on one KST date" {
+    "every non-staff occurrence must be at most three hours and on one UTC component date" {
         val start = reserveTermPolicy.now().plusDays(1).withHour(22)
         shouldThrow<CserealException> {
             reservationService.reserveRoom(request(room.id, start, end = start.plusHours(3).plusMinutes(1)))

--- a/src/test/kotlin/com/wafflestudio/csereal/core/reservation/service/ReservationServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/reservation/service/ReservationServiceTest.kt
@@ -40,6 +40,7 @@ import java.time.Clock
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
+import java.time.ZoneOffset
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -85,8 +86,18 @@ class ReservationServiceTest(
         } shouldBe CserealException(ErrorCode.INVALID_RECURRING_WEEKS)
     }
 
-    "fixed KST clocks enforce applyStart just-before and exact boundaries" {
-        val descriptor = defaultAt(LocalDateTime.of(2027, 2, 1, 9, 0)).descriptor(
+    "a request at the fixed UTC now is rejected as past" {
+        val nowUtc = LocalDateTime.of(2027, 3, 10, 10, 0)
+        val fixture = harness(nowUtc)
+        unitAuthenticate("ROLE_STAFF")
+
+        shouldThrow<CserealException> {
+            fixture.service.reserveRoom(request(fixture.room.id, nowUtc, 1))
+        } shouldBe CserealException(ErrorCode.PAST_RESERVATION_DENIED)
+    }
+
+    "fixed clocks enforce UTC applyStart just-before and exact boundaries" {
+        val descriptor = defaultAt(LocalDateTime.of(2027, 2, 1, 0, 0)).descriptor(
             2027,
             ReserveTermType.FIRST_SEMESTER
         )
@@ -115,8 +126,8 @@ class ReservationServiceTest(
             .single().reservationType shouldBe ReservationType.REGULAR
     }
 
-    "fixed KST clocks enforce termStart just-before and exact boundaries" {
-        val descriptor = defaultAt(LocalDateTime.of(2027, 3, 1, 0, 0)).descriptor(
+    "fixed clocks enforce UTC termStart just-before and exact boundaries" {
+        val descriptor = defaultAt(LocalDateTime.of(2027, 2, 28, 15, 0)).descriptor(
             2027,
             ReserveTermType.FIRST_SEMESTER
         )
@@ -135,12 +146,12 @@ class ReservationServiceTest(
         exact.verifySingleTermLookup()
     }
 
-    "persisted custom phases include an exact GAP and active-term end bound" {
+    "persisted UTC custom phases include an exact GAP and active-term end bound" {
         val term = ReserveTermEntity(
-            LocalDateTime.of(2027, 2, 3, 9, 0),
-            LocalDateTime.of(2027, 2, 20, 18, 0),
-            LocalDateTime.of(2027, 3, 1, 0, 0),
-            LocalDateTime.of(2027, 6, 25, 12, 0)
+            LocalDateTime.of(2027, 2, 3, 0, 0),
+            LocalDateTime.of(2027, 2, 20, 9, 0),
+            LocalDateTime.of(2027, 2, 28, 15, 0),
+            LocalDateTime.of(2027, 6, 25, 3, 0)
         )
         val gap = harness(term.applyEndTime)
         every { gap.termRepository.findContainingRequestStart(any()) } returns listOf(term)
@@ -150,21 +161,22 @@ class ReservationServiceTest(
         } shouldBe CserealException(ErrorCode.TERM_APPLICATION_CLOSED)
 
         val active = harness(term.termEndTime.minusDays(1))
+        val requestStartUtc = term.termEndTime.minusMinutes(30)
         every { active.termRepository.findContainingRequestStart(any()) } returns listOf(term)
         unitAuthenticate("ROLE_RESERVATION")
         shouldThrow<CserealException> {
-            active.service.reserveRoom(request(active.room.id, term.termEndTime.minusMinutes(30), 1))
+            active.service.reserveRoom(request(active.room.id, requestStartUtc, 1))
         } shouldBe CserealException(ErrorCode.INVALID_RESERVATION_PERIOD)
     }
 
     "modified persisted times drive REGULAR without canonical matching" {
         val term = ReserveTermEntity(
-            LocalDateTime.of(2027, 2, 3, 9, 0),
-            LocalDateTime.of(2027, 2, 20, 18, 0),
-            LocalDateTime.of(2027, 3, 5, 0, 0),
-            LocalDateTime.of(2027, 6, 25, 0, 0)
+            LocalDateTime.of(2027, 2, 3, 0, 0),
+            LocalDateTime.of(2027, 2, 20, 9, 0),
+            LocalDateTime.of(2027, 3, 4, 15, 0),
+            LocalDateTime.of(2027, 6, 24, 15, 0)
         )
-        val fixture = harness(LocalDateTime.of(2027, 2, 10, 12, 0))
+        val fixture = harness(LocalDateTime.of(2027, 2, 10, 3, 0))
         every { fixture.termRepository.findContainingRequestStart(any()) } returns listOf(term)
         unitAuthenticate("ROLE_LABMASTER")
 
@@ -172,24 +184,26 @@ class ReservationServiceTest(
             .single().reservationType shouldBe ReservationType.REGULAR
     }
 
-    "ONE_TIME opening is closed just before and open exactly at the weekend-adjusted Monday" {
-        val target = LocalDateTime.of(2026, 7, 19, 14, 0)
-        val opening = LocalDateTime.of(2026, 7, 6, 9, 0)
+    "a UTC ONE_TIME request opens at the weekend-adjusted Monday derived in Seoul" {
+        val reservationStartUtc = LocalDateTime.of(2026, 7, 19, 14, 0)
+        val openingUtc = LocalDateTime.of(2026, 7, 6, 0, 0)
 
-        val before = harness(opening.minusSeconds(1))
+        val before = harness(openingUtc.minusSeconds(1))
         unitAuthenticate("ROLE_RESERVATION")
-        shouldThrow<CserealException> { before.service.reserveRoom(request(before.room.id, target, 1)) } shouldBe
+        shouldThrow<CserealException> {
+            before.service.reserveRoom(request(before.room.id, reservationStartUtc, 1))
+        } shouldBe
             CserealException(ErrorCode.ONE_TIME_NOT_OPENED)
 
-        val exact = harness(opening)
+        val exact = harness(openingUtc)
         unitAuthenticate("ROLE_RESERVATION")
-        exact.service.reserveRoom(request(exact.room.id, target, 1))
+        exact.service.reserveRoom(request(exact.room.id, reservationStartUtc, 1))
             .single().reservationType shouldBe ReservationType.ONE_TIME
         exact.verifySingleTermLookup()
     }
 
     "REGULAR one-occurrence and repeated requests persist exact canonical rows" {
-        val now = LocalDateTime.of(2027, 2, 1, 9, 0)
+        val now = LocalDateTime.of(2027, 2, 1, 0, 0)
         listOf(1, 3).forEach { weeks ->
             val fixture = harness(now)
             val descriptor = fixture.defaultPolicy.descriptor(2027, ReserveTermType.FIRST_SEMESTER)
@@ -212,7 +226,7 @@ class ReservationServiceTest(
     }
 
     "only a truly missing target enables fallback while malformed and multiple targets fail closed" {
-        val now = LocalDateTime.of(2027, 2, 1, 9, 0)
+        val now = LocalDateTime.of(2027, 2, 1, 0, 0)
         val missing = harness(now)
         val descriptor = missing.defaultPolicy.descriptor(2027, ReserveTermType.FIRST_SEMESTER)
         missing.persistMissing()
@@ -243,7 +257,7 @@ class ReservationServiceTest(
     }
 
     "a missing target is resolved once and permits ONE_TIME after opening" {
-        val fixture = harness(LocalDateTime.of(2027, 3, 8, 9, 0))
+        val fixture = harness(LocalDateTime.of(2027, 3, 8, 0, 0))
         fixture.persistMissing()
         unitAuthenticate("ROLE_RESERVATION")
         val target = LocalDateTime.of(2027, 3, 20, 10, 0)
@@ -254,12 +268,12 @@ class ReservationServiceTest(
     }
 
     "creation-role precedence and room authorization are explicit" {
-        val staff = harness(LocalDateTime.of(2027, 2, 1, 9, 0), RoomType.LAB)
+        val staff = harness(LocalDateTime.of(2027, 2, 1, 0, 0), RoomType.LAB)
         unitAuthenticate("ROLE_STAFF", "ROLE_LABMASTER", "ROLE_RESERVATION")
         staff.service.reserveRoom(request(staff.room.id, LocalDateTime.of(2027, 3, 10, 10, 0), 1))
             .single().reservationType shouldBe ReservationType.UNRESTRICTED
 
-        val labmaster = harness(LocalDateTime.of(2027, 2, 1, 9, 0))
+        val labmaster = harness(LocalDateTime.of(2027, 2, 1, 0, 0))
         val descriptor = labmaster.defaultPolicy.descriptor(2027, ReserveTermType.FIRST_SEMESTER)
         labmaster.persistCanonical(descriptor)
         unitAuthenticate("ROLE_LABMASTER", "ROLE_RESERVATION")
@@ -267,7 +281,7 @@ class ReservationServiceTest(
             request(labmaster.room.id, descriptor.termStartTime.plusDays(10).plusHours(10), 1)
         ).single().reservationType shouldBe ReservationType.REGULAR
 
-        val reservationOnly = harness(LocalDateTime.of(2027, 2, 1, 9, 0))
+        val reservationOnly = harness(LocalDateTime.of(2027, 2, 1, 0, 0))
         reservationOnly.persistCanonical(descriptor)
         unitAuthenticate("ROLE_RESERVATION")
         shouldThrow<CserealException> {
@@ -276,7 +290,7 @@ class ReservationServiceTest(
             )
         } shouldBe CserealException(ErrorCode.LABMASTER_ONLY)
 
-        val nonSeminar = harness(LocalDateTime.of(2027, 3, 1, 0, 0), RoomType.LECTURE)
+        val nonSeminar = harness(LocalDateTime.of(2027, 2, 28, 15, 0), RoomType.LECTURE)
         unitAuthenticate("ROLE_RESERVATION")
         shouldThrow<CserealException> {
             nonSeminar.service.reserveRoom(
@@ -287,7 +301,7 @@ class ReservationServiceTest(
 
     "room 8 enforces the complete role matrix" {
         val target = LocalDateTime.of(2027, 3, 20, 10, 0)
-        val afterOpening = LocalDateTime.of(2027, 3, 8, 9, 0)
+        val afterOpening = LocalDateTime.of(2027, 3, 8, 0, 0)
 
         val staff = harness(afterOpening, roomId = 8)
         unitAuthenticate("ROLE_STAFF")
@@ -341,7 +355,7 @@ class ReservationServiceTest(
     }
 
     "the pessimistic room lookup occurs before the login-user query" {
-        val fixture = harness(LocalDateTime.of(2027, 3, 8, 9, 0))
+        val fixture = harness(LocalDateTime.of(2027, 3, 8, 0, 0))
         unitAuthenticate("ROLE_RESERVATION")
         fixture.service.reserveRoom(
             request(fixture.room.id, LocalDateTime.of(2027, 3, 20, 10, 0), 1)
@@ -454,11 +468,11 @@ class ReservationServiceTest(
         )
 
         private fun policyAt(now: LocalDateTime) = ReserveTermPolicy(
-            Clock.fixed(now.atZone(SEOUL).toInstant(), SEOUL)
+            Clock.fixed(now.toInstant(ZoneOffset.UTC), SEOUL)
         )
 
         private fun defaultAt(now: LocalDateTime) = ReserveTermDefaultPolicy(
-            Clock.fixed(now.atZone(SEOUL).toInstant(), SEOUL)
+            Clock.fixed(now.toInstant(ZoneOffset.UTC), SEOUL)
         )
 
         private fun harness(

--- a/src/test/kotlin/com/wafflestudio/csereal/core/reservation/service/ReserveTermDefaultPolicyTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/reservation/service/ReserveTermDefaultPolicyTest.kt
@@ -6,24 +6,37 @@ import io.kotest.matchers.shouldBe
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDateTime
-import java.time.ZoneId
+import java.time.ZoneOffset
 
 class ReserveTermDefaultPolicyTest : StringSpec({
     "default policy computes scheduler-only canonical windows" {
         val policy = ReserveTermDefaultPolicy(
-            Clock.fixed(Instant.parse("2026-07-17T00:00:00Z"), ZoneId.of("Asia/Seoul"))
+            Clock.fixed(Instant.parse("2026-07-17T00:00:00Z"), ZoneOffset.UTC)
         )
         val descriptor = policy.descriptor(2027, ReserveTermType.SECOND_SEMESTER)
 
-        descriptor.applyStartTime shouldBe LocalDateTime.of(2027, 8, 2, 9, 0)
-        descriptor.applyEndTime shouldBe LocalDateTime.of(2027, 9, 1, 0, 0)
+        descriptor.applyStartTime shouldBe LocalDateTime.of(2027, 8, 2, 0, 0)
+        descriptor.applyEndTime shouldBe LocalDateTime.of(2027, 8, 31, 15, 0)
         descriptor.termStartTime shouldBe descriptor.applyEndTime
-        descriptor.termEndTime shouldBe LocalDateTime.of(2028, 1, 1, 0, 0)
+        descriptor.termEndTime shouldBe LocalDateTime.of(2027, 12, 31, 15, 0)
+    }
+
+    "current and next defaults follow Asia/Seoul date boundaries" {
+        listOf(
+            Instant.parse("2027-02-28T14:59:59Z") to
+                listOf(ReserveTermType.WINTER, ReserveTermType.FIRST_SEMESTER),
+            Instant.parse("2027-02-28T15:00:00Z") to
+                listOf(ReserveTermType.FIRST_SEMESTER, ReserveTermType.SUMMER)
+        ).forEach { (instant, expectedTypes) ->
+            val policy = ReserveTermDefaultPolicy(Clock.fixed(instant, ZoneOffset.UTC))
+
+            policy.currentAndNextDescriptors().map { it.termType } shouldBe expectedTypes
+        }
     }
 
     "current and next defaults cross the year boundary" {
         val policy = ReserveTermDefaultPolicy(
-            Clock.fixed(Instant.parse("2027-12-15T00:00:00Z"), ZoneId.of("Asia/Seoul"))
+            Clock.fixed(Instant.parse("2027-12-15T00:00:00Z"), ZoneOffset.UTC)
         )
 
         policy.currentAndNextDescriptors().map { it.termType } shouldBe

--- a/src/test/kotlin/com/wafflestudio/csereal/core/reservation/service/ReserveTermManualCreationServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/reservation/service/ReserveTermManualCreationServiceTest.kt
@@ -45,7 +45,10 @@ class ReserveTermManualCreationServiceTest(
         reserveTermRepository.findById(existing.id).orElseThrow().snapshot() shouldBe snapshot
         created.termYear shouldBe null
         created.termType shouldBe null
+        created.applyStartTime shouldBe request.applyStartTime
+        created.applyEndTime shouldBe request.applyEndTime
         created.termStartTime shouldBe request.termStartTime
+        created.termEndTime shouldBe request.termEndTime
     }
 
     test("existing term start equal to candidate end is persisted without changing the existing row") {
@@ -88,10 +91,10 @@ class ReserveTermManualCreationServiceTest(
 }) {
     companion object {
         private fun validRequest() = CreateCustomReserveTermRequest(
-            applyStartTime = LocalDateTime.of(2027, 2, 1, 9, 0),
-            applyEndTime = LocalDateTime.of(2027, 3, 1, 0, 0),
-            termStartTime = LocalDateTime.of(2027, 3, 1, 0, 0),
-            termEndTime = LocalDateTime.of(2027, 7, 1, 0, 0)
+            applyStartTime = LocalDateTime.of(2027, 2, 1, 0, 0),
+            applyEndTime = LocalDateTime.of(2027, 2, 28, 15, 0),
+            termStartTime = LocalDateTime.of(2027, 2, 28, 15, 0),
+            termEndTime = LocalDateTime.of(2027, 6, 30, 15, 0)
         )
 
         private fun existingTerm(

--- a/src/test/kotlin/com/wafflestudio/csereal/core/reservation/service/ReserveTermPolicyTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/reservation/service/ReserveTermPolicyTest.kt
@@ -15,12 +15,29 @@ class ReserveTermPolicyTest : BehaviorSpec({
     val clock = Clock.fixed(Instant.parse("2026-07-17T00:00:00Z"), ZoneId.of("Asia/Seoul"))
     val policy = ReserveTermPolicy(clock)
 
+    given("UTC component clock basis") {
+        then("now is derived from the clock instant in UTC") {
+            policy.now() shouldBe LocalDateTime.of(2026, 7, 17, 0, 0)
+        }
+
+        then("the default phase comparison uses the same UTC component basis") {
+            val term = ReserveTermEntity(
+                LocalDateTime.of(2026, 7, 17, 0, 0),
+                LocalDateTime.of(2026, 7, 17, 1, 0),
+                LocalDateTime.of(2026, 8, 1, 0, 0),
+                LocalDateTime.of(2026, 9, 1, 0, 0)
+            )
+
+            policy.phase(term) shouldBe ReserveTermPhase.REGULAR_APPLICATION
+        }
+    }
+
     given("persisted schedule validation and phases") {
         val term = ReserveTermEntity(
-            LocalDateTime.of(2027, 2, 3, 9, 0),
-            LocalDateTime.of(2027, 2, 20, 18, 0),
-            LocalDateTime.of(2027, 3, 1, 0, 0),
-            LocalDateTime.of(2027, 6, 25, 0, 0)
+            LocalDateTime.of(2027, 2, 3, 0, 0),
+            LocalDateTime.of(2027, 2, 20, 9, 0),
+            LocalDateTime.of(2027, 2, 28, 15, 0),
+            LocalDateTime.of(2027, 6, 24, 15, 0)
         )
 
         then("a non-overlapping application window is valid with half-open boundaries") {
@@ -85,19 +102,21 @@ class ReserveTermPolicyTest : BehaviorSpec({
     }
 
     given("one-time opening") {
-        then("a weekend opening moves to Monday at 09:00") {
-            policy.oneTimeReservationOpenTime(LocalDateTime.of(2026, 7, 19, 14, 0)) shouldBe
-                LocalDateTime.of(2026, 7, 6, 9, 0)
+        then("a UTC reservation start uses the Asia/Seoul calendar and returns a UTC opening") {
+            val reservationStartUtc = LocalDateTime.of(2026, 7, 17, 16, 0)
+
+            policy.oneTimeReservationOpenTime(reservationStartUtc) shouldBe
+                LocalDateTime.of(2026, 7, 6, 0, 0)
         }
 
         then("active terms cannot open before their persisted start") {
             val term = ReserveTermEntity(
-                LocalDateTime.of(2027, 1, 1, 9, 0),
-                LocalDateTime.of(2027, 1, 15, 0, 0),
-                LocalDateTime.of(2027, 3, 1, 0, 0),
-                LocalDateTime.of(2027, 7, 1, 0, 0)
+                LocalDateTime.of(2027, 1, 1, 0, 0),
+                LocalDateTime.of(2027, 1, 14, 15, 0),
+                LocalDateTime.of(2027, 2, 28, 15, 0),
+                LocalDateTime.of(2027, 6, 30, 15, 0)
             )
-            policy.activeTermOneTimeReservationOpenTime(term, LocalDateTime.of(2027, 3, 2, 10, 0)) shouldBe
+            policy.activeTermOneTimeReservationOpenTime(term, LocalDateTime.of(2027, 3, 2, 1, 0)) shouldBe
                 term.termStartTime
         }
     }


### PR DESCRIPTION
## 변경 사항

- `Asia/Seoul` 기준 기본 reserve term 일정을 UTC `LocalDateTime` 구성요소로 변환합니다.
- 현재 시각, phase, `ONE_TIME` 오픈 시각을 UTC 기준으로 비교하되 달력 규칙은 KST에서 계산합니다.
- Custom term 입력은 기존 예약 API와 동일하게 UTC 구성요소를 변환 없이 전달합니다.
- API, 내부 값, DB wall-clock 및 raw SQL의 timezone 계약을 문서화합니다.

## 영향 범위

- 기존 reservation persistence, DTO, entity, Jackson serializer 및 JDBC 설정은 변경하지 않습니다.
- Flyway migration이나 기존 데이터 호환 분기를 추가하지 않습니다.

## 검증

- [x] `./gradlew ktlintCheck`
- [x] `./gradlew test` (139 tests)
- [x] 독립 whole-changeset review