### PR TITLE
fix(reservation): validate limits in Seoul time

### DIFF
--- a/docs/reservation-client-handoff.md
+++ b/docs/reservation-client-handoff.md
@@ -75,7 +75,7 @@ termStartTime < termEndTime
 
 Phase는 신청 기간을 먼저 확인합니다. Term이 활성 상태여도 `applyStartTime <= now < applyEndTime`이면 `REGULAR_APPLICATION`입니다. Term 안에서 신청 기간이 열리기 전과 닫힌 뒤에는 `TERM_ACTIVE`입니다.
 
-Non-staff 예약은 각 회차가 UTC 구성요소 기준으로 같은 날짜 안에 끝나야 하며 3시간을 넘을 수 없습니다. Room ID 8은 `ROLE_PROFESSOR`가 추가로 필요하지만, professor 역할만으로 예약 생성 권한이 생기지는 않습니다.
+Non-staff 예약은 각 회차가 `Asia/Seoul` 기준 같은 날짜 안에 끝나야 하며 3시간을 넘을 수 없습니다. 반복 예약의 시간은 회차별로 검사하며 합산하지 않습니다. Room ID 8은 `ROLE_PROFESSOR`가 추가로 필요하지만, professor 역할만으로 예약 생성 권한이 생기지는 않습니다.
 
 `ONE_TIME` 예약은 요청 날짜 2주 전 09:00 `Asia/Seoul`에 열립니다. 그날이 토요일이나 일요일이면 다음 월요일 09:00로 미룹니다. 유효한 활성 term에서는 `termStartTime`보다 먼저 열리지 않으며, 공휴일은 따로 보정하지 않습니다.
 
@@ -84,6 +84,7 @@ Non-staff 예약은 각 회차가 UTC 구성요소 기준으로 같은 날짜 �
 | Code | 의미 |
 |---|---|
 | `RESERVE-04` | Reservation-only 사용자가 유효한 BEFORE 또는 REGULAR phase에서 요청함 |
+| `RESERVE-06` | Non-staff 회차가 KST 날짜 경계를 넘거나 3시간을 초과함 |
 | `RESERVE-07` | 대상 행이 Invalid 또는 Multiple임 |
 | `RESERVE-08` | Labmaster가 application 시작 전에 요청함 |
 | `RESERVE-10` | 반복 횟수 정책 위반 |
@@ -124,7 +125,7 @@ screen:  2027-03-20 10:00 KST
 - `/terms`의 빈 배열, 운영자가 수정한 시각, 누락된 대상 term을 안전하게 처리합니다.
 - `REGULAR_APPLICATION` 구간은 `applyStartTime <= now < applyEndTime`입니다.
 - 유효한 GAP과 `Missing` 대체 규칙을 다르게 안내합니다.
-- Non-staff `ONE_TIME` 요청은 `recurringWeeks = 1`이고, 각 회차가 같은 날 3시간 안에 끝납니다.
+- 모든 Non-staff 요청은 각 회차가 KST 기준 같은 날 3시간 안에 끝나며, `ONE_TIME` 요청은 `recurringWeeks = 1`입니다.
 - 예약과 `/terms` 응답을 실제 UTC instant로 파싱해 사용자 timezone으로 표시합니다.
 
 클라이언트 소스 변경은 이 서버 작업 범위에 포함되지 않습니다.

--- a/docs/reservation-logic-overview.md
+++ b/docs/reservation-logic-overview.md
@@ -58,7 +58,7 @@ termStartTime <= requestStart < termEndTime
 
 ## 3. 역할과 phase
 
-Staff는 term과 관계없이 `UNRESTRICTED`이며, 설정된 반복 상한을 적용합니다. 기본값은 `20`입니다. Non-staff는 먼저 세미나실 여부, room ID 8의 `ROLE_PROFESSOR` 조건, 생성 역할, 같은 날짜 및 최대 3시간 규칙을 통과해야 합니다.
+Staff는 term과 관계없이 `UNRESTRICTED`이며, 설정된 반복 상한을 적용합니다. 기본값은 `20`입니다. Non-staff는 먼저 세미나실 여부, room ID 8의 `ROLE_PROFESSOR` 조건, 생성 역할, 회차별 KST 기준 같은 날짜 및 최대 3시간 규칙을 통과해야 합니다. 반복 예약의 시간은 회차 간 합산하지 않습니다.
 
 유효한 대상 term의 phase는 다음 순서로 판정합니다. 신청 기간이 열려 있으면 term 활성 여부와 관계없이 `REGULAR_APPLICATION`이 우선합니다. 신청 기간 밖의 활성 term은 `TERM_ACTIVE`입니다.
 

--- a/src/main/kotlin/com/wafflestudio/csereal/common/CserealException.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/common/CserealException.kt
@@ -27,7 +27,11 @@ enum class ErrorCode(val status: HttpStatus, val code: String, val msg: String) 
     PROFESSOR_ROOM_DENIED(HttpStatus.FORBIDDEN, "RESERVE-03", "교수회의실은 스태프 또는 교수만 예약 가능"),
     LABMASTER_ONLY(HttpStatus.FORBIDDEN, "RESERVE-04", "정기예약 기간에는 랩대표만 예약을 가능"),
     INVALID_RESERVATION_PERIOD(HttpStatus.BAD_REQUEST, "RESERVE-05", "정기예약은 지정된 학기 내에서만 가능"),
-    RESERVATION_TIME_EXCEEDED(HttpStatus.BAD_REQUEST, "RESERVE-06", "정기예약 기간에 3시간을 초과한 예약 불가"),
+    RESERVATION_TIME_EXCEEDED(
+        HttpStatus.BAD_REQUEST,
+        "RESERVE-06",
+        "Staff가 아닌 예약은 KST 기준 같은 날짜 내에서 회차당 최대 3시간까지 가능"
+    ),
     TERM_NOT_REGISTERED(HttpStatus.FORBIDDEN, "RESERVE-07", "아직 등록되지 않은 기간은 예약 불가"),
     TERM_NOT_OPENED(HttpStatus.FORBIDDEN, "RESERVE-08", "정기예약 신청 기간이 아직 시작되지 않음"),
     RESERVATION_OCCUPIED(HttpStatus.CONFLICT, "RESERVE-09", "해당 시간에 이미 예약이 있습니다"),

--- a/src/main/kotlin/com/wafflestudio/csereal/core/reservation/service/ReservationService.kt
+++ b/src/main/kotlin/com/wafflestudio/csereal/core/reservation/service/ReservationService.kt
@@ -21,6 +21,8 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Duration
 import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZoneOffset
 import java.util.UUID
 
 interface ReservationService {
@@ -50,6 +52,7 @@ class ReservationServiceImpl(
         private const val ROLE_PROFESSOR = "ROLE_PROFESSOR"
         private const val PROFESSOR_ROOM_ID = 8L
         private val MAX_NON_STAFF_DURATION = Duration.ofHours(3)
+        private val SEOUL_ZONE: ZoneId = ZoneId.of("Asia/Seoul")
         private val SUPPORTED_RESERVATION_YEARS = 1001..9998
         private val MAX_SUPPORTED_RESERVATION_TIME = LocalDateTime.of(9998, 12, 31, 23, 59, 59, 999_999_000)
     }
@@ -201,7 +204,10 @@ class ReservationServiceImpl(
     }
 
     private fun validateNonStaffDuration(request: ReserveRequest) {
-        if (request.startTime.toLocalDate() != request.endTime.toLocalDate() ||
+        val startDateInSeoul = request.startTime.toInstant(ZoneOffset.UTC).atZone(SEOUL_ZONE).toLocalDate()
+        val endDateInSeoul = request.endTime.toInstant(ZoneOffset.UTC).atZone(SEOUL_ZONE).toLocalDate()
+
+        if (startDateInSeoul != endDateInSeoul ||
             Duration.between(request.startTime, request.endTime) > MAX_NON_STAFF_DURATION
         ) {
             throw CserealException(ErrorCode.RESERVATION_TIME_EXCEEDED)

--- a/src/test/kotlin/com/wafflestudio/csereal/core/reservation/service/CommonUserReserveTermServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/reservation/service/CommonUserReserveTermServiceTest.kt
@@ -68,7 +68,7 @@ class CommonUserReserveTermServiceTest(
         } shouldBe CserealException(ErrorCode.ONE_TIME_RECURRING_DENIED)
     }
 
-    "every non-staff occurrence must be at most three hours and on one UTC component date" {
+    "every non-staff occurrence must be at most three hours and on one Seoul date" {
         val start = reserveTermPolicy.now().plusDays(1).withHour(22)
         shouldThrow<CserealException> {
             reservationService.reserveRoom(request(room.id, start, end = start.plusHours(3).plusMinutes(1)))

--- a/src/test/kotlin/com/wafflestudio/csereal/core/reservation/service/ReservationServiceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/csereal/core/reservation/service/ReservationServiceTest.kt
@@ -37,6 +37,7 @@ import org.springframework.security.oauth2.core.oidc.OidcIdToken
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
 import java.time.Clock
+import java.time.Duration
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -185,7 +186,7 @@ class ReservationServiceTest(
     }
 
     "a UTC ONE_TIME request opens at the weekend-adjusted Monday derived in Seoul" {
-        val reservationStartUtc = LocalDateTime.of(2026, 7, 19, 14, 0)
+        val reservationStartUtc = LocalDateTime.of(2026, 7, 19, 13, 0)
         val openingUtc = LocalDateTime.of(2026, 7, 6, 0, 0)
 
         val before = harness(openingUtc.minusSeconds(1))
@@ -223,6 +224,24 @@ class ReservationServiceTest(
             canonical.termYear shouldBe descriptor.termYear
             canonical.termType shouldBe descriptor.termType
         }
+    }
+
+    "REGULAR recurring reservations apply the three-hour limit per occurrence" {
+        val fixture = harness(LocalDateTime.of(2027, 2, 1, 0, 0))
+        val descriptor = fixture.defaultPolicy.descriptor(2027, ReserveTermType.FIRST_SEMESTER)
+        fixture.persistCanonical(descriptor)
+        val start = descriptor.termStartTime.plusDays(10).plusHours(10)
+        unitAuthenticate("ROLE_LABMASTER")
+
+        fixture.service.reserveRoom(request(fixture.room.id, start, weeks = 2, hours = 3))
+
+        fixture.saved.size shouldBe 2
+        fixture.saved.forEachIndexed { index, reservation ->
+            reservation.startTime shouldBe start.plusWeeks(index.toLong())
+            reservation.endTime shouldBe start.plusWeeks(index.toLong()).plusHours(3)
+            reservation.reservationType shouldBe ReservationType.REGULAR
+        }
+        fixture.saved.sumOf { Duration.between(it.startTime, it.endTime).toMinutes() } shouldBe 360L
     }
 
     "only a truly missing target enables fallback while malformed and multiple targets fail closed" {
@@ -335,23 +354,45 @@ class ReservationServiceTest(
         } shouldBe CserealException(ErrorCode.RESERVATION_PERMISSION_DENIED)
     }
 
-    "same-date and three-hour limits reject independently" {
-        val now = LocalDateTime.of(2027, 3, 1, 0, 0)
-        val crossDate = harness(now)
+    "a UTC midnight boundary within one Seoul date is allowed for non-staff" {
+        val fixture = harness(LocalDateTime.of(2027, 3, 8, 0, 0))
         unitAuthenticate("ROLE_RESERVATION")
-        shouldThrow<CserealException> {
-            crossDate.service.reserveRoom(
-                request(crossDate.room.id, LocalDateTime.of(2027, 3, 20, 23, 30), 1, hours = 1)
-            )
-        } shouldBe CserealException(ErrorCode.RESERVATION_TIME_EXCEEDED)
 
-        val overThreeHours = harness(now)
+        fixture.service.reserveRoom(
+            request(fixture.room.id, LocalDateTime.of(2027, 3, 20, 23, 30), 1, hours = 1)
+        ).single().reservationType shouldBe ReservationType.ONE_TIME
+    }
+
+    "a Seoul midnight boundary is rejected for non-staff even within three hours" {
+        val fixture = harness(LocalDateTime.of(2027, 3, 8, 0, 0))
         unitAuthenticate("ROLE_RESERVATION")
+
         shouldThrow<CserealException> {
-            overThreeHours.service.reserveRoom(
-                request(overThreeHours.room.id, LocalDateTime.of(2027, 3, 20, 10, 0), 1, hours = 4)
+            fixture.service.reserveRoom(
+                request(fixture.room.id, LocalDateTime.of(2027, 3, 20, 14, 30), 1, hours = 1)
             )
         } shouldBe CserealException(ErrorCode.RESERVATION_TIME_EXCEEDED)
+    }
+
+    "an over-three-hour occurrence is rejected for non-staff" {
+        val fixture = harness(LocalDateTime.of(2027, 3, 8, 0, 0))
+        val start = LocalDateTime.of(2027, 3, 20, 1, 0)
+        unitAuthenticate("ROLE_RESERVATION")
+
+        shouldThrow<CserealException> {
+            fixture.service.reserveRoom(
+                request(fixture.room.id, start, 1).copy(endTime = start.plusHours(3).plusMinutes(1))
+            )
+        } shouldBe CserealException(ErrorCode.RESERVATION_TIME_EXCEEDED)
+    }
+
+    "staff are exempt from both Seoul date and three-hour limits" {
+        val fixture = harness(LocalDateTime.of(2027, 3, 1, 0, 0))
+        unitAuthenticate("ROLE_STAFF")
+
+        fixture.service.reserveRoom(
+            request(fixture.room.id, LocalDateTime.of(2027, 3, 20, 13, 0), 1, hours = 4)
+        ).single().reservationType shouldBe ReservationType.UNRESTRICTED
     }
 
     "the pessimistic room lookup occurs before the login-user query" {
@@ -369,7 +410,7 @@ class ReservationServiceTest(
 
     "specific cancellation preserves owner, staff, other-user, and missing behavior" {
         val now = reserveTermPolicy.now()
-        val start = now.toLocalDate().plusDays(1).atTime(10, 0)
+        val start = now.toLocalDate().plusDays(1).atTime(9, 0)
         reserveTermRepository.deleteAll()
         reserveTermRepository.save(
             ReserveTermEntity(now.minusDays(2), now.minusDays(1), now.minusDays(3), now.plusYears(1))


### PR DESCRIPTION
## 제목

세미나실 예약 시간 제한을 KST 기준으로 검증

### 한줄 요약

Non-staff 예약의 동일 날짜 및 3시간 제한을 KST 기준 회차별로 검증합니다.

### 상세 설명

[`0c2994c`]: 예약 시각의 UTC 구성요소를 `Asia/Seoul` 날짜로 변환하여 동일 날짜 여부를 판정하고, 반복 예약 시간을 합산하지 않고 회차별로 최대 3시간을 허용하도록 테스트를 보강했습니다. Staff는 날짜 및 3시간 제한에서 계속 제외됩니다.

[`bc91836`]: 클라이언트 안내와 예약 로직 문서에 KST 날짜 기준, 모든 Non-staff 적용 범위, 반복 회차 비합산 규칙을 반영했습니다.

### 검증

- 대상 예약 서비스 테스트 25/25 통과
- 전체 테스트 143/143 통과
- `./gradlew ktlintCheck` 통과
- 독립 whole-changeset review 통과